### PR TITLE
Add vertical-slice world model modules

### DIFF
--- a/game/consequences.py
+++ b/game/consequences.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .savage_fate import SavageTag
+
+
+@dataclass
+class Consequence:
+    """Narrative and mechanical fallout from a battle or operation."""
+
+    affected_district: str | None = None
+    affected_faction: str | None = None
+    affected_agent: str | None = None
+    severity: int = 1
+    narrative_text: str = ""
+    mechanical_effects: dict = field(default_factory=dict)
+    tags: list[SavageTag] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "affected_district": self.affected_district,
+            "affected_faction": self.affected_faction,
+            "affected_agent": self.affected_agent,
+            "severity": self.severity,
+            "narrative_text": self.narrative_text,
+            "mechanical_effects": self.mechanical_effects,
+            "tags": [tag.to_dict() for tag in self.tags],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "Consequence") -> "Consequence":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            affected_district=data.get("affected_district"),
+            affected_faction=data.get("affected_faction"),
+            affected_agent=data.get("affected_agent"),
+            severity=data.get("severity", 1),
+            narrative_text=data.get("narrative_text", ""),
+            mechanical_effects=dict(data.get("mechanical_effects", {})),
+            tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
+        )
+
+
+def create_opening_consequence(district_name: str = "Chrome Warrens") -> Consequence:
+    """Seed fallout that tells the player the district is already unstable."""
+    return Consequence(
+        affected_district=district_name,
+        severity=1,
+        narrative_text="Blackout rumors spike after an Aegis patrol vanishes under the east rail.",
+        mechanical_effects={"unrest": 3, "media_heat": 2},
+    )

--- a/game/factions.py
+++ b/game/factions.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .savage_fate import SavageTag, tag_from_library
+
+
+@dataclass
+class Faction:
+    """Political, corporate, or street power active in the vertical slice."""
+
+    name: str
+    influence: int
+    hostility_to_player: int
+    public_legitimacy: int
+    active_tags: list[SavageTag] = field(default_factory=list)
+
+    def clamp_pressure(self) -> None:
+        self.influence = max(0, min(100, self.influence))
+        self.hostility_to_player = max(0, min(100, self.hostility_to_player))
+        self.public_legitimacy = max(0, min(100, self.public_legitimacy))
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "influence": self.influence,
+            "hostility_to_player": self.hostility_to_player,
+            "public_legitimacy": self.public_legitimacy,
+            "active_tags": [tag.to_dict() for tag in self.active_tags],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "Faction") -> "Faction":
+        if isinstance(data, cls):
+            return data
+        faction = cls(
+            name=data.get("name", "Unknown Faction"),
+            influence=data.get("influence", 25),
+            hostility_to_player=data.get("hostility_to_player", 25),
+            public_legitimacy=data.get("public_legitimacy", 25),
+            active_tags=[
+                SavageTag.from_dict(tag) for tag in data.get("active_tags", [])
+            ],
+        )
+        faction.clamp_pressure()
+        return faction
+
+
+def create_vertical_slice_factions() -> list[Faction]:
+    """Build the three factions present in the first playable world slice."""
+    return [
+        Faction(
+            name="Aegis Dynamics",
+            influence=72,
+            hostility_to_player=18,
+            public_legitimacy=54,
+            active_tags=[tag_from_library("media_swarm")],
+        ),
+        Faction(
+            name="Warrens Free Clinic",
+            influence=34,
+            hostility_to_player=8,
+            public_legitimacy=81,
+            active_tags=[],
+        ),
+        Faction(
+            name="Chrome Jackals",
+            influence=49,
+            hostility_to_player=62,
+            public_legitimacy=19,
+            active_tags=[tag_from_library("gang_pressure")],
+        ),
+    ]

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -4,6 +4,11 @@ import json
 from dataclasses import dataclass, field
 from typing import List, TYPE_CHECKING
 
+from .consequences import Consequence, create_opening_consequence
+from .factions import Faction, create_vertical_slice_factions
+from .operations import Operation, create_operation_templates
+from .world import District, create_vertical_slice_district
+
 if TYPE_CHECKING:
     from .character import Character
 
@@ -33,6 +38,22 @@ class GameState:
 
     # List of recruited characters
     characters: List[Character] = field(default_factory=list)
+
+    # First vertical-slice world model: one district, one base, and three factions
+    base_name: str = "Aegis Forward Base Kilo"
+    district: District = field(default_factory=create_vertical_slice_district)
+    factions: list[Faction] = field(default_factory=create_vertical_slice_factions)
+    active_operations: list[Operation] = field(
+        default_factory=create_operation_templates
+    )
+    recent_consequences: list[Consequence] = field(
+        default_factory=lambda: [create_opening_consequence()]
+    )
+    event_log: list[str] = field(
+        default_factory=lambda: [
+            "Turn 1: Forward Base Kilo establishes overwatch in the Chrome Warrens."
+        ]
+    )
 
     # Experience points gained through battles
     x: int = 0
