### PR TITLE
Add turn-based corp budget and battle icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ python main.py
 ## Controls
 
 ### Corp View
+- Each turn grants funds to invest in the corporation
 - `1-4` add funds to research, security, politics and black ops
+- Budget is refreshed automatically when all funds are spent
 - `S` save game / `L` load game
 
 ### City View
@@ -29,4 +31,5 @@ python main.py
 
 ### Battle View
 - Arrow keys move the unit
+- PC and enemy icons are displayed on the map
 - `Esc` return to management

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -5,22 +5,61 @@ from typing import List
 
 @dataclass
 class GameState:
-    corp_budget: dict = field(default_factory=lambda: {
-        "research": 0,
-        "security": 0,
-        "politics": 0,
-        "black_ops": 0,
-    })
-    city_budget: dict = field(default_factory=lambda: {
-        "armaments": 0,
-        "garrisons": 0,
-        "defense_zones": 0,
-    })
+    """Holds the state of the current game."""
+
+    # Corporation values accumulated over all turns
+    corp_budget: dict = field(
+        default_factory=lambda: {
+            "research": 0,
+            "security": 0,
+            "politics": 0,
+            "black_ops": 0,
+        }
+    )
+
+    # Management data for the city phase
+    city_budget: dict = field(
+        default_factory=lambda: {
+            "armaments": 0,
+            "garrisons": 0,
+            "defense_zones": 0,
+        }
+    )
+
+    # List of recruited characters
     characters: List["Character"] = field(default_factory=list)
 
-    def adjust_corp_budget(self, key: str, amount: int) -> None:
-        if key in self.corp_budget:
+    # Turn management
+    turn: int = 1
+    budget_pool: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.budget_pool:
+            self.budget_pool = self.compute_budget()
+
+    # ------------------------------------------------------------------
+    # Turn and budget management
+    # ------------------------------------------------------------------
+    def compute_budget(self) -> int:
+        """Compute the budget for the next turn based on current corp values."""
+        return 100 + sum(self.corp_budget.values()) // 10
+
+    def allocate_corp_funds(self, key: str, amount: int) -> bool:
+        """Attempt to allocate funds from the current budget."""
+        if key in self.corp_budget and self.budget_pool >= amount:
             self.corp_budget[key] += amount
+            self.budget_pool -= amount
+            return True
+        return False
+
+    def advance_turn(self) -> None:
+        """Move to the next turn and refresh the budget."""
+        self.turn += 1
+        self.budget_pool = self.compute_budget()
+
+    def adjust_corp_budget(self, key: str, amount: int) -> None:
+        """Backward compatible wrapper around :py:meth:`allocate_corp_funds`."""
+        self.allocate_corp_funds(key, amount)
 
     def adjust_city_budget(self, key: str, amount: int) -> None:
         if key in self.city_budget:
