### PR TITLE
Resolve defeated player agents after battle with vertical-slice outcomes

### DIFF
--- a/game/battle_outcomes.py
+++ b/game/battle_outcomes.py
@@ -1,0 +1,46 @@
+"""Post-battle outcome resolution for tactical engagements."""
+
+from __future__ import annotations
+
+import random
+from typing import Callable
+
+from .character import Character
+
+DEFEATED_AGENT_OUTCOMES = (
+    "killed",
+    "critically injured",
+    "captured",
+    "traumatized but extracted",
+)
+
+
+def resolve_defeated_agent_outcome(
+    character: Character,
+    *,
+    remove_character: Callable[[Character], None],
+    record_event: Callable[[str], None],
+) -> str:
+    """Apply and record a vertical-slice outcome for a downed agent."""
+    outcome = random.choice(DEFEATED_AGENT_OUTCOMES)
+    if outcome == "killed":
+        character.history.append("Killed in action during a failed tactical engagement.")
+        remove_character(character)
+        record_event(f"{character.name} was killed in action.")
+        return outcome
+
+    character.stats.hp = max(1, character.stats.max_hp // 4)
+    if outcome == "critically injured":
+        character.injuries.append("Critical battle trauma")
+        character.history.append("Evacuated with critical injuries after being downed in battle.")
+        record_event(f"{character.name} survived with critical injuries.")
+    elif outcome == "captured":
+        character.history.append("Captured by hostile forces after being downed in battle.")
+        record_event(
+            f"{character.name} was captured and remains on the roster as a recovery problem."
+        )
+    else:
+        character.trauma.append("Combat shock")
+        character.history.append("Extracted alive but traumatized after being downed in battle.")
+        record_event(f"{character.name} was extracted with lasting trauma.")
+    return outcome

--- a/game/views.py
+++ b/game/views.py
@@ -3,6 +3,7 @@ import os
 import random
 
 from .character import Character
+from .battle_outcomes import resolve_defeated_agent_outcome
 from .dossier import build_agent_dossier_lines
 from .stats import PlayerStats, EnemyStats
 from .gamestate import GameState
@@ -106,8 +107,6 @@ class CityView(arcade.View):
 
 class RPGView(arcade.View):
     def setup(self):
-        if not game_state.characters:
-            game_state.characters.append(Character(name="Agent 1"))
         self.text = "RPG Phase"
         self.recruiting = False
         self.selected_role = None
@@ -253,6 +252,7 @@ class BattleView(arcade.View):
             )
             for i, char in enumerate(game_state.characters)
         ]
+        self.defeated_player_units = []
         avg_level = (
             sum(c.stats.level for c in game_state.characters) / len(game_state.characters)
             if game_state.characters else 1
@@ -328,17 +328,38 @@ class BattleView(arcade.View):
         defeated = self.initial_enemy_count if victory else 0
         if victory:
             game_state.x += 50 * defeated
-        for unit in list(self.player_units):
-            if unit.character:
-                unit.character.stats.hp = unit.health
-                if victory:
-                    unit.character.gain_xp(50 * defeated)
-                if unit.health <= 0 and unit.character in game_state.characters:
-                    game_state.characters.remove(unit.character)
+        processed_character_ids = set()
+        all_player_units = list(self.player_units) + list(self.defeated_player_units)
+        for unit in all_player_units:
+            if not unit.character or id(unit.character) in processed_character_ids:
+                continue
+            processed_character_ids.add(id(unit.character))
+            if unit.health <= 0:
+                self.resolve_defeated_player_unit(unit)
+                continue
+            unit.character.stats.hp = unit.health
+            if victory:
+                unit.character.gain_xp(50 * defeated)
         self.resolve_mission_outcome(victory)
         rpg_view = RPGView()
         rpg_view.setup()
         self.window.show_view(rpg_view)
+
+    def resolve_defeated_player_unit(self, unit: Unit) -> None:
+        """Resolve a downed agent's vertical-slice post-battle outcome."""
+        character = unit.character
+        if not character:
+            return
+        resolve_defeated_agent_outcome(
+            character,
+            remove_character=self.remove_character_from_roster,
+            record_event=game_state.add_event,
+        )
+
+    def remove_character_from_roster(self, character: Character) -> None:
+        """Remove a character only when a battle outcome confirms death."""
+        if character in game_state.characters:
+            game_state.characters.remove(character)
 
     def resolve_mission_outcome(self, victory: bool) -> None:
         if not self.mission:
@@ -389,6 +410,7 @@ class BattleView(arcade.View):
                     if target.health <= 0:
                         if target.sprite:
                             target.sprite.kill()
+                        self.defeated_player_units.append(target)
                         idx = self.player_units.index(target)
                         self.player_units.remove(target)
                         if idx <= self.active_index and self.active_index > 0:


### PR DESCRIPTION
### Motivation
- Prevent downed player units from being silently deleted at battle end so their post-battle state can be resolved and recorded. 
- Apply a vertical-slice of outcomes (death, critical injury, capture, trauma/extraction) and only remove a character from the roster when the outcome is death. 
- Keep the codebase readable by moving defeated-agent outcome logic into a separate file under `game/` as a small, testable module.

### Description
- Added `game/battle_outcomes.py` with `resolve_defeated_agent_outcome(...)` implementing the four outcomes and callbacks for removal/recording. 
- In `BattleView.setup()` added `self.defeated_player_units = []` so downed units are tracked separately from active tactical units. 
- Updated enemy AI to append downed player `Unit` objects to `self.defeated_player_units` before removing them from `self.player_units`. 
- Reworked `end_battle()` to iterate both active and defeated units (de-duplicating by character identity), preserve HP/XP for living units, and route downed units to `resolve_defeated_player_unit()` which uses the new outcome resolver; roster removal now happens only via a death outcome callback. 
- Added `remove_character_from_roster()` helper and removed the previous silent recreation of a default agent in `RPGView.setup()` so failed-battle consequences are visible.

### Testing
- Ran `python -m compileall game` which succeeded and confirmed modules compile. 
- Parsed the modified files with `PYTHONDONTWRITEBYTECODE=1 python - <<'PY' ... ast.parse(...)` to sanity-check syntax which succeeded. 
- Exercised `resolve_defeated_agent_outcome` with `unittest.mock.patch` to force each outcome path (examples used `patch('random.choice', ...)`) and verified non-death outcomes leave the character in the roster and death triggers the provided removal callback, which passed. 
- Attempted a small integration-style invocation of `BattleView.resolve_defeated_player_unit` but that run failed due to an `ImportError: Library "GL" not found` from `arcade/pyglet` in the CI environment, so full integration under `BattleView` could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0565249a20832b8b5e72fbfb818407)