### PR TITLE
Set starting PC as samurai

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -105,7 +105,10 @@ class CityView(arcade.View):
 class RPGView(arcade.View):
     def setup(self):
         if not game_state.characters:
-            game_state.characters.append(Character(name="Agent 1"))
+            # Start the party with a samurai that has boosted STR
+            game_state.characters.append(
+                create_character("Agent 1", "samurai")
+            )
         self.text = "RPG Phase"
         self.recruiting = False
         self.selected_role = None


### PR DESCRIPTION
## Summary
- create the default Agent 1 via `create_character` so they start as a samurai

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846ed785dcc832b98a4ce158867b9d6