@@ -28,6 +67,8 @@ class GameState:
 
     def save(self, path: str):
         data = {
+            "turn": self.turn,
+            "budget_pool": self.budget_pool,
             "corp_budget": self.corp_budget,
             "city_budget": self.city_budget,
             "characters": [c.to_dict() for c in self.characters],
@@ -42,6 +83,9 @@ class GameState:
         gs = cls()
         gs.corp_budget.update(data.get("corp_budget", {}))
         gs.city_budget.update(data.get("city_budget", {}))
+        gs.turn = data.get("turn", 1)
+        gs.budget_pool = data.get("budget_pool", gs.compute_budget())
         from .character import Character
+
         gs.characters = [Character.from_dict(c) for c in data.get("characters", [])]
         return gs

--- a/game/views.py
+++ b/game/views.py
@@ -1,8 +1,8 @@
 import arcade
-from .gamestate import GameState
-from .character import Character
-from .unit import Unit
 
+from .character import Character
+from .gamestate import GameState
+from .unit import Unit
 
 game_state = GameState()
 
@@ -10,16 +10,28 @@ game_state = GameState()
 class CorpView(arcade.View):
     def setup(self):
         self.text = "Corporation Management"
+        if game_state.budget_pool <= 0:
+            game_state.budget_pool = game_state.compute_budget()
 
     def on_draw(self):
         self.clear()
         y = self.window.height - 40
         arcade.draw_text(self.text, 20, y, arcade.color.WHITE, 20)
         y -= 40
+        arcade.draw_text(
+            f"Turn {game_state.turn} - Budget: {game_state.budget_pool}",
+            20,
+            y,
+            arcade.color.AQUA,
+            14,
+        )
+        y -= 20
         for k, v in game_state.corp_budget.items():
             arcade.draw_text(f"{k}: {v}", 20, y, arcade.color.WHITE, 14)
             y -= 20
-        arcade.draw_text("1-4 to invest, S to save, L to load", 20, 40, arcade.color.AQUA, 14)
+        arcade.draw_text(
+            "1-4 to invest, S to save, L to load", 20, 40, arcade.color.AQUA, 14
+        )
         arcade.draw_text("Press C for City, R for RPG", 20, 20, arcade.color.AQUA, 14)
 
     def on_key_press(self, key, modifiers):
@@ -33,17 +45,19 @@ class CorpView(arcade.View):
             rpg_view.setup()
             self.window.show_view(rpg_view)
         elif key == arcade.key.KEY_1:
-            game_state.adjust_corp_budget("research", 10)
+            game_state.allocate_corp_funds("research", 10)
         elif key == arcade.key.KEY_2:
-            game_state.adjust_corp_budget("security", 10)
+            game_state.allocate_corp_funds("security", 10)
         elif key == arcade.key.KEY_3:
-            game_state.adjust_corp_budget("politics", 10)
+            game_state.allocate_corp_funds("politics", 10)
         elif key == arcade.key.KEY_4:
-            game_state.adjust_corp_budget("black_ops", 10)
+            game_state.allocate_corp_funds("black_ops", 10)
         elif key == arcade.key.S:
             game_state.save("savegame.json")
         elif key == arcade.key.L:
             game_state = GameState.load("savegame.json")
+        if game_state.budget_pool <= 0:
+            game_state.advance_turn()
 
 
 class CityView(arcade.View):
@@ -86,9 +100,17 @@ class RPGView(arcade.View):
         arcade.draw_text(self.text, 20, self.window.height - 40, arcade.color.WHITE, 20)
         y = self.window.height - 80
         for char in game_state.characters:
-            arcade.draw_text(f"{char.name} - Lvl {char.level} - SP {char.skill_points}", 20, y, arcade.color.WHITE, 14)
+            arcade.draw_text(
+                f"{char.name} - Lvl {char.level} - SP {char.skill_points}",
+                20,
+                y,
+                arcade.color.WHITE,
+                14,
+            )
             y -= 20
-        arcade.draw_text("Press N to recruit, B for Battle", 20, 20, arcade.color.AQUA, 14)
+        arcade.draw_text(
+            "Press N to recruit, B for Battle", 20, 20, arcade.color.AQUA, 14
+        )
 
     def on_key_press(self, key, modifiers):
         global game_state
@@ -106,26 +128,32 @@ class BattleView(arcade.View):
         self.map = arcade.load_tilemap("scenes/test.tmx")
         self.scene = arcade.Scene.from_tilemap(self.map)
         self.camera = arcade.Camera(self.window.width, self.window.height)
-        self.unit = Unit(position=(64, 64))
+        self.player_units = [Unit(position=(64, 64))]
+        self.enemy_units = [Unit(position=(224, 224))]
 
     def on_draw(self):
         self.clear()
         self.camera.use()
         self.scene.draw()
-        x, y = self.unit.position
-        arcade.draw_circle_filled(x, y, 10, arcade.color.RED)
+        for unit in self.player_units:
+            x, y = unit.position
+            arcade.draw_circle_filled(x, y, 10, arcade.color.BLUE)
+        for enemy in self.enemy_units:
+            x, y = enemy.position
+            arcade.draw_circle_filled(x, y, 10, arcade.color.RED)
         self.camera.disable()
         arcade.draw_text("Arrows to move, Esc to exit", 20, 20, arcade.color.AQUA, 14)
 
     def on_key_press(self, key, modifiers):
+        player = self.player_units[0]
         if key == arcade.key.UP:
-            self.unit.move(0, 32)
+            player.move(0, 32)
         elif key == arcade.key.DOWN:
-            self.unit.move(0, -32)
+            player.move(0, -32)
         elif key == arcade.key.LEFT:
-            self.unit.move(-32, 0)
+            player.move(-32, 0)
         elif key == arcade.key.RIGHT:
-            self.unit.move(32, 0)
+            player.move(32, 0)
         elif key == arcade.key.ESCAPE:
             corp_view = CorpView()
             corp_view.setup()


### PR DESCRIPTION
## Summary
- implement per-turn corporation budget with automatic growth
- expose current turn and budget in Corp view
- show simple icons for player and enemy units on the battle map
- update documentation for new mechanics

## Testing
- `python -m py_compile game/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844178dde08832bbf34aabb687ae451