### PR TITLE
Add mission layer before tactical battles

### DIFF
--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -6,6 +6,7 @@ from typing import List, TYPE_CHECKING
 
 from .consequences import Consequence, create_opening_consequence
 from .factions import Faction, create_vertical_slice_factions
+from .mission_templates import MissionTemplate, create_mission_templates
 from .operations import Operation, create_operation_templates
 from .world import District, create_vertical_slice_district
 
@@ -46,6 +47,11 @@ class GameState:
     active_operations: list[Operation] = field(
         default_factory=create_operation_templates
     )
+    mission_templates: list[MissionTemplate] = field(
+        default_factory=create_mission_templates
+    )
+    active_mission: MissionTemplate | None = None
+    selected_mission_index: int = 0
     recent_consequences: list[Consequence] = field(
         default_factory=lambda: [create_opening_consequence()]
     )
@@ -101,6 +107,53 @@ class GameState:
         if consequence.narrative_text:
             self.add_event(consequence.narrative_text)
 
+    def apply_consequence(self, consequence: Consequence) -> None:
+        """Apply district and faction effects from a mission consequence."""
+        effects = consequence.mechanical_effects
+        for key in ("stability", "unrest", "media_heat"):
+            if key in effects and hasattr(self.district, key):
+                setattr(self.district, key, getattr(self.district, key) + effects[key])
+        self.district.clamp_pressure()
+
+        if consequence.affected_faction:
+            faction = self.get_faction(consequence.affected_faction)
+            if faction:
+                if "faction_hostility" in effects:
+                    faction.hostility_to_player += effects["faction_hostility"]
+                if "faction_influence" in effects:
+                    faction.influence += effects["faction_influence"]
+                if "faction_legitimacy" in effects:
+                    faction.public_legitimacy += effects["faction_legitimacy"]
+                for tag in consequence.tags:
+                    if all(existing.name != tag.name for existing in faction.active_tags):
+                        faction.active_tags.append(tag)
+                faction.clamp_pressure()
+
+        for tag in consequence.tags:
+            if all(existing.name != tag.name for existing in self.district.tags):
+                self.district.tags.append(tag)
+        self.record_consequence(consequence)
+
+    def apply_active_mission_pressure(self) -> None:
+        """Apply up-front district pressure from the selected active mission."""
+        if not self.active_mission:
+            return
+        for key, amount in self.active_mission.district_pressure.items():
+            if hasattr(self.district, key):
+                setattr(self.district, key, getattr(self.district, key) + amount)
+        self.district.clamp_pressure()
+        self.add_event(
+            f"Mission launched: {self.active_mission.title} against "
+            f"{self.active_mission.target_faction}."
+        )
+
+    def get_faction(self, name: str) -> Faction | None:
+        """Find a faction by name in the current world slice."""
+        for faction in self.factions:
+            if faction.name == name:
+                return faction
+        return None
+
     def adjust_corp_budget(self, key: str, amount: int) -> None:
         """Backward compatible wrapper around :py:meth:`allocate_corp_funds`."""
         self.allocate_corp_funds(key, amount)
@@ -123,6 +176,13 @@ class GameState:
             "active_operations": [
                 operation.to_dict() for operation in self.active_operations
             ],
+            "mission_templates": [
+                mission.to_dict() for mission in self.mission_templates
+            ],
+            "active_mission": (
+                self.active_mission.to_dict() if self.active_mission else None
+            ),
+            "selected_mission_index": self.selected_mission_index,
             "recent_consequences": [
                 consequence.to_dict() for consequence in self.recent_consequences
             ],
@@ -150,6 +210,17 @@ class GameState:
             Operation.from_dict(operation)
             for operation in data.get("active_operations", [])
         ] or create_operation_templates(gs.district.name)
