### PR TITLE
Add tactical battle objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ python main.py
 
 ### Battle View
 - Arrow keys move the unit
+- `E` interact with tactical objective markers
 - `Space` melee attack
 - `F` shoot at range
 - `P` psi attack
 - `V` psi defense
 - `D` defend against physical attacks
-- PC and enemy icons are displayed on the map
+- PC, enemy and objective markers are displayed on the map
+- Complete the battlefield objective or eliminate all enemies to win
 - `Esc` return to management
 - On first entering, choose a background image from `assets/maps`

--- a/game/mission_objectives.py
+++ b/game/mission_objectives.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .mission_templates import MissionTemplate
+
+GRID_SIZE = 32
+DEFAULT_OBJECTIVE_POSITION = (448, 320)
+FALLBACK_OBJECTIVE_TYPE = "eliminate"
+SUPPORTED_OBJECTIVE_TYPES = {"extract", "sabotage", "data_theft", FALLBACK_OBJECTIVE_TYPE}
+
+_OBJECTIVE_PROTOTYPES = {
+    "extract": {
+        "label": "WITNESS",
+        "description": "reach WITNESS extraction point",
+        "completion_message": "Witness secured. Extraction complete.",
+    },
+    "sabotage": {
+        "label": "RELAY",
+        "description": "sabotage RELAY at close range",
+        "completion_message": "Relay burned. Sabotage complete.",
+    },
+    "data_theft": {
+        "label": "CACHE",
+        "description": "steal CACHE data at close range",
+        "completion_message": "Cache copied. Data theft complete.",
+    },
+}
+
+
+@dataclass
+class BattleObjective:
+    """Small interactable mission objective placed on the tactical battlefield."""
+
+    kind: str
+    position: tuple[int, int]
+    label: str
+    completed: bool = False
+    progress: int = 0
+    description: str = "complete the battlefield objective"
+    completion_message: str = "Objective complete."
+
+    @property
+    def status_text(self) -> str:
+        state = "complete" if self.completed else self.description
+        return f"Objective: {state}"
+
+
+def normalize_objective_type(objective_type: str | None) -> str:
+    """Return a supported objective type, preserving old saves with safe elimination."""
+    if objective_type in SUPPORTED_OBJECTIVE_TYPES:
+        return objective_type
+    return FALLBACK_OBJECTIVE_TYPE
+
+
+def create_battle_objective(
+    mission: "MissionTemplate | None",
+    position: tuple[int, int] = DEFAULT_OBJECTIVE_POSITION,
+) -> BattleObjective | None:
+    """Build the battlefield objective prototype for a mission, if it has one."""
+    kind = normalize_objective_type(getattr(mission, "objective_type", None))
+    prototype = _OBJECTIVE_PROTOTYPES.get(kind)
+    if prototype is None:
+        return None
+    return BattleObjective(
+        kind=kind,
+        position=position,
+        label=prototype["label"],
+        description=prototype["description"],
+        completion_message=prototype["completion_message"],
+    )
+
+
+def is_in_interaction_range(
+    actor_position: tuple[int, int],
+    objective: BattleObjective,
+    *,
+    grid_size: int = GRID_SIZE,
+    max_cells: int = 1,
+) -> bool:
+    """Return whether an actor is within the allowed grid-cell interaction range."""
+    max_distance = grid_size * max_cells
+    return (
+        (actor_position[0] - objective.position[0]) ** 2
+        + (actor_position[1] - objective.position[1]) ** 2
+    ) ** 0.5 <= max_distance
+
+
+def interact_with_objective(
+    actor_position: tuple[int, int], objective: BattleObjective
+) -> tuple[bool, str]:
+    """Try to complete an objective and return success plus a readable message."""
+    if objective.completed:
+        return True, objective.completion_message
+    if not is_in_interaction_range(actor_position, objective):
+        return False, f"Move within one grid cell of {objective.label} to interact."
+    objective.completed = True
+    objective.progress = 1
+    return True, objective.completion_message

--- a/game/mission_templates.py
+++ b/game/mission_templates.py
@@ -52,6 +52,7 @@ class MissionTemplate:
     district: str
     district_pressure: dict
     starting_enemy_count: int
+    objective_type: str = "eliminate"
     possible_complications: list[MissionComplication] = field(default_factory=list)
     success_consequences: list[Consequence] = field(default_factory=list)
     failure_consequences: list[Consequence] = field(default_factory=list)
@@ -67,6 +68,7 @@ class MissionTemplate:
             "district": self.district,
             "district_pressure": dict(self.district_pressure),
             "starting_enemy_count": self.starting_enemy_count,
+            "objective_type": self.objective_type,
             "possible_complications": [
                 complication.to_dict() for complication in self.possible_complications
             ],
@@ -92,6 +94,9 @@ class MissionTemplate:
             district=data.get("district", "Chrome Warrens"),
             district_pressure=dict(data.get("district_pressure", {})),
             starting_enemy_count=data.get("starting_enemy_count", 1),