@@ -64,6 +85,21 @@ class GameState:
         """Move to the next turn and refresh the budget."""
         self.turn += 1
         self.budget_pool = self.compute_budget()
+        self.add_event(
+            f"Turn {self.turn}: Corporate budget refreshed for {self.base_name}."
+        )
+
+    def add_event(self, text: str) -> None:
+        """Append a compact event-log entry and retain only the latest beats."""
+        self.event_log.append(text)
+        self.event_log = self.event_log[-12:]
+
+    def record_consequence(self, consequence: Consequence) -> None:
+        """Store recent fallout and add it to the event log."""
+        self.recent_consequences.append(consequence)
+        self.recent_consequences = self.recent_consequences[-6:]
+        if consequence.narrative_text:
+            self.add_event(consequence.narrative_text)
 
     def adjust_corp_budget(self, key: str, amount: int) -> None:
         """Backward compatible wrapper around :py:meth:`allocate_corp_funds`."""
@@ -81,6 +117,16 @@ class GameState:
             "city_budget": self.city_budget,
             "characters": [c.to_dict() for c in self.characters],
             "x": self.x,
+            "base_name": self.base_name,
+            "district": self.district.to_dict(),
+            "factions": [faction.to_dict() for faction in self.factions],
+            "active_operations": [
+                operation.to_dict() for operation in self.active_operations
+            ],
+            "recent_consequences": [
+                consequence.to_dict() for consequence in self.recent_consequences
+            ],
+            "event_log": list(self.event_log),
         }
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
@@ -95,6 +141,20 @@ class GameState:
         gs.turn = data.get("turn", 1)
         gs.budget_pool = data.get("budget_pool", gs.compute_budget())
         gs.x = data.get("x", 0)
+        gs.base_name = data.get("base_name", gs.base_name)
+        gs.district = District.from_dict(data.get("district", gs.district.to_dict()))
+        gs.factions = [
+            Faction.from_dict(faction) for faction in data.get("factions", [])
+        ] or create_vertical_slice_factions()
+        gs.active_operations = [
+            Operation.from_dict(operation)
+            for operation in data.get("active_operations", [])
+        ] or create_operation_templates(gs.district.name)
+        gs.recent_consequences = [
+            Consequence.from_dict(consequence)
+            for consequence in data.get("recent_consequences", [])
+        ] or [create_opening_consequence(gs.district.name)]
+        gs.event_log = list(data.get("event_log", gs.event_log))
         from .character import Character
 
         gs.characters = [Character.from_dict(c) for c in data.get("characters", [])]

--- a/game/operations.py
+++ b/game/operations.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .savage_fate import SavageTag, tag_from_library
+
+
+@dataclass
+class Operation:
+    """Mission-sized pressure applied to one faction in one district."""
+
+    type: str
+    target_faction: str
+    district: str
+    risk: int
+    objective: str
+    complications: list[str] = field(default_factory=list)
+    outcome_tags: list[SavageTag] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "type": self.type,
+            "target_faction": self.target_faction,
+            "district": self.district,
+            "risk": self.risk,
+            "objective": self.objective,
+            "complications": list(self.complications),
+            "outcome_tags": [tag.to_dict() for tag in self.outcome_tags],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "Operation") -> "Operation":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            type=data.get("type", "intel"),
+            target_faction=data.get("target_faction", "Unknown Faction"),
+            district=data.get("district", "Chrome Warrens"),
+            risk=data.get("risk", 1),
+            objective=data.get("objective", "Stabilize the district."),
+            complications=list(data.get("complications", [])),
+            outcome_tags=[
+                SavageTag.from_dict(tag) for tag in data.get("outcome_tags", [])
+            ],
+        )
+
+
+def create_operation_templates(
+    district_name: str = "Chrome Warrens",
+) -> list[Operation]:
+    """Return a handful of reusable vertical-slice operation seeds."""
+    return [
+        Operation(
+            type="hearts_and_minds",
+            target_faction="Warrens Free Clinic",
+            district=district_name,
+            risk=2,
+            objective="Escort medtechs through blackout alleys and win visible trust.",
+            complications=[
+                "Power failures hide ambush routes",
+                "Cameras may frame the team as occupiers",
+            ],
+            outcome_tags=[tag_from_library("media_swarm")],
+        ),
+        Operation(
+            type="counter_gang_raid",
+            target_faction="Chrome Jackals",
+            district=district_name,
+            risk=4,
+            objective="Break a Jackal weapons handoff before it floods the Warrens.",
+            complications=[
+                "Civilian lookouts protect the drop",
+                "The Jackals wired the crates to burn evidence",
+            ],
+            outcome_tags=[tag_from_library("gang_pressure")],
+        ),
+        Operation(
+            type="signal_trace",
+            target_faction="Aegis Dynamics",
+            district=district_name,
+            risk=3,
+            objective="Trace a spoofed corporate order without triggering Aegis auditors.",
+            complications=[
+                "Ghost packets mimic friendly command",
+                "A media drone is already on scene",
+            ],
+            outcome_tags=[tag_from_library("ghost_signal")],
+        ),
+    ]