+        gs.mission_templates = [
+            MissionTemplate.from_dict(mission)
+            for mission in data.get("mission_templates", [])
+        ] or create_mission_templates(gs.district.name)
+        active_mission_data = data.get("active_mission")
+        gs.active_mission = (
+            MissionTemplate.from_dict(active_mission_data)
+            if active_mission_data
+            else None
+        )
+        gs.selected_mission_index = data.get("selected_mission_index", 0)
         gs.recent_consequences = [
             Consequence.from_dict(consequence)
             for consequence in data.get("recent_consequences", [])

--- a/game/mission_templates.py
+++ b/game/mission_templates.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .consequences import Consequence
+from .savage_fate import SavageTag, tag_from_library
+
+
+@dataclass
+class MissionComplication:
+    """A battle complication that can become fallout for an active mission."""
+
+    key: str
+    name: str
+    trigger_text: str
+    risk_threshold: int
+    tags: list[SavageTag] = field(default_factory=list)
+    consequence: Consequence = field(default_factory=Consequence)
+
+    def to_dict(self) -> dict:
+        return {
+            "key": self.key,
+            "name": self.name,
+            "trigger_text": self.trigger_text,
+            "risk_threshold": self.risk_threshold,
+            "tags": [tag.to_dict() for tag in self.tags],
+            "consequence": self.consequence.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "MissionComplication") -> "MissionComplication":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            key=data.get("key", "unknown"),
+            name=data.get("name", "Unknown Complication"),
+            trigger_text=data.get("trigger_text", "The mission twists out of shape."),
+            risk_threshold=data.get("risk_threshold", 1),
+            tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
+            consequence=Consequence.from_dict(data.get("consequence", {})),
+        )
+
+
+@dataclass
+class MissionTemplate:
+    """A vertical-slice mission seed that drives tactical battle setup and fallout."""
+
+    id: str
+    title: str
+    objective_text: str
+    target_faction: str
+    district: str
+    district_pressure: dict
+    starting_enemy_count: int
+    possible_complications: list[MissionComplication] = field(default_factory=list)
+    success_consequences: list[Consequence] = field(default_factory=list)
+    failure_consequences: list[Consequence] = field(default_factory=list)
+    risk_level: int = 1
+    tags: list[SavageTag] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "objective_text": self.objective_text,
+            "target_faction": self.target_faction,
+            "district": self.district,
+            "district_pressure": dict(self.district_pressure),
+            "starting_enemy_count": self.starting_enemy_count,
+            "possible_complications": [
+                complication.to_dict() for complication in self.possible_complications
+            ],
+            "success_consequences": [
+                consequence.to_dict() for consequence in self.success_consequences
+            ],
+            "failure_consequences": [
+                consequence.to_dict() for consequence in self.failure_consequences
+            ],
+            "risk_level": self.risk_level,
+            "tags": [tag.to_dict() for tag in self.tags],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "MissionTemplate") -> "MissionTemplate":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            id=data.get("id", "unknown"),
+            title=data.get("title", "Unknown Mission"),
+            objective_text=data.get("objective_text", "Win the tactical engagement."),
+            target_faction=data.get("target_faction", "Unknown Faction"),
+            district=data.get("district", "Chrome Warrens"),
+            district_pressure=dict(data.get("district_pressure", {})),
+            starting_enemy_count=data.get("starting_enemy_count", 1),
+            possible_complications=[
+                MissionComplication.from_dict(complication)
+                for complication in data.get("possible_complications", [])
+            ],
+            success_consequences=[
+                Consequence.from_dict(consequence)
+                for consequence in data.get("success_consequences", [])
+            ],
+            failure_consequences=[
+                Consequence.from_dict(consequence)
+                for consequence in data.get("failure_consequences", [])
+            ],
+            risk_level=data.get("risk_level", 1),
+            tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
+        )
+
+
+def create_core_complications(district_name: str) -> list[MissionComplication]:
+    """Return complications shared by the first mission layer."""
+    return [
+        MissionComplication(
+            key="media_leak",
+            name="Media Leak",
+            trigger_text="A pirate news relay leaks the team's route before extraction.",
+            risk_threshold=2,
+            tags=[tag_from_library("media_leak")],
+            consequence=Consequence(
+                affected_district=district_name,
+                severity=2,
+                narrative_text="Media leak: pirate feeds turn the firefight into a public scandal.",
+                mechanical_effects={"media_heat": 8, "stability": -2},
+                tags=[tag_from_library("media_leak")],
+            ),
+        ),
+        MissionComplication(
+            key="civilian_panic",
+            name="Civilian Panic",
+            trigger_text="Crowds panic as muzzle flashes bounce across the stacked market decks.",
+            risk_threshold=3,
+            tags=[tag_from_library("civilian_panic")],
+            consequence=Consequence(
+                affected_district=district_name,
+                severity=2,
+                narrative_text="Civilian panic: frightened residents jam streets and blame Aegis patrols.",
+                mechanical_effects={"unrest": 7, "stability": -4},
+                tags=[tag_from_library("civilian_panic")],
+            ),
+        ),
+        MissionComplication(
+            key="faction_retaliation",
+            name="Faction Retaliation",
+            trigger_text="The target faction marks the squad and calls in retaliation crews.",
+            risk_threshold=4,
+            tags=[tag_from_library("faction_retaliation")],
+            consequence=Consequence(
+                affected_district=district_name,
+                severity=3,
+                narrative_text="Faction retaliation: the target faction answers with reprisals and fresh threats.",
+                mechanical_effects={"faction_hostility": 9, "unrest": 4},
+                tags=[tag_from_library("faction_retaliation")],
+            ),
+        ),
+    ]
+
+
+def create_mission_templates(
+    district_name: str = "Chrome Warrens",
+) -> list[MissionTemplate]:
+    """Build the three playable vertical-slice missions before entering battle."""
+    complications = create_core_complications(district_name)
+    return [
+        MissionTemplate(
+            id="extraction",
+            title="Extraction: Neon Witness",
+            objective_text="Extract a clinic witness from the east-rail blackout before gangs sell them to Aegis auditors.",
+            target_faction="Chrome Jackals",
+            district=district_name,
+            district_pressure={"unrest": 3, "media_heat": 2},
+            starting_enemy_count=2,
+            possible_complications=[complications[0], complications[1]],
+            success_consequences=[
+                Consequence(
+                    affected_district=district_name,
+                    affected_faction="Warrens Free Clinic",
+                    severity=1,
+                    narrative_text="Extraction success: the witness reaches the clinic and locals share safehouse routes.",
+                    mechanical_effects={"stability": 5, "unrest": -4, "faction_hostility": -3},
+                    tags=[tag_from_library("civilian_panic")],
+                )
+            ],
+            failure_consequences=[
+                Consequence(
+                    affected_district=district_name,
+                    affected_faction="Chrome Jackals",
+                    severity=3,
+                    narrative_text="Extraction failure: the witness disappears and Jackal recruiters own the rumor mill.",
+                    mechanical_effects={"unrest": 8, "media_heat": 4, "faction_hostility": 6},
+                    tags=[tag_from_library("gang_pressure")],
+                )
+            ],
+            risk_level=2,
+            tags=[tag_from_library("neon_blackout")],
+        ),
+        MissionTemplate(
+            id="sabotage",
+            title="Sabotage: Jackal Relay Burn",
+            objective_text="Destroy the Chrome Jackals' relay van before it coordinates raids on the defense zones.",
+            target_faction="Chrome Jackals",
+            district=district_name,
+            district_pressure={"unrest": 5, "media_heat": 1},
+            starting_enemy_count=3,
+            possible_complications=[complications[1], complications[2]],
+            success_consequences=[
+                Consequence(
+                    affected_district=district_name,
+                    affected_faction="Chrome Jackals",
+                    severity=2,
+                    narrative_text="Sabotage success: the Jackal relay goes dark and their raid clock slips.",
+                    mechanical_effects={"unrest": -6, "stability": 3, "faction_influence": -5},
+                    tags=[tag_from_library("gang_pressure")],
+                )
+            ],
+            failure_consequences=[
+                Consequence(
+                    affected_district=district_name,
+                    affected_faction="Chrome Jackals",
+                    severity=3,
+                    narrative_text="Sabotage failure: the relay survives and Jackal retaliation teams flood the alleys.",
+                    mechanical_effects={"unrest": 9, "faction_hostility": 8, "stability": -5},
+                    tags=[tag_from_library("faction_retaliation")],
+                )
+            ],
+            risk_level=4,
+            tags=[tag_from_library("gang_pressure")],
+        ),
+        MissionTemplate(
+            id="data_theft",
+            title="Data Theft: Ghost Order Cache",
+            objective_text="Steal the spoofed Aegis order cache without letting corporate counterintel trace the breach.",
+            target_faction="Aegis Dynamics",
+            district=district_name,
+            district_pressure={"media_heat": 4, "stability": -1},
+            starting_enemy_count=2,
+            possible_complications=[complications[0], complications[2]],
+            success_consequences=[
+                Consequence(
+                    affected_district=district_name,
+                    affected_faction="Aegis Dynamics",
+                    severity=2,
+                    narrative_text="Data theft success: the ghost order cache exposes a false-flag command chain.",
+                    mechanical_effects={"media_heat": -3, "stability": 4, "faction_influence": -4},
+                    tags=[tag_from_library("ghost_signal")],
+                )
+            ],
+            failure_consequences=[
+                Consequence(
+                    affected_district=district_name,
+                    affected_faction="Aegis Dynamics",
+                    severity=3,
+                    narrative_text="Data theft failure: Aegis counterintel frames the squad as rogue assets.",
+                    mechanical_effects={"media_heat": 9, "faction_hostility": 7, "stability": -4},
+                    tags=[tag_from_library("media_leak")],
+                )
+            ],
+            risk_level=3,
+            tags=[tag_from_library("ghost_signal"), tag_from_library("media_swarm")],
+        ),
+    ]