+            objective_type=data.get("objective_type")
+            if data.get("objective_type") in {"extract", "sabotage", "data_theft", "eliminate"}
+            else "eliminate",
             possible_complications=[
                 MissionComplication.from_dict(complication)
                 for complication in data.get("possible_complications", [])
@@ -171,6 +176,7 @@ def create_mission_templates(
             district=district_name,
             district_pressure={"unrest": 3, "media_heat": 2},
             starting_enemy_count=2,
+            objective_type="extract",
             possible_complications=[complications[0], complications[1]],
             success_consequences=[
                 Consequence(
@@ -203,6 +209,7 @@ def create_mission_templates(
             district=district_name,
             district_pressure={"unrest": 5, "media_heat": 1},
             starting_enemy_count=3,
+            objective_type="sabotage",
             possible_complications=[complications[1], complications[2]],
             success_consequences=[
                 Consequence(
@@ -235,6 +242,7 @@ def create_mission_templates(
             district=district_name,
             district_pressure={"media_heat": 4, "stability": -1},
             starting_enemy_count=2,
+            objective_type="data_theft",
             possible_complications=[complications[0], complications[2]],
             success_consequences=[
                 Consequence(

--- a/game/views.py
+++ b/game/views.py
@@ -21,6 +21,7 @@ from .ui.dashboard import (
     build_recent_consequence_lines,
 )
 from .gamestate import GameState
+from .mission_objectives import create_battle_objective, interact_with_objective
 from .mission_system import (
     ensure_mission_templates,
     launch_selected_mission as launch_mission_system,
@@ -374,6 +375,7 @@ class BattleView(GameView):
         )
         self.player_list = arcade.SpriteList()
         self.enemy_list = arcade.SpriteList()
+        self.battle_objective = create_battle_objective(self.mission)
 
         for unit in self.player_units:
             sprite = arcade.Sprite(
@@ -542,6 +544,33 @@ class BattleView(GameView):
         self.enemy_list.draw()
         self.player_list.draw()
 
+        if self.battle_objective:
+            ox, oy = self.battle_objective.position
+            marker_color = (
+                arcade.color.GREEN
+                if self.battle_objective.completed
+                else arcade.color.YELLOW
+            )
+            arcade.draw_lrbt_rectangle_filled(
+                ox - 14,
+                ox + 14,
+                oy - 14,
+                oy + 14,
+                marker_color,
+            )
+            arcade.draw_rect_outline(
+                arcade.LBWH(ox - 18, oy - 18, 36, 36),
+                arcade.color.AQUA,
+                border_width=2,
+            )
+            arcade.draw_text(
+                self.battle_objective.label,
+                ox - 28,
+                oy + 24,
+                arcade.color.WHITE,
+                12,
+            )
+
         # Draw enemy HP bars
         for enemy in self.enemy_units:
             if enemy.sprite and enemy.stats:
@@ -614,10 +643,21 @@ class BattleView(GameView):
                 arcade.color.LIGHT_GRAY,
                 12,
             )
-        if self.message:
+        if self.battle_objective:
             arcade.draw_text(
-                self.message, 20, self.window.height - 62, arcade.color.YELLOW, 16
+                self.battle_objective.status_text,
+                20,
+                self.window.height - 62,
+                arcade.color.AQUA,
+                12,
             )
+        if self.message:
+            message_y = (
+                self.window.height - 84
+                if self.battle_objective
+                else self.window.height - 62
+            )
+            arcade.draw_text(self.message, 20, message_y, arcade.color.YELLOW, 16)
         if self.turn == "ended":
             if not self.enemy_units:
                 msg = "Victory!"
@@ -635,7 +675,7 @@ class BattleView(GameView):
                 )
             else:
                 arcade.draw_text(
-                    "Arrows move, Space melee, F shoot, P psi atk, V psi def, D defend, Esc exit",
+                    "Arrows move, E objective, Space melee, F shoot, P psi atk, V psi def, D defend, Esc exit",
                     20,
                     20,
                     arcade.color.AQUA,
@@ -715,7 +755,20 @@ class BattleView(GameView):
             return
 
         # Normal input handling when not selecting target
-        if key == arcade.key.UP:
+        if key == arcade.key.E:
+            if not self.battle_objective:
+                self.message = (
+                    "No battlefield objective on this mission. Eliminate enemies to win."
+                )
+            else:
+                completed, message = interact_with_objective(
+                    player.position, self.battle_objective
+                )
+                self.message = message
+                if completed:
+                    self.end_battle(True)
+                    return
+        elif key == arcade.key.UP:
             new_x, new_y = player.position[0], player.position[1] + 32
             if not self.is_occupied(new_x, new_y, exclude=player):
                 player.move(0, 32)

--- a/tests/test_agent_aftermath.py
+++ b/tests/test_agent_aftermath.py
@@ -38,6 +38,7 @@ fake_arcade = types.SimpleNamespace(
         RIGHT=1003,
         A=65,
         D=68,
+        E=69,
         F=70,
         P=80,
         V=86,

--- a/tests/test_mission_objectives.py
+++ b/tests/test_mission_objectives.py
@@ -1,0 +1,88 @@
+"""Battlefield objective creation and completion rules."""
+
+import unittest
+
+from game.mission_objectives import (
+    BattleObjective,
+    create_battle_objective,
+    interact_with_objective,
+    is_in_interaction_range,
+)
+from game.mission_templates import MissionTemplate, create_mission_templates
+
+
+def _mission(objective_type="extract"):
+    return MissionTemplate(
+        id="objective_test",
+        title="Objective Test",
+        objective_text="Secure the prototype objective.",
+        target_faction="Test Faction",
+        district="Test District",
+        district_pressure={},
+        starting_enemy_count=1,
+        objective_type=objective_type,
+    )
+
+
+class MissionObjectivesTest(unittest.TestCase):
+    def test_mission_templates_assign_distinct_objective_types(self):
+        templates = {mission.id: mission for mission in create_mission_templates()}
+
+        self.assertEqual(templates["extraction"].objective_type, "extract")
+        self.assertEqual(templates["sabotage"].objective_type, "sabotage")
+        self.assertEqual(templates["data_theft"].objective_type, "data_theft")
+
+    def test_objective_creation_uses_readable_label_for_type(self):
+        objective = create_battle_objective(_mission("data_theft"))
+
+        self.assertIsNotNone(objective)
+        self.assertEqual(objective.kind, "data_theft")
+        self.assertEqual(objective.label, "CACHE")
+        self.assertFalse(objective.completed)
+        self.assertIn("CACHE", objective.status_text)
+
+    def test_interaction_range_allows_one_grid_cell(self):
+        objective = BattleObjective(kind="extract", position=(448, 320), label="WITNESS")
+
+        self.assertTrue(is_in_interaction_range((416, 320), objective))
+        self.assertTrue(is_in_interaction_range((448, 320), objective))
+        self.assertFalse(is_in_interaction_range((384, 320), objective))
+
+    def test_interaction_completes_objective_in_range(self):
+        objective = BattleObjective(kind="sabotage", position=(448, 320), label="RELAY")
+
+        completed, message = interact_with_objective((448, 288), objective)
+
+        self.assertTrue(completed)
+        self.assertTrue(objective.completed)
+        self.assertEqual(objective.progress, 1)
+        self.assertIn("complete", message.lower())
+
+    def test_interaction_out_of_range_keeps_objective_pending(self):
+        objective = BattleObjective(kind="extract", position=(448, 320), label="WITNESS")
+
+        completed, message = interact_with_objective((352, 320), objective)
+
+        self.assertFalse(completed)
+        self.assertFalse(objective.completed)
+        self.assertIn("within one grid cell", message)
+
+    def test_mission_template_save_load_preserves_objective_type(self):
+        mission = _mission("sabotage")
+
+        loaded = MissionTemplate.from_dict(mission.to_dict())
+
+        self.assertEqual(loaded.objective_type, "sabotage")
+
+    def test_mission_template_load_defaults_missing_or_unknown_type_to_eliminate(self):
+        legacy_payload = _mission("extract").to_dict()
+        legacy_payload.pop("objective_type")
+        unknown_payload = {**legacy_payload, "objective_type": "escort"}
+
+        self.assertEqual(MissionTemplate.from_dict(legacy_payload).objective_type, "eliminate")
+        self.assertEqual(MissionTemplate.from_dict(unknown_payload).objective_type, "eliminate")
+        self.assertIsNone(create_battle_objective(MissionTemplate.from_dict(legacy_payload)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rpg_view.py
+++ b/tests/test_rpg_view.py
@@ -36,6 +36,7 @@ fake_arcade = types.SimpleNamespace(
         RIGHT=1003,
         A=65,
         D=68,
+        E=69,
         F=70,
         P=80,
         V=86,


### PR DESCRIPTION
### Motivation
- Make missions tactically distinct by adding a visible battlefield objective that can win a mission without killing every enemy.
- Keep save/load compatibility and reuse the existing aftermath pipeline for mission resolution.

### Description
- Add `objective_type: str` to `MissionTemplate` with serialization in `to_dict()` and guarded deserialization in `from_dict()` that defaults unknown/missing values to `"eliminate"`.
- Assign objective types in `create_mission_templates()` for the three templates: `extraction -> "extract"`, `sabotage -> "sabotage"`, `data_theft -> "data_theft"`.
- Introduce a new module `game/mission_objectives.py` implementing `BattleObjective`, prototypes, `create_battle_objective()`, `is_in_interaction_range()` and `interact_with_objective()`.
- Integrate objectives into `BattleView` (`setup`, `on_draw`, and `on_key_press`): instantiate the objective, render a simple marker and status line, add `E` to interact, and call `end_battle(True)` on successful interaction to reuse existing aftermath flow.
- Update `README.md` to document the `E` interaction key and that objectives can win missions; add a focused unit test file `tests/test_mission_objectives.py` and small test harness updates for the new key constant.

### Testing
- Ran unit tests with `python -m unittest discover -s tests` and all tests passed (`Ran 33 tests — OK`).
- Executed `python -m unittest tests/test_mission_objectives.py` during development (7 tests — OK) and compiled changed modules with `python -m py_compile game/mission_templates.py game/mission_objectives.py game/views.py` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0573366920832b8f3594c5d75444d8)