### PR TITLE
Add background selection for BattleView

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ python main.py
 - Arrow keys move the unit
 - PC and enemy icons are displayed on the map
 - `Esc` return to management
+- On first entering, choose a background image from `assets/maps`


### PR DESCRIPTION
## Summary
- read JPEG background images from `assets/maps`
- let the player pick a background before a battle
- display the chosen background in battles
- document map selection in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68458429079c832b974a7c3393e6b441