### PR TITLE
Add agent dossier fields and RPG dossier display

### DIFF
--- a/game/character.py
+++ b/game/character.py
@@ -6,12 +6,24 @@ from .stats import PlayerStats
 
 @dataclass
 class Character:
-    """Player character with associated statistics."""
+    """Player character with associated statistics and agent dossier details."""
 
     name: str
     role: str = "samurai"
     stats: PlayerStats = field(default_factory=PlayerStats)
     pending_points: int = 0
+    traits: list[str] = field(default_factory=list)
+    addictions: list[str] = field(default_factory=list)
+    fears: list[str] = field(default_factory=list)
+    ambition: str = ""
+    loyalty: int = 0
+    stress: int = 0
+    trauma: list[str] = field(default_factory=list)
+    injuries: list[str] = field(default_factory=list)
+    reputation: list[str] = field(default_factory=list)
+    relationships: dict[str, int] = field(default_factory=dict)
+    history: list[str] = field(default_factory=list)
+    savage_tags: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -19,6 +31,18 @@ class Character:
             "role": self.role,
             "stats": asdict(self.stats),
             "pending_points": self.pending_points,
+            "traits": list(self.traits),
+            "addictions": list(self.addictions),
+            "fears": list(self.fears),
+            "ambition": self.ambition,
+            "loyalty": self.loyalty,
+            "stress": self.stress,
+            "trauma": list(self.trauma),
+            "injuries": list(self.injuries),
+            "reputation": list(self.reputation),
+            "relationships": dict(self.relationships),
+            "history": list(self.history),
+            "savage_tags": list(self.savage_tags),
         }
 
     @classmethod
@@ -30,6 +54,18 @@ class Character:
             role=data.get("role", "samurai"),
             stats=stats,
             pending_points=data.get("pending_points", 0),
+            traits=list(data.get("traits", [])),
+            addictions=list(data.get("addictions", [])),
+            fears=list(data.get("fears", [])),
+            ambition=data.get("ambition", ""),
+            loyalty=data.get("loyalty", 0),
+            stress=data.get("stress", 0),
+            trauma=list(data.get("trauma", [])),
+            injuries=list(data.get("injuries", [])),
+            reputation=list(data.get("reputation", [])),
+            relationships=dict(data.get("relationships", {})),
+            history=list(data.get("history", [])),
+            savage_tags=list(data.get("savage_tags", [])),
         )
 
     def gain_xp(self, amount: int) -> None:

--- a/game/dossier.py
+++ b/game/dossier.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from .character import Character
+
+
+NO_TRAIT = "No notable trait"
+NO_WOUND = "No recorded injury or trauma"
+NO_HISTORY = "No history logged"
+
+
+def first_or_default(values: list[str], default: str) -> str:
+    """Return the first dossier entry or a readable placeholder."""
+    return values[0] if values else default
+
+
+def first_wound_or_trauma(character: Character) -> str:
+    """Prefer visible injuries, then unresolved trauma for the agent dossier."""
+    if character.injuries:
+        return character.injuries[0]
+    if character.trauma:
+        return character.trauma[0]
+    return NO_WOUND
+
+
+def build_agent_dossier_lines(character: Character) -> tuple[str, str]:
+    """Build concise RPG-view dossier lines for an agent."""
+    stats = character.stats
+    summary = (
+        f"{character.name} ({character.role}) HP {stats.hp}/{stats.max_hp} "
+        f"Stress {character.stress} Loyalty {character.loyalty}"
+    )
+    detail = (
+        f"  Trait: {first_or_default(character.traits, NO_TRAIT)} | "
+        f"Scar: {first_wound_or_trauma(character)} | "
+        f"History: {first_or_default(character.history, NO_HISTORY)}"
+    )
+    return summary, detail

--- a/game/views.py
+++ b/game/views.py
@@ -3,6 +3,7 @@ import os
 import random
 
 from .character import Character
+from .dossier import build_agent_dossier_lines
 from .stats import PlayerStats, EnemyStats
 from .gamestate import GameState
 from .unit import Unit
@@ -116,9 +117,10 @@ class RPGView(arcade.View):
         arcade.draw_text(self.text, 20, self.window.height - 40, arcade.color.WHITE, 20)
         y = self.window.height - 80
         for char in game_state.characters:
-            s = char.stats
-            info = f"{char.name} ({char.role}) Lv{s.level} HP{s.hp}/{s.max_hp} STR{s.str} AGI{s.agi} PSI{s.psi} DEF{s.defense} CON{s.con} CHA{s.cha} XP{s.xp}"
+            info, dossier = build_agent_dossier_lines(char)
             arcade.draw_text(info, 20, y, arcade.color.WHITE, 14)
+            arcade.draw_text(dossier, 40, y - 15, arcade.color.LIGHT_GRAY, 12)
+            y -= 15
             if char.pending_points > 0:
                 arcade.draw_text(
                     f"  Allocate {char.pending_points} pts: 1=PSI 2=STR 3=AGI 4=CON 5=CHA",


### PR DESCRIPTION
### Motivation
- Introduce agent-facing metadata (dossier) separate from combat stats so narrative/AI-facing fields are available without mixing into `PlayerStats`.
- Persist those dossier fields in savegames so agent state (traits, injuries, history, relationships, etc.) survives save/load cycles.
- Surface a concise, human-readable dossier in the RPG UI so players can quickly see name, role, HP, stress, loyalty, a trait, an injury/trauma, and a memorable history line.

### Description
- Added dossier fields to `Character` (`traits`, `addictions`, `fears`, `ambition`, `loyalty`, `stress`, `trauma`, `injuries`, `reputation`, `relationships`, `history`, `savage_tags`) and left combat values in `PlayerStats` unchanged in `game/character.py`.
- Updated `Character.to_dict()` and `Character.from_dict()` to serialize/deserialize all new dossier fields so `GameState.save()` writes them into `savegame.json` and `GameState.load()` restores them.
- Introduced `game/dossier.py` containing `build_agent_dossier_lines()` and small helpers to format a concise two-line agent dossier with sensible fallbacks for missing data.
- Replaced the verbose numeric stat line in `RPGView.on_draw()` with the dossier display by calling `build_agent_dossier_lines()` and rendering the summary and detail lines.

### Testing
- Compiled changed modules with `compile()` to validate syntax and ensure no import errors, which succeeded.
- Verified `Character.to_dict()`/`Character.from_dict()` round-trip via assertions that compared original and loaded dictionaries, which passed.
- Tested `build_agent_dossier_lines()` content and `GameState.save()`/`GameState.load()` using a `NamedTemporaryFile` to assert persistence of `traits`, `relationships`, and `history`, which passed.
- Ran `git diff --check` to ensure no whitespace or diff issues, which produced no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0562011330832bb5c7ba0b0114548e)