### PR TITLE
Add latest agent aftermath report

### DIFF
--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -55,6 +55,7 @@ class GameState:
     recent_consequences: list[Consequence] = field(
         default_factory=lambda: [create_opening_consequence()]
     )
+    latest_agent_aftermath: list[str] = field(default_factory=list)
     event_log: list[str] = field(
         default_factory=lambda: [
             "Turn 1: Forward Base Kilo establishes overwatch in the Chrome Warrens."
@@ -186,6 +187,7 @@ class GameState:
             "recent_consequences": [
                 consequence.to_dict() for consequence in self.recent_consequences
             ],
+            "latest_agent_aftermath": list(self.latest_agent_aftermath),
             "event_log": list(self.event_log),
         }
         with open(path, "w", encoding="utf-8") as f:
@@ -225,6 +227,7 @@ class GameState:
             Consequence.from_dict(consequence)
             for consequence in data.get("recent_consequences", [])
         ] or [create_opening_consequence(gs.district.name)]
+        gs.latest_agent_aftermath = list(data.get("latest_agent_aftermath", []))
         gs.event_log = list(data.get("event_log", gs.event_log))
         from .character import Character
 

--- a/game/ui/dashboard.py
+++ b/game/ui/dashboard.py
@@ -86,6 +86,17 @@ def build_recent_consequence_lines(
     return lines
 
 
+def build_agent_aftermath_lines(lines: list[str], limit: int = 4) -> list[str]:
+    """Build compact latest agent aftermath lines for the RPG dashboard."""
+    if not lines:
+        return ["No agent aftermath recorded yet."]
+
+    report_lines: list[str] = []
+    for line in lines[-limit:][::-1]:
+        report_lines.append(line.removeprefix("Aftermath: "))
+    return report_lines
+
+
 def build_event_log_lines(events: list[str], limit: int = 5) -> list[str]:
     """Build newest event-log beats first for compact screen space."""
     if not events:

--- a/game/views.py
+++ b/game/views.py
@@ -13,6 +13,7 @@ from .combat_system import (
 from .dossier import build_agent_dossier_lines
 from .ui.drawing import draw_line_group
 from .ui.dashboard import (
+    build_agent_aftermath_lines,
     build_district_status_lines,
     build_event_log_lines,
     build_faction_pressure_lines,
@@ -238,6 +239,14 @@ class RPGView(GameView):
                 arcade.color.LIGHT_GRAY,
                 11,
             )
+            y -= 28
+            draw_line_group(
+                "Aftermath Report",
+                build_agent_aftermath_lines(self.game_state.latest_agent_aftermath),
+                20,
+                y,
+                arcade.color.LIGHT_GRAY,
+            )
         if self.message:
             arcade.draw_text(self.message, 20, 42, arcade.color.YELLOW, 13)
         arcade.draw_text(
@@ -407,6 +416,7 @@ class BattleView(GameView):
             victory,
             self.triggered_complication,
         )
+        self.game_state.latest_agent_aftermath = aftermath_lines[-4:]
         for line in aftermath_lines:
             self.game_state.add_event(line)
         rpg_view = RPGView(self.game_state)

--- a/tests/test_agent_aftermath.py
+++ b/tests/test_agent_aftermath.py
@@ -1,6 +1,8 @@
 """Agent mission aftermath rules."""
 
+import os
 import sys
+import tempfile
 import types
 import unittest
 
@@ -67,6 +69,7 @@ fake_arcade = types.SimpleNamespace(
 sys.modules.setdefault("arcade", fake_arcade)
 
 from game.agent_aftermath import apply_mission_aftermath
+from game.ui.dashboard import build_agent_aftermath_lines
 from game.character import Character
 from game.consequences import Consequence
 from game.gamestate import GameState
@@ -183,7 +186,45 @@ class AgentAftermathTest(unittest.TestCase):
                 for event in game_state.event_log
             )
         )
+        self.assertEqual(
+            game_state.latest_agent_aftermath,
+            [
+                "Aftermath: Survivor carries Event Log Test "
+                "(victory, stress 6/100, loyalty +1)."
+            ],
+        )
         self.assertIn("Event Log Test", game_state.characters[0].history[0])
+
+    def test_dashboard_report_shows_latest_compact_aftermath_first(self):
+        lines = [
+            "Aftermath: One carries Old Job.",
+            "Aftermath: Two carries New Job.",
+            "Aftermath: Three carries Final Job.",
+        ]
+
+        self.assertEqual(
+            build_agent_aftermath_lines(lines, limit=2),
+            ["Three carries Final Job.", "Two carries New Job."],
+        )
+
+    def test_latest_agent_aftermath_persists_through_save_load(self):
+        game_state = GameState()
+        game_state.latest_agent_aftermath = [
+            "Aftermath: Saved Agent carries Archive Raid."
+        ]
+
+        with tempfile.NamedTemporaryFile(delete=False) as save_file:
+            save_path = save_file.name
+        try:
+            game_state.save(save_path)
+            loaded_state = GameState.load(save_path)
+        finally:
+            os.unlink(save_path)
+
+        self.assertEqual(
+            loaded_state.latest_agent_aftermath,
+            ["Aftermath: Saved Agent carries Archive Raid."],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Surface recent mission aftermath to the player so agent stress/loyalty/trauma become visible story beats. 
- Persist a short, compact aftermath report across saves so the RPG view can show the immediate emotional fallout after missions.

### Description
- Add `latest_agent_aftermath: list[str]` to `GameState` with a default empty list and include it in `GameState.save`/`GameState.load` JSON. 
- Store the last few aftermath lines (`aftermath_lines[-4:]`) on the game state in `BattleView.end_battle` after calling `apply_mission_aftermath`. 
- Add `build_agent_aftermath_lines(lines: list[str], limit: int = 4)` in `game/ui/dashboard.py` to format a compact, newest-first aftermath report. 
- Render an `Aftermath Report` block in `RPGView.on_draw` under the mission board using `draw_line_group` and the new dashboard helper, while continuing to write full aftermath lines to the event log. 
- Add/extend tests in `tests/test_agent_aftermath.py` to cover storage to `GameState.latest_agent_aftermath`, compact formatting, and save/load persistence. 

### Testing
- Ran the test suite with `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q` and observed `9 passed`. 
- Added unit assertions verifying `GameState.latest_agent_aftermath` is populated after `BattleView.end_battle` and that `build_agent_aftermath_lines` returns newest-first compact lines. 
- Verified save/load roundtrip preserves `latest_agent_aftermath` via `GameState.save`/`GameState.load`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056ee62b74832bbd8ccba52d3761b7)