--- a/game/savage_fate.py
+++ b/game/savage_fate.py
@@ -63,6 +63,24 @@ SAVAGE_TAG_LIBRARY: dict[str, SavageTag] = {
         intensity=3,
         source="operation",
     ),
+    "media_leak": SavageTag(
+        name="media_leak",
+        description="Leaked footage turns tactical choices into public evidence.",
+        intensity=2,
+        source="complication",
+    ),
+    "civilian_panic": SavageTag(
+        name="civilian_panic",
+        description="Noncombatants scatter, block exits, and amplify district unrest.",
+        intensity=2,
+        source="complication",
+    ),
+    "faction_retaliation": SavageTag(
+        name="faction_retaliation",
+        description="A wounded faction answers with reprisal crews and pressure campaigns.",
+        intensity=3,
+        source="complication",
+    ),
 }
 
 

--- a/game/views.py
+++ b/game/views.py
@@ -6,6 +6,7 @@ from .character import Character
 from .dossier import build_agent_dossier_lines
 from .stats import PlayerStats, EnemyStats
 from .gamestate import GameState
+from .mission_templates import MissionTemplate, create_mission_templates
 from .unit import Unit
 
 def create_character(name: str, role: str) -> Character:
@@ -111,6 +112,20 @@ class RPGView(arcade.View):
         self.recruiting = False
         self.selected_role = None
         self.allocating = None
