### PR TITLE
Add management world-state dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ python main.py
 ## Controls
 
 ### Corp View
+- District Pulse and Latest Fallout panels surface unrest, media heat and consequences
 - Each turn grants funds to invest in the corporation
 - `1-4` add funds to research, security, politics and black ops
 - Budget is refreshed automatically when all funds are spent
 - `S` save game / `L` load game
 
 ### City View
+- District Pressure, Faction Pressure and Operations Log panels show city consequences
 - `7-9` allocate city budget
 
 ### RPG View

--- a/game/ui/__init__.py
+++ b/game/ui/__init__.py
@@ -1,5 +1,15 @@
-"""Arcade UI view helpers and view modules."""
+"""Arcade UI helpers.
 
-from .base import GameView
+Keep lightweight text/dashboard modules importable in headless tests by loading the
+Arcade-backed ``GameView`` only when callers explicitly request it.
+"""
 
 __all__ = ["GameView"]
+
+
+def __getattr__(name: str):
+    if name == "GameView":
+        from .base import GameView
+
+        return GameView
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/game/ui/dashboard.py
+++ b/game/ui/dashboard.py
@@ -1,0 +1,93 @@
+"""Readable dashboard text builders for management views.
+
+These helpers keep Arcade view classes focused on input/drawing while the
+world-state presentation stays testable and reusable across Corp/City views.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ..consequences import Consequence
+from ..factions import Faction
+from ..world import District
+
+
+def _tag_names(tagged_items: Iterable[object], empty: str = "none") -> str:
+    """Return compact Savage Fate tag names for dashboard display."""
+    names = [getattr(tag, "name", str(tag)) for tag in tagged_items]
+    return ", ".join(names) if names else empty
+
+
+def pressure_label(value: int, *, inverse: bool = False) -> str:
+    """Translate a 0-100 pressure value into a readable severity label."""
+    if inverse:
+        if value >= 70:
+            return "secure"
+        if value >= 40:
+            return "strained"
+        return "collapsing"
+    if value >= 70:
+        return "critical"
+    if value >= 40:
+        return "volatile"
+    return "contained"
+
+
+def build_district_status_lines(district: District) -> list[str]:
+    """Build concise district pulse lines for management screens."""
+    return [
+        f"District: {district.name} ({district.control_faction} control)",
+        (
+            f"Stability {district.stability}/100 "
+            f"[{pressure_label(district.stability, inverse=True)}] | "
+            f"Unrest {district.unrest}/100 "
+            f"[{pressure_label(district.unrest)}] | "
+            f"Media Heat {district.media_heat}/100 "
+            f"[{pressure_label(district.media_heat)}]"
+        ),
+        f"Active Tags: {_tag_names(district.tags)}",
+    ]
+
+
+def build_faction_pressure_lines(factions: list[Faction], limit: int = 3) -> list[str]:
+    """Build faction pressure summaries sorted by hostility to the player."""
+    ranked = sorted(
+        factions, key=lambda faction: faction.hostility_to_player, reverse=True
+    )
+    lines = []
+    for faction in ranked[:limit]:
+        lines.append(
+            f"{faction.name}: Hostility {faction.hostility_to_player}/100 | "
+            f"Influence {faction.influence}/100 | "
+            f"Legitimacy {faction.public_legitimacy}/100 | "
+            f"Tags: {_tag_names(faction.active_tags)}"
+        )
+    return lines or ["No active factions tracked."]
+
+
+def build_recent_consequence_lines(
+    consequences: list[Consequence], limit: int = 3
+) -> list[str]:
+    """Build latest fallout lines with severity and affected target."""
+    if not consequences:
+        return ["No fallout recorded yet."]
+
+    lines = []
+    for consequence in consequences[-limit:][::-1]:
+        target = (
+            consequence.affected_agent
+            or consequence.affected_faction
+            or consequence.affected_district
+            or "city grid"
+        )
+        text = consequence.narrative_text or "Unspecified consequence ripples outward."
+        lines.append(f"S{consequence.severity} {target}: {text}")
+    return lines
+
+
+def build_event_log_lines(events: list[str], limit: int = 5) -> list[str]:
+    """Build newest event-log beats first for compact screen space."""
+    if not events:
+        return ["No operational events logged."]
+    return list(events[-limit:][::-1])

--- a/game/ui/drawing.py
+++ b/game/ui/drawing.py
@@ -1,0 +1,21 @@
+"""Small Arcade drawing helpers shared by management views."""
+
+from __future__ import annotations
+
+import arcade
+
+
+def draw_line_group(
+    title: str,
+    lines: list[str],
+    x: int,
+    y: int,
+    color=arcade.color.WHITE,
+) -> int:
+    """Draw a titled block of compact management text and return the next y."""
+    arcade.draw_text(title, x, y, arcade.color.YELLOW, 14)
+    y -= 18
+    for line in lines:
+        arcade.draw_text(line, x + 12, y, color, 11)
+        y -= 15
+    return y - 8

--- a/game/views.py
+++ b/game/views.py
@@ -10,6 +10,13 @@ from .combat_system import (
     run_enemy_ai as run_enemy_ai_system,
 )
 from .dossier import build_agent_dossier_lines
+from .ui.drawing import draw_line_group
+from .ui.dashboard import (
+    build_district_status_lines,
+    build_event_log_lines,
+    build_faction_pressure_lines,
+    build_recent_consequence_lines,
+)
 from .gamestate import GameState
 from .mission_system import (
     ensure_mission_templates,
@@ -41,10 +48,27 @@ class CorpView(GameView):
             arcade.color.AQUA,
             14,
         )
-        y -= 20
+        y -= 22
         for k, v in self.game_state.corp_budget.items():
             arcade.draw_text(f"{k}: {v}", 20, y, arcade.color.WHITE, 14)
-            y -= 20
+            y -= 18
+
+        y -= 8
+        y = draw_line_group(
+            "District Pulse",
+            build_district_status_lines(self.game_state.district),
+            20,
+            y,
+            arcade.color.LIGHT_GRAY,
+        )
+        draw_line_group(
+            "Latest Fallout",
+            build_recent_consequence_lines(self.game_state.recent_consequences),
+            20,
+            y,
+            arcade.color.LIGHT_GRAY,
+        )
+
         arcade.draw_text(
             "1-4 to invest, S to save, L to load", 20, 40, arcade.color.AQUA, 14
         )
@@ -87,6 +111,30 @@ class CityView(GameView):
         for k, v in self.game_state.city_budget.items():
             arcade.draw_text(f"{k}: {v}", 20, y, arcade.color.WHITE, 14)
             y -= 20
+
+        y -= 12
+        y = draw_line_group(
+            "District Pressure",
+            build_district_status_lines(self.game_state.district),
+            20,
+            y,
+            arcade.color.LIGHT_GRAY,
+        )
+        y = draw_line_group(
+            "Faction Pressure",
+            build_faction_pressure_lines(self.game_state.factions),
+            20,
+            y,
+            arcade.color.LIGHT_GRAY,
+        )
+        draw_line_group(
+            "Operations Log",
+            build_event_log_lines(self.game_state.event_log),
+            20,
+            y,
+            arcade.color.LIGHT_GRAY,
+        )
+
         arcade.draw_text("7-9 to invest", 20, 40, arcade.color.AQUA, 14)
         arcade.draw_text("Press R for RPG", 20, 20, arcade.color.AQUA, 14)
 


### PR DESCRIPTION
### Motivation
- Management views did not surface district/faction fallout, weakening player feedback about mission consequences.
- Provide a small, testable presentation layer so emergent city-state changes are visible during Corp/City play.
- Keep UI rendering modular and reusable to avoid duplicating layout code in Arcade views.

### Description
- Add `game/ui/dashboard.py` with reusable dashboard builders for district pulse, faction pressure, recent consequences, and event-log lines.
- Add `game/ui/drawing.py` with a shared `draw_line_group` helper to render compact titled text blocks used by management screens.
- Wire the new builders into `CorpView` and `CityView` in `game/views.py` to display District Pulse/Latest Fallout and District Pressure/Faction Pressure/Operations Log respectively.
- Make `game/ui/__init__.py` lazily provide `GameView` so lightweight dashboard modules can be imported in headless tests without initializing Arcade/GL.
- Update `README.md` to document the new management panels under Corp and City controls.

### Testing
- Ran lightweight dashboard assertions that exercise `pressure_label`, `build_district_status_lines`, `build_faction_pressure_lines`, `build_recent_consequence_lines`, and `build_event_log_lines`, which completed successfully and printed `dashboard builders ok`.
- Compiled modules with `python -m compileall -q game main.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0569c5907c832ba9f79c06ebf4d792)