### PR TITLE
Add stress-gate: warn before launching agents at breakdown risk

### DIFF
--- a/game/agent_readiness.py
+++ b/game/agent_readiness.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from .character import Character
+from .character import Character, is_deployable
 from .mission_templates import MissionTemplate
-
 
 LOW_RISK_STRESS = 35
 HIGH_RISK_STRESS = 65
@@ -31,6 +30,18 @@ def estimate_mission_stress(mission: MissionTemplate | None) -> int:
 def projected_stress(character: Character, mission: MissionTemplate | None) -> int:
     """Estimate post-mission stress before complications or defeat."""
     return min(100, character.stress + estimate_mission_stress(mission))
+
+
+def agents_at_breaking_risk(
+    characters: list[Character], mission: MissionTemplate | None
+) -> list[Character]:
+    """Return deployable agents projected to hit the breakdown threshold."""
+    return [
+        character
+        for character in characters
+        if is_deployable(character)
+        and projected_stress(character, mission) >= BREAKDOWN_STRESS
+    ]
 
 
 def _risk_note(character: Character, projected: int) -> str:

--- a/game/views.py
+++ b/game/views.py
@@ -2,7 +2,7 @@ import arcade
 import os
 
 from .agent_aftermath import apply_mission_aftermath
-from .agent_readiness import build_agent_readiness_lines
+from .agent_readiness import agents_at_breaking_risk, build_agent_readiness_lines
 from .battle_outcomes import resolve_defeated_agent_outcome
 from .character import Character, is_deployable
 from .combat_system import (
@@ -161,6 +161,8 @@ class RPGView(GameView):
         self.selected_role = None
         self.allocating = None
         self.message = ""
+        self.pending_breakdown_confirmation = False
+        self.pending_breakdown_mission_id = None
         ensure_mission_templates(self.game_state)
 
     def selected_mission(self) -> MissionTemplate:
@@ -174,8 +176,37 @@ class RPGView(GameView):
             self.message = (
                 "Recruit at least one deployable agent before launching an operation."
             )
+            self.pending_breakdown_confirmation = False
+            self.pending_breakdown_mission_id = None
             return
 
+        selected_mission = self.selected_mission()
+        agents_at_risk = agents_at_breaking_risk(
+            self.game_state.characters, selected_mission
+        )
+        confirmation_matches = (
+            self.pending_breakdown_confirmation
+            and self.pending_breakdown_mission_id == selected_mission.id
+        )
+        if agents_at_risk and not confirmation_matches:
+            lead_agent = agents_at_risk[0]
+            self.pending_breakdown_confirmation = True
+            self.pending_breakdown_mission_id = selected_mission.id
+            self.message = (
+                f"{lead_agent.name} is at breakdown risk. "
+                "Press B again to force deployment."
+            )
+            return
+
+        if agents_at_risk:
+            names = ", ".join(agent.name for agent in agents_at_risk)
+            self.game_state.add_event(
+                f"Command forced {names} into {selected_mission.title} "
+                "despite breakdown risk."
+            )
+
+        self.pending_breakdown_confirmation = False
+        self.pending_breakdown_mission_id = None
         mission = launch_mission_system(self.game_state)
         battle_view = BattleView(self.game_state)
         battle_view.setup(mission)
@@ -297,6 +328,8 @@ class RPGView(GameView):
             idx = key - arcade.key.KEY_1
             if idx < len(self.game_state.mission_templates):
                 self.game_state.selected_mission_index = idx
+                self.pending_breakdown_confirmation = False
+                self.pending_breakdown_mission_id = None
         else:
             # Allocate stat points if any
             for char in self.game_state.characters:

--- a/tests/test_agent_readiness.py
+++ b/tests/test_agent_readiness.py
@@ -3,6 +3,7 @@
 import unittest
 
 from game.agent_readiness import (
+    agents_at_breaking_risk,
     build_agent_readiness_lines,
     estimate_mission_stress,
     projected_stress,
@@ -39,9 +40,25 @@ class AgentReadinessTest(unittest.TestCase):
         self.assertEqual(estimate_mission_stress(mission), 14)
         self.assertEqual(projected_stress(agent, mission), 100)
 
+    def test_breaking_risk_helper_returns_only_deployable_threshold_agents(self):
+        ready_at_risk = Character("Ghost", stress=80)
+        stable = Character("Calm", stress=40)
+        recovering_at_risk = Character("Stitch", stress=80, recovery_turns=1)
+        downed_at_risk = Character("Downed", stress=80)
+        downed_at_risk.stats.hp = 0
+        mission = _mission(risk_level=3)
+
+        at_risk = agents_at_breaking_risk(
+            [ready_at_risk, stable, recovering_at_risk, downed_at_risk], mission
+        )
+
+        self.assertEqual(at_risk, [ready_at_risk])
+
     def test_readiness_lines_rank_most_at_risk_agent_first(self):
         steady = Character("Calm", stress=5)
-        frayed = Character("Ghost", stress=78, trauma=["Haunted by Faction Retaliation"])
+        frayed = Character(
+            "Ghost", stress=78, trauma=["Haunted by Faction Retaliation"]
+        )
         mission = _mission(risk_level=3)
 
         lines = build_agent_readiness_lines([steady, frayed], mission)

--- a/tests/test_rpg_view.py
+++ b/tests/test_rpg_view.py
@@ -68,6 +68,7 @@ sys.modules.setdefault("arcade", fake_arcade)
 
 from game.character import Character
 from game.gamestate import GameState
+from game.mission_templates import MissionTemplate
 from game.recruitment import recruit_agent
 from game import views
 
@@ -80,6 +81,19 @@ class _FakeWindow:
 
     def show_view(self, view):
         self.shown_view = view
+
+
+def _mission(mission_id="stress_gate", title="Relay Burn", risk_level=3):
+    return MissionTemplate(
+        id=mission_id,
+        title=title,
+        objective_text="Burn the relay before the city notices.",
+        target_faction="Test Faction",
+        district="Test District",
+        district_pressure={},
+        starting_enemy_count=1,
+        risk_level=risk_level,
+    )
 
 
 class _FakeBattleView:
@@ -139,10 +153,97 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
 
         self.assertTrue(
             any(
-                "Wounded" in text and "Recovery: 3 turns" in text
-                for text in drawn_text
+                "Wounded" in text and "Recovery: 3 turns" in text for text in drawn_text
             )
         )
+
+    def test_stable_agent_launches_without_breakdown_confirmation(self):
+        game_state = GameState(
+            characters=[Character("Calm", stress=40)],
+            mission_templates=[_mission()],
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+        original_battle_view = views.BattleView
+        views.BattleView = _FakeBattleView
+        try:
+            view.on_key_press(views.arcade.key.B, None)
+        finally:
+            views.BattleView = original_battle_view
+
+        self.assertIsInstance(view.window.shown_view, _FakeBattleView)
+        self.assertFalse(view.pending_breakdown_confirmation)
+        self.assertFalse(
+            any("Command forced" in event for event in game_state.event_log)
+        )
+
+    def test_breaking_risk_blocks_first_launch_attempt_with_warning(self):
+        game_state = GameState(
+            characters=[Character("Ghost", stress=80)],
+            mission_templates=[_mission()],
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+
+        view.on_key_press(views.arcade.key.B, None)
+
+        self.assertIsNone(view.window.shown_view)
+        self.assertIsNone(game_state.active_mission)
+        self.assertTrue(view.pending_breakdown_confirmation)
+        self.assertEqual(view.pending_breakdown_mission_id, "stress_gate")
+        self.assertEqual(
+            view.message,
+            "Ghost is at breakdown risk. Press B again to force deployment.",
+        )
+
+    def test_second_breaking_risk_launch_attempt_proceeds_and_logs_event(self):
+        game_state = GameState(
+            characters=[Character("Ghost", stress=80)],
+            mission_templates=[_mission()],
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+        original_battle_view = views.BattleView
+        views.BattleView = _FakeBattleView
+        try:
+            view.on_key_press(views.arcade.key.B, None)
+            view.on_key_press(views.arcade.key.B, None)
+        finally:
+            views.BattleView = original_battle_view
+
+        self.assertIsInstance(view.window.shown_view, _FakeBattleView)
+        self.assertIs(view.window.shown_view.mission, game_state.active_mission)
+        self.assertFalse(view.pending_breakdown_confirmation)
+        self.assertTrue(
+            any(
+                "Command forced Ghost into Relay Burn despite breakdown risk." in event
+                for event in game_state.event_log
+            )
+        )
+
+    def test_breaking_confirmation_only_applies_to_same_selected_mission(self):
+        game_state = GameState(
+            characters=[Character("Ghost", stress=80)],
+            mission_templates=[
+                _mission("relay_burn", "Relay Burn"),
+                _mission("black_ice", "Black Ice Sweep"),
+            ],
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+
+        view.on_key_press(views.arcade.key.B, None)
+        view.on_key_press(views.arcade.key.KEY_2, None)
+        view.on_key_press(views.arcade.key.B, None)
+
+        self.assertIsNone(view.window.shown_view)
+        self.assertIsNone(game_state.active_mission)
+        self.assertTrue(view.pending_breakdown_confirmation)
+        self.assertEqual(view.pending_breakdown_mission_id, "black_ice")
 
     def test_recruit_then_launches_selected_mission(self):
         game_state = GameState()


### PR DESCRIPTION
### Motivation
- Make pre-mission stress warnings mechanically meaningful so sending agents near breakdown produces tension and requires explicit confirmation. 

### Description
- Add `agents_at_breaking_risk(characters, mission)` to `game/agent_readiness.py` to return only deployable agents whose `projected_stress(...) >= BREAKDOWN_STRESS`, reusing `projected_stress`, `BREAKDOWN_STRESS`, and `is_deployable`.
- Update `RPGView` in `game/views.py` to track confirmation state with `self.pending_breakdown_confirmation` and `self.pending_breakdown_mission_id` and to block the first `B` press when any deployable agent is at breaking risk, showing a clear warning message and requiring a second `B` to force launch.
- When the player force-confirms, record a compact event via `GameState.add_event`, then proceed to `launch_selected_mission` and open the `BattleView` as before.
- Reset pending confirmation when the selected mission changes or when launch is blocked due to no deployable agents.
- Add focused unit tests that exercise the helper and RPG launch flow in `tests/test_agent_readiness.py` and `tests/test_rpg_view.py`.

### Testing
- Ran `python -m pytest tests/test_agent_readiness.py tests/test_rpg_view.py`, and both test files passed.
- Ran the full suite with `python -m pytest`, and all tests passed (26 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05717d18a4832b9b6950b1ca797aa8)