### PR TITLE
Implement target selection for attacks

### DIFF
--- a/game/unit.py
+++ b/game/unit.py
@@ -62,10 +62,12 @@ class Unit:
         return self._perform_attack(other, stat="str", range_=1)
 
     def shoot(self, other: "Unit") -> int:
-        return self._perform_attack(other, stat="agi", range_=3)
+        """Ranged attack using agility with a 10 cell range."""
+        return self._perform_attack(other, stat="agi", range_=10)
 
     def psi_attack(self, other: "Unit") -> int:
-        return self._perform_attack(other, stat="psi", range_=2)
+        """Psi attack with a 10 cell range."""
+        return self._perform_attack(other, stat="psi", range_=10)
 
     def defend(self) -> bool:
         if self.action_points <= 0:


### PR DESCRIPTION
## Summary
- add a 10-cell range for ranged and psi attacks
- add a target selection phase when the attack key is pressed
- highlight the selected enemy and allow cycling
- execute the attack on confirmation
- fix highlight drawing for older arcade versions
- use `draw_rectangle_outline` with center and size

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846cac57bec832ba1601b978d793ee8