--- a/game/savage_fate.py
+++ b/game/savage_fate.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SavageTag:
+    """Narrative tag used to color missions, outcomes, and consequences."""
+
+    name: str
+    description: str
+    intensity: int = 1
+    source: str = "world"
+    expires_after_turns: int | None = None
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "intensity": self.intensity,
+            "source": self.source,
+            "expires_after_turns": self.expires_after_turns,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "SavageTag") -> "SavageTag":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            name=data.get("name", "unknown"),
+            description=data.get("description", ""),
+            intensity=data.get("intensity", 1),
+            source=data.get("source", "world"),
+            expires_after_turns=data.get("expires_after_turns"),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+
+SAVAGE_TAG_LIBRARY: dict[str, SavageTag] = {
+    "neon_blackout": SavageTag(
+        name="neon_blackout",
+        description="Rolling power outages make every alley a blind spot.",
+        intensity=2,
+        source="district",
+    ),
+    "media_swarm": SavageTag(
+        name="media_swarm",
+        description="Pirate feeds and corporate journalists are hunting for a scandal.",
+        intensity=2,
+        source="media",
+    ),
+    "gang_pressure": SavageTag(
+        name="gang_pressure",
+        description="Street crews are testing who really owns the district.",
+        intensity=1,
+        source="faction",
+    ),
+    "ghost_signal": SavageTag(
+        name="ghost_signal",
+        description="A hostile signal rides the local mesh and spoofs trusted orders.",
+        intensity=3,
+        source="operation",
+    ),
+}
+
+
+def tag_from_library(name: str) -> SavageTag:
+    """Return a detached copy of a known narrative tag."""
+    tag = SAVAGE_TAG_LIBRARY[name]
+    return SavageTag.from_dict(tag.to_dict())

--- a/game/world.py
+++ b/game/world.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .savage_fate import SavageTag, tag_from_library
+
+
+@dataclass
+class District:
+    """A single playable slice of CyberCity's wider urban sprawl."""
+
+    name: str
+    stability: int
+    control_faction: str
+    unrest: int
+    media_heat: int
+    tags: list[SavageTag] = field(default_factory=list)
+
+    def clamp_pressure(self) -> None:
+        """Keep mutable district pressure values within readable 0-100 bands."""
+        self.stability = max(0, min(100, self.stability))
+        self.unrest = max(0, min(100, self.unrest))
+        self.media_heat = max(0, min(100, self.media_heat))
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "stability": self.stability,
+            "control_faction": self.control_faction,
+            "unrest": self.unrest,
+            "media_heat": self.media_heat,
+            "tags": [tag.to_dict() for tag in self.tags],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "District") -> "District":
+        if isinstance(data, cls):
+            return data
+        district = cls(
+            name=data.get("name", "Chrome Warrens"),
+            stability=data.get("stability", 45),
+            control_faction=data.get("control_faction", "Aegis Dynamics"),
+            unrest=data.get("unrest", 35),
+            media_heat=data.get("media_heat", 20),
+            tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
+        )
+        district.clamp_pressure()
+        return district
+
+
+def create_vertical_slice_district() -> District:
+    """Build the one district used by the first vertical-slice world model."""
+    return District(
+        name="Chrome Warrens",
+        stability=45,
+        control_faction="Aegis Dynamics",
+        unrest=38,
+        media_heat=24,
+        tags=[tag_from_library("neon_blackout"), tag_from_library("gang_pressure")],
+    )


### PR DESCRIPTION
### Motivation
- Move world / narrative model out of `views.py` into focused modules to keep UI code small and make the world data model testable and extendable.
- Provide a minimal, playable vertical slice (one district, one base, three factions, and a few operation templates) so systems work end-to-end before broadening scope.

### Description
- Add new modules: `game/savage_fate.py`, `game/world.py`, `game/factions.py`, `game/operations.py`, and `game/consequences.py` containing dataclasses and helpers for narrative tags, `District`, `Faction`, `Operation`, and `Consequence` respectively, each with `to_dict`/`from_dict` serialization helpers and small factories (`tag_from_library`, `create_vertical_slice_*`, `create_operation_templates`, `create_opening_consequence`).
- Introduce `SavageTag` narrative-tag library and `tag_from_library` to produce detached tag instances used by factions, districts, operations, and consequences.
- Extend `GameState` (`game/gamestate.py`) with vertical-slice fields: `base_name`, `district`, `factions`, `active_operations`, `recent_consequences`, and `event_log`, plus helper methods `add_event` and `record_consequence` and persistence of the new fields in `save`/`load`.
- Keep changes self-contained to a small vertical slice (one district, one base, three factions, a handful of operation templates) and preserve existing character/budget behaviour.

### Testing
- Ran a small runtime check that instantiates `GameState`, verifies `district.name == "Chrome Warrens"`, `len(factions) == 3`, `len(active_operations) == 3`, advances a turn, round-trips `save`/`load`, and asserts loaded state matches, which completed successfully (`world model serialization ok`).
- Compiled the `game` package with `python -m compileall game` to check syntax, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0560a1a204832b9e6b1631c55564da)