### PR TITLE
Add mission aftermath for surviving agents

### DIFF
--- a/game/agent_aftermath.py
+++ b/game/agent_aftermath.py
@@ -1,0 +1,123 @@
+"""Mission aftermath rules for agent stress, loyalty, and memory."""
+
+from __future__ import annotations
+
+from .character import Character
+from .mission_templates import MissionComplication, MissionTemplate
+
+MIN_STRESS = 0
+MAX_STRESS = 100
+
+
+def clamp_stress(value: int) -> int:
+    """Keep stress in the readable UI range."""
+    return max(MIN_STRESS, min(MAX_STRESS, value))
+
+
+def _mission_title(mission: MissionTemplate | None) -> str:
+    return mission.title if mission else "Unknown Operation"
+
+
+def _risk_level(mission: MissionTemplate | None) -> int:
+    return max(0, int(getattr(mission, "risk_level", 1)))
+
+
+def _complication_intensity(complication: MissionComplication | None) -> int:
+    if not complication:
+        return 0
+    tag_intensity = sum(max(0, tag.intensity) for tag in complication.tags)
+    consequence_severity = max(0, complication.consequence.severity)
+    return max(4, tag_intensity + consequence_severity)
+
+
+def _add_unique_savage_tags(
+    character: Character, complication: MissionComplication | None
+) -> list[str]:
+    """Attach complication tag names to a character without duplicating them."""
+    if not complication:
+        return []
+
+    added_tags: list[str] = []
+    for tag in complication.tags:
+        if tag.name not in character.savage_tags:
+            character.savage_tags.append(tag.name)
+            added_tags.append(tag.name)
+    return added_tags
+
+
+def _maybe_add_trauma(
+    character: Character,
+    mission: MissionTemplate | None,
+    complication: MissionComplication | None,
+) -> str | None:
+    """Add a compact trauma hook when fallout is severe enough to linger."""
+    if not complication:
+        return None
+
+    risk = _risk_level(mission)
+    severity = complication.consequence.severity
+    if character.stress < 65 and risk + severity < 6:
+        return None
+
+    trauma = f"Haunted by {complication.name}"
+    if trauma not in character.trauma:
+        character.trauma.append(trauma)
+    return trauma
+
+
+def apply_mission_aftermath(
+    characters: list[Character],
+    mission: MissionTemplate | None,
+    victory: bool,
+    triggered_complication: MissionComplication | None = None,
+) -> list[str]:
+    """Apply emotional aftermath to surviving mission participants.
+
+    The caller is expected to pass only surviving agents who participated in the
+    battle. Returned strings are intentionally compact for the event log.
+    """
+    title = _mission_title(mission)
+    risk = _risk_level(mission)
+    base_stress = risk * 4
+    if victory:
+        base_stress = max(0, base_stress - 2)
+    else:
+        base_stress += 3
+
+    complication_stress = _complication_intensity(triggered_complication)
+    outcome_label = "victory" if victory else "defeat"
+    aftermath_lines: list[str] = []
+
+    for character in characters:
+        stress_delta = base_stress + complication_stress
+        before_stress = character.stress
+        character.stress = clamp_stress(character.stress + stress_delta)
+        applied_stress = character.stress - before_stress
+
+        clean_victory = victory and triggered_complication is None
+        if clean_victory:
+            character.loyalty += 1
+
+        character.history.append(
+            f"{title}: {outcome_label}, stress {applied_stress:+d}"
+        )
+
+        added_tags = _add_unique_savage_tags(character, triggered_complication)
+        trauma = _maybe_add_trauma(character, mission, triggered_complication)
+
+        line = (
+            f"Aftermath: {character.name} carries {title} "
+            f"({outcome_label}, stress {character.stress}/100"
+        )
+        if clean_victory:
+            line += ", loyalty +1"
+        if triggered_complication:
+            line += f", {triggered_complication.name} +{complication_stress}"
+        if trauma:
+            line += f", trauma: {trauma}"
+        elif added_tags:
+            line += f", tag: {added_tags[0]}"
+        line += ")."
+        aftermath_lines.append(line)
+
+    return aftermath_lines

--- a/game/views.py
+++ b/game/views.py
@@ -1,6 +1,7 @@
 import arcade
 import os
 