+        if not game_state.mission_templates:
+            game_state.mission_templates = create_mission_templates(game_state.district.name)
+        game_state.selected_mission_index %= len(game_state.mission_templates)
+
+    def selected_mission(self) -> MissionTemplate:
+        return game_state.mission_templates[game_state.selected_mission_index]
+
+    def launch_selected_mission(self) -> None:
+        mission = MissionTemplate.from_dict(self.selected_mission().to_dict())
+        game_state.active_mission = mission
+        game_state.apply_active_mission_pressure()
+        battle_view = BattleView()
+        battle_view.setup(mission)
+        self.window.show_view(battle_view)
 
     def on_draw(self):
         self.clear()
@@ -136,15 +151,44 @@ class RPGView(arcade.View):
                 "Select role: 1 Samurai, 2 Sniper, 3 Psi", 20, y, arcade.color.YELLOW, 14
             )
             y -= 20
+        else:
+            arcade.draw_text("Mission Board", 20, y, arcade.color.YELLOW, 16)
+            y -= 22
+            for idx, mission in enumerate(game_state.mission_templates, start=1):
+                prefix = ">" if idx - 1 == game_state.selected_mission_index else " "
+                arcade.draw_text(
+                    f"{prefix}{idx}. {mission.title} | {mission.target_faction} | "
+                    f"Risk {mission.risk_level} | Enemies {mission.starting_enemy_count}",
+                    20,
+                    y,
+                    arcade.color.AQUA if idx - 1 == game_state.selected_mission_index else arcade.color.WHITE,
+                    12,
+                )
+                y -= 16
+            mission = self.selected_mission()
+            arcade.draw_text(mission.objective_text, 40, y, arcade.color.LIGHT_GRAY, 11)
+            y -= 16
+            complication_names = ", ".join(
+                complication.name for complication in mission.possible_complications
+            )
+            arcade.draw_text(
+                f"Complications: {complication_names}",
+                40,
+                y,
+                arcade.color.LIGHT_GRAY,
+                11,
+            )
         arcade.draw_text(
-            "Press N to recruit, B for Battle", 20, 20, arcade.color.AQUA, 14
+            "Press N to recruit, 1-3 select mission, B to launch mission",
+            20,
+            20,
+            arcade.color.AQUA,
+            14,
         )
 
     def on_key_press(self, key, modifiers):
         if key == arcade.key.B:
