### PR TITLE
Add recovery timers for severe battle outcomes

### DIFF
--- a/game/battle_outcomes.py
+++ b/game/battle_outcomes.py
@@ -7,6 +7,10 @@ from typing import Callable
 
 from .character import Character
 
+CRITICAL_INJURY_RECOVERY_TURNS = 2
+CAPTURED_RECOVERY_TURNS = 4
+
+
 DEFEATED_AGENT_OUTCOMES = (
     "killed",
     "critically injured",
@@ -31,13 +35,27 @@ def resolve_defeated_agent_outcome(
 
     character.stats.hp = max(1, character.stats.max_hp // 4)
     if outcome == "critically injured":
+        character.recovery_turns = max(
+            character.recovery_turns, CRITICAL_INJURY_RECOVERY_TURNS
+        )
         character.injuries.append("Critical battle trauma")
-        character.history.append("Evacuated with critical injuries after being downed in battle.")
-        record_event(f"{character.name} survived with critical injuries.")
-    elif outcome == "captured":
-        character.history.append("Captured by hostile forces after being downed in battle.")
+        character.history.append(
+            "Evacuated with critical injuries after being downed in battle. "
+            f"Recovery required: {character.recovery_turns} turns."
+        )
         record_event(
-            f"{character.name} was captured and remains on the roster as a recovery problem."
+            f"{character.name} survived with critical injuries "
+            f"and needs {character.recovery_turns} turns to recover."
+        )
+    elif outcome == "captured":
+        character.recovery_turns = max(character.recovery_turns, CAPTURED_RECOVERY_TURNS)
+        character.history.append(
+            "Captured by hostile forces after being downed in battle. "
+            f"Recovery required: {character.recovery_turns} turns."
+        )
+        record_event(
+            f"{character.name} was captured and cannot deploy for "
+            f"{character.recovery_turns} turns."
         )
     else:
         character.trauma.append("Combat shock")

--- a/game/character.py
+++ b/game/character.py
@@ -24,6 +24,7 @@ class Character:
     relationships: dict[str, int] = field(default_factory=dict)
     history: list[str] = field(default_factory=list)
     savage_tags: list[str] = field(default_factory=list)
+    recovery_turns: int = 0
 
     def to_dict(self) -> dict:
         return {
@@ -43,6 +44,7 @@ class Character:
             "relationships": dict(self.relationships),
             "history": list(self.history),
             "savage_tags": list(self.savage_tags),
+            "recovery_turns": self.recovery_turns,
         }
 
     @classmethod
@@ -66,6 +68,7 @@ class Character:
             relationships=dict(data.get("relationships", {})),
             history=list(data.get("history", [])),
             savage_tags=list(data.get("savage_tags", [])),
+            recovery_turns=data.get("recovery_turns", 0),
         )
 
     def gain_xp(self, amount: int) -> None:
@@ -78,3 +81,8 @@ class Character:
             self.stats.recalculate_hp()
             self.stats.hp = min(self.stats.hp + 10, self.stats.max_hp)
             self.pending_points += 5
+
+
+def is_deployable(character: Character) -> bool:
+    """Return whether an agent can currently be assigned to a mission."""
+    return character.stats.hp > 0 and character.recovery_turns <= 0

--- a/game/combat_system.py
+++ b/game/combat_system.py
@@ -4,7 +4,7 @@ import random
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from .character import Character
+from .character import Character, is_deployable
 from .mission_templates import MissionTemplate
 from .stats import EnemyStats
 from .unit import Unit
@@ -39,7 +39,8 @@ def is_occupied(
 
 
 def create_player_units(characters: list[Character]) -> list[Unit]:
-    """Create battle units from the current player roster."""
+    """Create battle units from the deployable player roster."""
+    deployable_characters = [char for char in characters if is_deployable(char)]
     return [
         Unit(
             position=(64 + i * 64, 64),
@@ -47,7 +48,7 @@ def create_player_units(characters: list[Character]) -> list[Unit]:
             health=char.stats.hp,
             character=char,
         )
-        for i, char in enumerate(characters)
+        for i, char in enumerate(deployable_characters)
     ]
 
 

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -89,12 +89,21 @@ class GameState:
         return False
 
     def advance_turn(self) -> None:
-        """Move to the next turn and refresh the budget."""
+        """Move to the next turn, tick recovery timers, and refresh the budget."""
+        recovered_agents = []
+        for character in self.characters:
+            if character.recovery_turns > 0:
+                character.recovery_turns -= 1
+                if character.recovery_turns == 0:
+                    recovered_agents.append(character.name)
+
         self.turn += 1
         self.budget_pool = self.compute_budget()
         self.add_event(
             f"Turn {self.turn}: Corporate budget refreshed for {self.base_name}."
         )
+        for name in recovered_agents:
+            self.add_event(f"Turn {self.turn}: {name} is deployable after recovery.")
 
     def add_event(self, text: str) -> None:
         """Append a compact event-log entry and retain only the latest beats."""

--- a/game/views.py
+++ b/game/views.py
@@ -3,7 +3,7 @@ import os
 
 from .agent_aftermath import apply_mission_aftermath
 from .battle_outcomes import resolve_defeated_agent_outcome
-from .character import Character
+from .character import Character, is_deployable
 from .combat_system import (
     create_enemy_units,
     create_player_units,
@@ -166,11 +166,13 @@ class RPGView(GameView):
         return selected_mission_system(self.game_state)
 
     def has_deployable_agent(self) -> bool:
-        return any(char.stats.hp > 0 for char in self.game_state.characters)
+        return any(is_deployable(char) for char in self.game_state.characters)
 
     def launch_selected_mission(self) -> None:
         if not self.has_deployable_agent():
-            self.message = "Recruit at least one agent before launching an operation."
+            self.message = (
+                "Recruit at least one deployable agent before launching an operation."
+            )
             return
 
         mission = launch_mission_system(self.game_state)
@@ -184,6 +186,8 @@ class RPGView(GameView):
         y = self.window.height - 80
         for char in self.game_state.characters:
             info, dossier = build_agent_dossier_lines(char)
+            if char.recovery_turns > 0:
+                info = f"{info} | Recovery: {char.recovery_turns} turns"
             arcade.draw_text(info, 20, y, arcade.color.WHITE, 14)
             arcade.draw_text(dossier, 40, y - 15, arcade.color.LIGHT_GRAY, 12)
             y -= 15

--- a/tests/test_recovery_status.py
+++ b/tests/test_recovery_status.py
@@ -1,0 +1,102 @@
+"""Agent recovery timers and deployment eligibility."""
+
+import unittest
+
+from game import battle_outcomes
+from game.character import Character, is_deployable
+from game.combat_system import create_player_units
+from game.gamestate import GameState
+
+
+class RecoveryStatusTest(unittest.TestCase):
+    def test_character_recovery_serializes_and_blocks_deployment(self):
+        agent = Character("Archive", recovery_turns=2)
+
+        restored = Character.from_dict(agent.to_dict())
+
+        self.assertEqual(restored.recovery_turns, 2)
+        self.assertFalse(is_deployable(restored))
+
+    def test_create_player_units_skips_unavailable_agents(self):
+        ready = Character("Ready")
+        recovering = Character("Recovering", recovery_turns=1)
+
+        units = create_player_units([ready, recovering])
+
+        self.assertEqual([unit.character for unit in units], [ready])
+
+    def test_advance_turn_reduces_recovery_and_restores_deployment(self):
+        agent = Character("Stitch", recovery_turns=1)
+        game_state = GameState(characters=[agent])
+
+        game_state.advance_turn()
+
+        self.assertEqual(agent.recovery_turns, 0)
+        self.assertTrue(is_deployable(agent))
+        self.assertTrue(
+            any(
+                "Stitch is deployable after recovery" in event
+                for event in game_state.event_log
+            )
+        )
+
+    def test_critical_injury_applies_short_recovery(self):
+        agent = Character("Wound")
+        events = []
+        original_choice = battle_outcomes.random.choice
+        battle_outcomes.random.choice = lambda outcomes: "critically injured"
+        try:
+            outcome = battle_outcomes.resolve_defeated_agent_outcome(
+                agent,
+                remove_character=lambda character: None,
+                record_event=events.append,
+            )
+        finally:
+            battle_outcomes.random.choice = original_choice
+
+        self.assertEqual(outcome, "critically injured")
+        self.assertEqual(
+            agent.recovery_turns, battle_outcomes.CRITICAL_INJURY_RECOVERY_TURNS
+        )
+        self.assertFalse(is_deployable(agent))
+        self.assertIn("critical injuries", events[0])
+
+    def test_captured_applies_larger_recovery_than_critical_injury(self):
+        agent = Character("Caught")
+        original_choice = battle_outcomes.random.choice
+        battle_outcomes.random.choice = lambda outcomes: "captured"
+        try:
+            battle_outcomes.resolve_defeated_agent_outcome(
+                agent,
+                remove_character=lambda character: None,
+                record_event=lambda event: None,
+            )
+        finally:
+            battle_outcomes.random.choice = original_choice
+
+        self.assertEqual(agent.recovery_turns, battle_outcomes.CAPTURED_RECOVERY_TURNS)
+        self.assertGreater(
+            battle_outcomes.CAPTURED_RECOVERY_TURNS,
+            battle_outcomes.CRITICAL_INJURY_RECOVERY_TURNS,
+        )
+        self.assertFalse(is_deployable(agent))
+
+    def test_traumatized_extracted_agents_remain_deployable(self):
+        agent = Character("Shaken")
+        original_choice = battle_outcomes.random.choice
+        battle_outcomes.random.choice = lambda outcomes: "traumatized but extracted"
+        try:
+            battle_outcomes.resolve_defeated_agent_outcome(
+                agent,
+                remove_character=lambda character: None,
+                record_event=lambda event: None,
+            )
+        finally:
+            battle_outcomes.random.choice = original_choice
+
+        self.assertEqual(agent.recovery_turns, 0)
+        self.assertTrue(is_deployable(agent))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpg_view.py
+++ b/tests/test_rpg_view.py
@@ -66,6 +66,7 @@ fake_arcade = types.SimpleNamespace(
 )
 sys.modules.setdefault("arcade", fake_arcade)
 
+from game.character import Character
 from game.gamestate import GameState
 from game.recruitment import recruit_agent
 from game import views
@@ -105,7 +106,42 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
         self.assertIsNone(game_state.active_mission)
         self.assertEqual(
             view.message,
-            "Recruit at least one agent before launching an operation.",
+            "Recruit at least one deployable agent before launching an operation.",
+        )
+
+    def test_launch_with_only_recovering_agent_sets_message(self):
+        game_state = GameState(characters=[Character("Wounded", recovery_turns=2)])
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+
+        view.on_key_press(views.arcade.key.B, None)
+
+        self.assertIsNone(view.window.shown_view)
+        self.assertIsNone(game_state.active_mission)
+        self.assertEqual(
+            view.message,
+            "Recruit at least one deployable agent before launching an operation.",
+        )
+
+    def test_rpg_view_shows_recovery_timer_for_unavailable_agent(self):
+        drawn_text = []
+        original_draw_text = views.arcade.draw_text
+        views.arcade.draw_text = lambda text, *args, **kwargs: drawn_text.append(text)
+        game_state = GameState(characters=[Character("Wounded", recovery_turns=3)])
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+        try:
+            view.on_draw()
+        finally:
+            views.arcade.draw_text = original_draw_text
+
+        self.assertTrue(
+            any(
+                "Wounded" in text and "Recovery: 3 turns" in text
+                for text in drawn_text
+            )
         )
 
     def test_recruit_then_launches_selected_mission(self):


### PR DESCRIPTION
### Motivation
- Prevent agents who are captured or critically injured from immediately redeploying by introducing a short operational penalty that keeps them on the roster but unavailable for a few turns.
- Surface that penalty to the player so losses have meaningful tactical consequences without adding complex medical systems.

### Description
- Add `recovery_turns: int = 0` to `Character` and include it in `Character.to_dict` / `Character.from_dict` for save/load persistence (`game/character.py`).
- Introduce `is_deployable(character)` helper to centralize deployment eligibility (`game/character.py`).
- Apply recovery timers in `resolve_defeated_agent_outcome`: short `CRITICAL_INJURY_RECOVERY_TURNS` for "critically injured" and longer `CAPTURED_RECOVERY_TURNS` for "captured", while leaving "traumatized but extracted" deployable (`game/battle_outcomes.py`).
- Make `create_player_units` only instantiate units for deployable agents (`game/combat_system.py`).
- Update RPG mission-launch guard to require at least one deployable agent and show `Recovery: X turns` beside unavailable agents in the roster display (`game/views.py`).
- Tick down `recovery_turns` and log recoveries in `GameState.advance_turn` (`game/gamestate.py`).
- Add automated tests for serialization, deployment filtering, turn ticking, outcome timers, and RPG view behavior (`tests/test_recovery_status.py`, updates to `tests/test_rpg_view.py`).

### Testing
- Ran the unit test suite with `python -m unittest discover -s tests -v` and all tests passed (17 tests, `OK`).
- Confirmed bytecode compilation via `python -m compileall game tests` with no errors.
- Verified new recovery behavior via targeted tests: serialization blocks deployment, `create_player_units` skips recovering agents, `advance_turn` decrements timers and logs recoveries, critical injury and capture set appropriate timers, and RPG view blocks launches and displays recovery text (all assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056fb6b2d4832b8a43accd6d6658ab)