+from .agent_aftermath import apply_mission_aftermath
 from .battle_outcomes import resolve_defeated_agent_outcome
 from .character import Character
 from .combat_system import (
@@ -386,6 +387,7 @@ class BattleView(GameView):
         if victory:
             self.game_state.x += 50 * defeated
         processed_character_ids = set()
+        surviving_participants = []
         all_player_units = list(self.player_units) + list(self.defeated_player_units)
         for unit in all_player_units:
             if not unit.character or id(unit.character) in processed_character_ids:
@@ -395,9 +397,18 @@ class BattleView(GameView):
                 self.resolve_defeated_player_unit(unit)
                 continue
             unit.character.stats.hp = unit.health
+            surviving_participants.append(unit.character)
             if victory:
                 unit.character.gain_xp(50 * defeated)
         self.resolve_mission_outcome(victory)
+        aftermath_lines = apply_mission_aftermath(
+            surviving_participants,
+            self.mission,
+            victory,
+            self.triggered_complication,
+        )
+        for line in aftermath_lines:
+            self.game_state.add_event(line)
         rpg_view = RPGView(self.game_state)
         rpg_view.setup()
         self.window.show_view(rpg_view)

--- a/tests/test_agent_aftermath.py
+++ b/tests/test_agent_aftermath.py
@@ -1,0 +1,190 @@
+"""Agent mission aftermath rules."""
+
+import sys
+import types
+import unittest
+
+
+class _FakeView:
+    def __init__(self, *args, **kwargs):
+        self.window = None
+
+    def clear(self):
+        pass
+
+
+fake_arcade = types.SimpleNamespace(
+    View=_FakeView,
+    key=types.SimpleNamespace(
+        B=66,
+        N=78,
+        KEY_1=49,
+        KEY_2=50,
+        KEY_3=51,
+        KEY_4=52,
+        KEY_5=53,
+        KEY_7=55,
+        KEY_8=56,
+        KEY_9=57,
+        C=67,
+        R=82,
+        S=83,
+        L=76,
+        UP=1000,
+        DOWN=1001,
+        LEFT=1002,
+        RIGHT=1003,
+        A=65,
+        D=68,
+        F=70,
+        P=80,
+        V=86,
+        SPACE=32,
+        ENTER=13,
+        RETURN=13,
+        ESCAPE=27,
+    ),
+    color=types.SimpleNamespace(
+        WHITE=(255, 255, 255),
+        AQUA=(0, 255, 255),
+        LIGHT_GRAY=(200, 200, 200),
+        YELLOW=(255, 255, 0),
+        DARK_RED=(100, 0, 0),
+        GREEN=(0, 255, 0),
+        RED=(255, 0, 0),
+    ),
+    draw_text=lambda *args, **kwargs: None,
+    draw_lrbt_rectangle_filled=lambda *args, **kwargs: None,
+    draw_rect_outline=lambda *args, **kwargs: None,
+    draw_line=lambda *args, **kwargs: None,
+    draw_texture_rect=lambda *args, **kwargs: None,
+    Camera2D=lambda *args, **kwargs: None,
+    SpriteList=list,
+    Sprite=lambda *args, **kwargs: types.SimpleNamespace(kill=lambda: None),
+    LBWH=lambda *args, **kwargs: None,
+    load_texture=lambda *args, **kwargs: None,
+)
+sys.modules.setdefault("arcade", fake_arcade)
+
+from game.agent_aftermath import apply_mission_aftermath
+from game.character import Character
+from game.consequences import Consequence
+from game.gamestate import GameState
+from game.mission_templates import MissionComplication, MissionTemplate
+from game.savage_fate import tag_from_library
+from game.unit import Unit
+from game import views
+
+
+def _mission(title="Low Risk Sweep", risk_level=1):
+    return MissionTemplate(
+        id="test",
+        title=title,
+        objective_text="Test objective",
+        target_faction="Test Faction",
+        district="Test District",
+        district_pressure={},
+        starting_enemy_count=1,
+        risk_level=risk_level,
+    )
+
+
+def _complication():
+    return MissionComplication(
+        key="faction_retaliation",
+        name="Faction Retaliation",
+        trigger_text="The target faction marks the squad.",
+        risk_threshold=1,
+        tags=[tag_from_library("faction_retaliation")],
+        consequence=Consequence(severity=3),
+    )
+
+
+class _FakeWindow:
+    def __init__(self):
+        self.shown_view = None
+
+    def show_view(self, view):
+        self.shown_view = view
+
+
+class AgentAftermathTest(unittest.TestCase):
+    def test_high_risk_mission_adds_more_stress_than_low_risk(self):
+        low_risk_agent = Character("Low")
+        high_risk_agent = Character("High")
+
+        apply_mission_aftermath([low_risk_agent], _mission(risk_level=1), True)
+        apply_mission_aftermath([high_risk_agent], _mission(risk_level=4), True)
+
+        self.assertGreater(high_risk_agent.stress, low_risk_agent.stress)
+        self.assertIn("Low Risk Sweep", high_risk_agent.history[0])
+
+    def test_clean_victory_adds_loyalty_and_history(self):
+        agent = Character("Clean")
+
+        lines = apply_mission_aftermath(
+            [agent], _mission("Clinic Rescue", risk_level=2), True
+        )
+
+        self.assertEqual(agent.loyalty, 1)
+        self.assertEqual(agent.stress, 6)
+        self.assertIn("Clinic Rescue", agent.history[0])
+        self.assertIn("Aftermath: Clean", lines[0])
+
+    def test_complication_adds_visible_stress_and_tag(self):
+        agent = Character("Marked")
+        complication = _complication()
+
+        lines = apply_mission_aftermath(
+            [agent], _mission("Relay Burn", risk_level=4), False, complication
+        )
+
+        self.assertGreaterEqual(agent.stress, 25)
+        self.assertIn("faction_retaliation", agent.savage_tags)
+        self.assertIn("Faction Retaliation", lines[0])
+
+    def test_stress_is_clamped_to_readable_range(self):
+        agent = Character("Frayed", stress=98)
+
+        apply_mission_aftermath(
+            [agent], _mission(risk_level=10), False, _complication()
+        )
+
+        self.assertEqual(agent.stress, 100)
+
+    def test_end_battle_writes_aftermath_to_event_log(self):
+        game_state = GameState(characters=[Character("Survivor")])
+        mission = _mission("Event Log Test", risk_level=2)
+        battle_view = views.BattleView(game_state)
+        battle_view.window = _FakeWindow()
+        battle_view.mission = mission
+        battle_view.initial_enemy_count = 1
+        battle_view.triggered_complication = None
+        battle_view.player_units = [
+            Unit(
+                position=(0, 0),
+                stats=game_state.characters[0].stats,
+                character=game_state.characters[0],
+                health=game_state.characters[0].stats.hp,
+            )
+        ]
+        battle_view.defeated_player_units = []
+
+        original_resolver = views.resolve_mission_outcome_system
+        views.resolve_mission_outcome_system = lambda *args: None
+        try:
+            battle_view.end_battle(True)
+        finally:
+            views.resolve_mission_outcome_system = original_resolver
+
+        self.assertTrue(
+            any(
+                "Aftermath: Survivor carries Event Log Test" in event
+                for event in game_state.event_log
+            )
+        )
+        self.assertIn("Event Log Test", game_state.characters[0].history[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make completed missions leave a small, readable emotional mark on participating agents so they behave like people who remember operations rather than only stat blocks.
- Surface tension and story hooks from successful and troubled missions by recording history, adjusting stress/loyalty, and surfacing complication fallout.

### Description
- Added a new module `game/agent_aftermath.py` implementing `apply_mission_aftermath(characters, mission, victory, triggered_complication=None) -> list[str]` that computes risk-scaled stress, clamps stress to `0-100`, increases `loyalty` on clean victories, appends a compact mission entry to `character.history`, and applies complication tags/trauma; it returns compact aftermath lines for the UI/event log.
- Derived complication intensity from complication tags and consequence severity, and attached unique `savage_tags` and optional trauma strings when fallout is severe.
- Wired `BattleView.end_battle` in `game/views.py` to collect surviving participants, invoke `apply_mission_aftermath(...)` after mission outcome resolution, and add each returned aftermath line to `game_state.event_log` via `game_state.add_event`.
- Added unit tests in `tests/test_agent_aftermath.py` to cover risk scaling, clean-victory loyalty/history, complication fallout and tags, stress clamping, and event-log integration.

### Testing
- Ran the test suite with `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests`, which completed successfully (`OK`) covering the new aftermath behavior.
- Unit tests assert that higher-risk missions add more stress, clean victories give loyalty and history entries, complications add visible stress and tags/trauma, stress is clamped, and `BattleView.end_battle` writes aftermath lines to the `event_log`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056dd0b610832b9db97011359ec8a7)