-            battle_view = BattleView()
-            battle_view.setup()
-            self.window.show_view(battle_view)
+            self.launch_selected_mission()
         elif key == arcade.key.N:
             if game_state.budget_pool >= 5:
                 self.recruiting = True
@@ -159,6 +203,12 @@ class RPGView(arcade.View):
                 role = role_map.get(key, "samurai")
                 game_state.characters.append(create_character(f"Agent {idx}", role))
                 self.recruiting = False
+        elif key in (arcade.key.KEY_1, arcade.key.KEY_2, arcade.key.KEY_3) and not any(
+            char.pending_points > 0 for char in game_state.characters
+        ):
+            idx = key - arcade.key.KEY_1
+            if idx < len(game_state.mission_templates):
+                game_state.selected_mission_index = idx
         else:
             # Allocate stat points if any
             for char in game_state.characters:
@@ -181,7 +231,13 @@ class RPGView(arcade.View):
 
 
 class BattleView(arcade.View):
-    def setup(self):
+    def setup(self, mission: MissionTemplate | None = None):
+        self.mission = mission or game_state.active_mission
+        if self.mission is None and game_state.mission_templates:
+            self.mission = MissionTemplate.from_dict(
+                game_state.mission_templates[game_state.selected_mission_index].to_dict()
+            )
+            game_state.active_mission = self.mission
         self.available_maps = [
             f for f in os.listdir("assets/maps") if f.lower().endswith(".jpeg")
         ]
@@ -201,7 +257,7 @@ class BattleView(arcade.View):
             sum(c.stats.level for c in game_state.characters) / len(game_state.characters)
             if game_state.characters else 1
         )
-        enemy_count = random.randint(1, 3)
+        enemy_count = self.mission.starting_enemy_count if self.mission else random.randint(1, 3)
         self.initial_enemy_count = enemy_count
         self.enemy_units = []
         for i in range(enemy_count):
@@ -227,7 +283,8 @@ class BattleView(arcade.View):
         self.turn_number = 1
         self.turn = "player"
         self.active_index = 0
-        self.message = ""
+        self.message = self.mission.objective_text if self.mission else ""
+        self.triggered_complication = None
         self.attack_timer = 0.0
         self.attack_line = None
         # Target selection state
@@ -267,7 +324,7 @@ class BattleView(arcade.View):
             self.start_player_turn()
 
     def end_battle(self, victory: bool) -> None:
-        """Finish the battle and return to the RPG view."""
+        """Finish the battle, apply mission fallout, and return to the RPG view."""
         defeated = self.initial_enemy_count if victory else 0
         if victory:
             game_state.x += 50 * defeated
@@ -278,9 +335,46 @@ class BattleView(arcade.View):
                     unit.character.gain_xp(50 * defeated)
                 if unit.health <= 0 and unit.character in game_state.characters:
                     game_state.characters.remove(unit.character)
