### PR TITLE
Prevent mission launches without recruited agents

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -157,12 +157,20 @@ class RPGView(GameView):
         self.recruiting = False
         self.selected_role = None
         self.allocating = None
+        self.message = ""
         ensure_mission_templates(self.game_state)
 
     def selected_mission(self) -> MissionTemplate:
         return selected_mission_system(self.game_state)
 
+    def has_deployable_agent(self) -> bool:
+        return any(char.stats.hp > 0 for char in self.game_state.characters)
+
     def launch_selected_mission(self) -> None:
+        if not self.has_deployable_agent():
+            self.message = "Recruit at least one agent before launching an operation."
+            return
+
         mission = launch_mission_system(self.game_state)
         battle_view = BattleView(self.game_state)
         battle_view.setup(mission)
@@ -229,6 +237,8 @@ class RPGView(GameView):
                 arcade.color.LIGHT_GRAY,
                 11,
             )
+        if self.message:
+            arcade.draw_text(self.message, 20, 42, arcade.color.YELLOW, 13)
         arcade.draw_text(
             "Press N to recruit, 1-3 select mission, B to launch mission",
             20,
@@ -244,6 +254,7 @@ class RPGView(GameView):
             if self.game_state.budget_pool >= 5:
                 self.recruiting = True
                 self.selected_role = None
+                self.message = ""
                 self.game_state.budget_pool -= 5
             else:
                 pass
@@ -257,6 +268,7 @@ class RPGView(GameView):
                 role = role_map.get(key, "samurai")
                 recruit_agent(self.game_state.characters, role)
                 self.recruiting = False
+                self.message = ""
         elif key in (arcade.key.KEY_1, arcade.key.KEY_2, arcade.key.KEY_3) and not any(
             char.pending_points > 0 for char in self.game_state.characters
         ):

--- a/tests/test_rpg_view.py
+++ b/tests/test_rpg_view.py
@@ -1,0 +1,130 @@
+"""RPG view mission launch guards."""
+
+import sys
+import types
+import unittest
+
+
+class _FakeView:
+    def __init__(self, *args, **kwargs):
+        self.window = None
+
+    def clear(self):
+        pass
+
+
+fake_arcade = types.SimpleNamespace(
+    View=_FakeView,
+    key=types.SimpleNamespace(
+        B=66,
+        N=78,
+        KEY_1=49,
+        KEY_2=50,
+        KEY_3=51,
+        KEY_4=52,
+        KEY_5=53,
+        KEY_7=55,
+        KEY_8=56,
+        KEY_9=57,
+        C=67,
+        R=82,
+        S=83,
+        L=76,
+        UP=1000,
+        DOWN=1001,
+        LEFT=1002,
+        RIGHT=1003,
+        A=65,
+        D=68,
+        F=70,
+        P=80,
+        V=86,
+        SPACE=32,
+        ENTER=13,
+        RETURN=13,
+        ESCAPE=27,
+    ),
+    color=types.SimpleNamespace(
+        WHITE=(255, 255, 255),
+        AQUA=(0, 255, 255),
+        LIGHT_GRAY=(200, 200, 200),
+        YELLOW=(255, 255, 0),
+        DARK_RED=(100, 0, 0),
+        GREEN=(0, 255, 0),
+        RED=(255, 0, 0),
+    ),
+    draw_text=lambda *args, **kwargs: None,
+    draw_lrbt_rectangle_filled=lambda *args, **kwargs: None,
+    draw_rect_outline=lambda *args, **kwargs: None,
+    draw_line=lambda *args, **kwargs: None,
+    draw_texture_rect=lambda *args, **kwargs: None,
+    Camera2D=lambda *args, **kwargs: None,
+    SpriteList=list,
+    Sprite=lambda *args, **kwargs: types.SimpleNamespace(kill=lambda: None),
+    LBWH=lambda *args, **kwargs: None,
+    load_texture=lambda *args, **kwargs: None,
+)
+sys.modules.setdefault("arcade", fake_arcade)
+
+from game.gamestate import GameState
+from game.recruitment import recruit_agent
+from game import views
+
+
+class _FakeWindow:
+    def __init__(self):
+        self.shown_view = None
+        self.height = 720
+        self.width = 1280
+
+    def show_view(self, view):
+        self.shown_view = view
+
+
+class _FakeBattleView:
+    def __init__(self, game_state):
+        self.game_state = game_state
+        self.mission = None
+        self.setup_called = False
+
+    def setup(self, mission):
+        self.mission = mission
+        self.setup_called = True
+
+
+class RPGViewMissionLaunchTest(unittest.TestCase):
+    def test_launch_without_agents_sets_message_and_keeps_rpg_view(self):
+        game_state = GameState()
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+
+        view.on_key_press(views.arcade.key.B, None)
+
+        self.assertIsNone(view.window.shown_view)
+        self.assertIsNone(game_state.active_mission)
+        self.assertEqual(
+            view.message,
+            "Recruit at least one agent before launching an operation.",
+        )
+
+    def test_recruit_then_launches_selected_mission(self):
+        game_state = GameState()
+        recruit_agent(game_state.characters, "samurai")
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+        original_battle_view = views.BattleView
+        views.BattleView = _FakeBattleView
+        try:
+            view.on_key_press(views.arcade.key.B, None)
+        finally:
+            views.BattleView = original_battle_view
+
+        self.assertIsInstance(view.window.shown_view, _FakeBattleView)
+        self.assertTrue(view.window.shown_view.setup_called)
+        self.assertIs(view.window.shown_view.mission, game_state.active_mission)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent the player from entering a tactical battle when there are no deployable agents so the player always has meaningful tactical choices.
- Provide clear UI feedback to explain why a mission launch was blocked and preserve the normal recruit-then-launch flow.

### Description
- Added a `self.message` field to `RPGView.setup` and a `has_deployable_agent` check that returns true if any character has positive `stats.hp` in `game/views.py`.
- Guarded `RPGView.launch_selected_mission` so it sets `self.message` to `"Recruit at least one agent before launching an operation."` and returns early when no deployable agents exist.
- Render the feedback string in `RPGView.on_draw` near the bottom controls and clear the message when recruitment starts or completes to avoid stale warnings.
- Added unit tests in `tests/test_rpg_view.py` that simulate the view, window and battle view to verify both the blocked launch with no agents and successful launch after recruiting.

### Testing
- Ran the new unit tests with `python -m unittest tests.test_rpg_view`, which executed 2 tests and passed (OK).
- Verified the view module compiles (`python -m py_compile game/views.py`) and the UI guard behavior via the headless test harness in the test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056caf30ac832b90b4b5fd1a48d9e7)