### PR TITLE
Add agent mission readiness briefing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ python main.py
 - `7-9` allocate city budget
 
 ### RPG View
+- Readiness Brief previews which agents may crack under the selected mission's stress
 - `N` recruit new agent
 - `B` start a battle
 

--- a/game/agent_readiness.py
+++ b/game/agent_readiness.py
@@ -1,0 +1,74 @@
+"""Pre-mission readiness rules for emotionally readable deployments."""
+
+from __future__ import annotations
+
+from .character import Character
+from .mission_templates import MissionTemplate
+
+
+LOW_RISK_STRESS = 35
+HIGH_RISK_STRESS = 65
+BREAKDOWN_STRESS = 85
+
+
+def stress_state_label(stress: int) -> str:
+    """Translate agent stress into a compact emotional state label."""
+    if stress >= BREAKDOWN_STRESS:
+        return "breaking"
+    if stress >= HIGH_RISK_STRESS:
+        return "frayed"
+    if stress >= LOW_RISK_STRESS:
+        return "rattled"
+    return "steady"
+
+
+def estimate_mission_stress(mission: MissionTemplate | None) -> int:
+    """Estimate baseline stress a mission will add before random fallout."""
+    risk = max(0, int(getattr(mission, "risk_level", 1)))
+    return max(0, risk * 4 - 2)
+
+
+def projected_stress(character: Character, mission: MissionTemplate | None) -> int:
+    """Estimate post-mission stress before complications or defeat."""
+    return min(100, character.stress + estimate_mission_stress(mission))
+
+
+def _risk_note(character: Character, projected: int) -> str:
+    if projected >= BREAKDOWN_STRESS:
+        return "breakdown risk"
+    if projected >= HIGH_RISK_STRESS:
+        if character.trauma:
+            return f"trauma may resurface: {character.trauma[0]}"
+        return "stress likely to linger"
+    if character.injuries:
+        return f"field injury: {character.injuries[0]}"
+    if character.savage_tags:
+        return f"tagged by {character.savage_tags[0]}"
+    return "cleared for deployment"
+
+
+def build_agent_readiness_lines(
+    characters: list[Character], mission: MissionTemplate | None, limit: int = 4
+) -> list[str]:
+    """Build readable pre-mission stress warnings for the RPG dashboard."""
+    deployable = [character for character in characters if character.stats.hp > 0]
+    if not deployable:
+        return ["No deployable agents. Recruit or recover someone before launch."]
+
+    ranked = sorted(
+        deployable,
+        key=lambda character: (
+            projected_stress(character, mission),
+            len(character.trauma),
+            len(character.injuries),
+        ),
+        reverse=True,
+    )
+    lines: list[str] = []
+    for character in ranked[:limit]:
+        projected = projected_stress(character, mission)
+        state = stress_state_label(projected)
+        note = _risk_note(character, projected)
+        stress_range = f"{character.stress}->{projected}"
+        lines.append(f"{character.name}: {state} after op ({stress_range}) - {note}.")
+    return lines

--- a/game/views.py
+++ b/game/views.py
@@ -2,6 +2,7 @@ import arcade
 import os
 
 from .agent_aftermath import apply_mission_aftermath
+from .agent_readiness import build_agent_readiness_lines
 from .battle_outcomes import resolve_defeated_agent_outcome
 from .character import Character
 from .combat_system import (
@@ -240,6 +241,13 @@ class RPGView(GameView):
                 11,
             )
             y -= 28
+            y = draw_line_group(
+                "Readiness Brief",
+                build_agent_readiness_lines(self.game_state.characters, mission),
+                20,
+                y,
+                arcade.color.LIGHT_GRAY,
+            )
             draw_line_group(
                 "Aftermath Report",
                 build_agent_aftermath_lines(self.game_state.latest_agent_aftermath),

--- a/tests/test_agent_readiness.py
+++ b/tests/test_agent_readiness.py
@@ -1,0 +1,64 @@
+"""Pre-mission readiness briefing rules."""
+
+import unittest
+
+from game.agent_readiness import (
+    build_agent_readiness_lines,
+    estimate_mission_stress,
+    projected_stress,
+    stress_state_label,
+)
+from game.character import Character
+from game.mission_templates import MissionTemplate
+
+
+def _mission(risk_level=3):
+    return MissionTemplate(
+        id="readiness_test",
+        title="Readiness Test",
+        objective_text="Test the deployment briefing.",
+        target_faction="Test Faction",
+        district="Test District",
+        district_pressure={},
+        starting_enemy_count=1,
+        risk_level=risk_level,
+    )
+
+
+class AgentReadinessTest(unittest.TestCase):
+    def test_stress_state_labels_keep_dashboard_readable(self):
+        self.assertEqual(stress_state_label(10), "steady")
+        self.assertEqual(stress_state_label(40), "rattled")
+        self.assertEqual(stress_state_label(70), "frayed")
+        self.assertEqual(stress_state_label(90), "breaking")
+
+    def test_projected_stress_uses_mission_risk_without_exceeding_cap(self):
+        agent = Character("Wire", stress=96)
+        mission = _mission(risk_level=4)
+
+        self.assertEqual(estimate_mission_stress(mission), 14)
+        self.assertEqual(projected_stress(agent, mission), 100)
+
+    def test_readiness_lines_rank_most_at_risk_agent_first(self):
+        steady = Character("Calm", stress=5)
+        frayed = Character("Ghost", stress=78, trauma=["Haunted by Faction Retaliation"])
+        mission = _mission(risk_level=3)
+
+        lines = build_agent_readiness_lines([steady, frayed], mission)
+
+        self.assertIn("Ghost: breaking after op (78->88)", lines[0])
+        self.assertIn("breakdown risk", lines[0])
+        self.assertIn("Calm: steady after op (5->15)", lines[1])
+
+    def test_no_deployable_agents_gets_launch_guidance(self):
+        downed = Character("Downed")
+        downed.stats.hp = 0
+
+        self.assertEqual(
+            build_agent_readiness_lines([downed], _mission()),
+            ["No deployable agents. Recruit or recover someone before launch."],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Players could only see emotional fallout after missions, leaving launch decisions opaque for stressed or traumatized agents.
- Provide a lightweight pre-mission briefing so the RPG mission board communicates emotional risk and helps generate memorable player choices.

### Description
- Add `game/agent_readiness.py` which estimates mission stress (`estimate_mission_stress`), projects post-op stress (`projected_stress`), maps stress to readable labels (`stress_state_label`), and emits concise risk notes; the main API is `build_agent_readiness_lines`.
- Surface the readiness brief in the RPG mission board by importing and calling `build_agent_readiness_lines` in `game/views.py` before the Aftermath report so players see who is at risk before launching a mission.
- Add unit tests `tests/test_agent_readiness.py` that cover label mapping, projection/clamping, ranking of most-at-risk agents, and guidance when no deployable agents exist.
- Update `README.md` RPG View controls to document the new Readiness Brief UX guidance.

### Testing
- Ran the test suite with `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -v` which executed 13 tests and all passed (`OK`).
- Note: a plain `python -m unittest discover -v` with default discovery did not find tests in this repo layout, so the tests are executed via the `-s tests` discovery path above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056fe523a4832bb2933b1e6f000e3e)