+        self.resolve_mission_outcome(victory)
         rpg_view = RPGView()
         rpg_view.setup()
         self.window.show_view(rpg_view)
+
+    def resolve_mission_outcome(self, victory: bool) -> None:
+        if not self.mission:
+            return
+        consequences = (
+            self.mission.success_consequences if victory else self.mission.failure_consequences
+        )
+        for consequence in consequences:
+            game_state.apply_consequence(consequence)
+        complication = self.pick_complication()
+        if complication:
+            consequence = complication.consequence
+            if not consequence.affected_faction:
+                consequence.affected_faction = self.mission.target_faction
+            game_state.apply_consequence(consequence)
+            game_state.add_event(f"Complication triggered: {complication.trigger_text}")
+        game_state.active_mission = None
+
+    def pick_complication(self):
+        if not self.mission or self.triggered_complication:
+            return None
+        tag_intensity = sum(tag.intensity for tag in self.mission.tags)
+        risk_score = self.mission.risk_level + tag_intensity
+        eligible = [
+            complication
+            for complication in self.mission.possible_complications
+            if risk_score >= complication.risk_threshold
+            or any(
+                tag.name in {mission_tag.name for mission_tag in self.mission.tags}
+                for tag in complication.tags
+            )
+        ]
+        if not eligible:
+            return None
+        self.triggered_complication = random.choice(eligible)
+        return self.triggered_complication
         
     def run_enemy_ai(self):
         for enemy in list(self.enemy_units):
@@ -432,9 +526,19 @@ class BattleView(arcade.View):
         status = (
             f"Turn {self.turn_number} - {self.turn.capitalize()}  Player HP: {current_hp}"
         )
+        if self.mission:
+            status = f"{self.mission.title} | {status}"
         arcade.draw_text(status, 20, self.window.height - 20, arcade.color.AQUA, 14)
+        if self.mission:
+            arcade.draw_text(
+                self.mission.objective_text,
+                20,
+                self.window.height - 42,
+                arcade.color.LIGHT_GRAY,
+                12,
+            )
         if self.message:
-            arcade.draw_text(self.message, 20, self.window.height - 40, arcade.color.YELLOW, 16)
+            arcade.draw_text(self.message, 20, self.window.height - 62, arcade.color.YELLOW, 16)
         if self.turn == "ended":
             if not self.enemy_units:
                 msg = "Victory!"


### PR DESCRIPTION
### Motivation
- Provide a mission/operation layer that drives tactical battles with explicit objectives, district pressure, complications and persistent fallout instead of launching context-free random encounters.

### Description
- Add `game/mission_templates.py` implementing `MissionTemplate` and `MissionComplication` and three vertical-slice templates (`extraction`, `sabotage`, `data_theft`) with objective text, `target_faction`, `district_pressure`, `starting_enemy_count`, `possible_complications`, `success_consequences`, `failure_consequences`, `risk_level`, and Savage Fate tags.
- Extend `GameState` with `mission_templates`, `active_mission`, and `selected_mission_index`, plus save/load support and new methods `apply_active_mission_pressure`, `apply_consequence`, and `get_faction` to apply mission fallout to district/faction state.
- Update `RPGView` to present a mission board, allow selecting missions with keys `1-3`, and launch the selected mission with `B` via `launch_selected_mission` which sets `active_mission` and calls `BattleView.setup()` with the mission.
- Update `BattleView.setup()` and resolution flow to accept a `mission` argument, use `mission.starting_enemy_count` and `mission.objective_text`, and apply mission success/failure consequences plus one triggered complication selected by `pick_complication` (uses `risk_level` and mission tags); add Savage Fate complication tags `media_leak`, `civilian_panic`, and `faction_retaliation`.

### Testing
- Ran `python -m py_compile game/*.py` to verify syntax; compilation succeeded.
- Executed an integration script that instantiated `GameState`, verified the three mission templates, set `active_mission`, applied mission pressure and consequences, saved and loaded state, and asserted `selected_mission_index` and `active_mission.id` round-tripped; assertions passed and printed `mission state ok`.
- Ran a repository check (`git diff --check`) with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0563a51ed4832b8950e47c25b9fb47)