### PR TITLE
Add mission squad deployment selection

### DIFF
--- a/game/combat_system.py
+++ b/game/combat_system.py
@@ -4,7 +4,8 @@ import random
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from .character import Character, is_deployable
+from .character import Character
+from .deployment import deployable_agents, selected_deployable_agents
 from .mission_templates import MissionTemplate
 from .stats import EnemyStats
 from .unit import Unit
@@ -38,9 +39,19 @@ def is_occupied(
     return False
 
 
-def create_player_units(characters: list[Character]) -> list[Unit]:
-    """Create battle units from the deployable player roster."""
-    deployable_characters = [char for char in characters if is_deployable(char)]
+def create_player_units(
+    characters: list[Character], selected_agent_names: list[str] | None = None
+) -> list[Unit]:
+    """Create battle units from selected deployable agents.
+
+    Passing ``None`` preserves the legacy all-deployable roster path for tests and
+    direct combat setup. Passing an empty list intentionally creates no units.
+    """
+    deployable_characters = (
+        deployable_agents(characters)
+        if selected_agent_names is None
+        else selected_deployable_agents(characters, selected_agent_names)
+    )
     return [
         Unit(
             position=(64 + i * 64, 64),

--- a/game/deployment.py
+++ b/game/deployment.py
@@ -1,0 +1,57 @@
+"""Mission deployment selection helpers."""
+
+from __future__ import annotations
+
+from .character import Character, is_deployable
+
+
+def deployable_agents(characters: list[Character]) -> list[Character]:
+    """Return agents who can currently be assigned to an operation."""
+    return [character for character in characters if is_deployable(character)]
+
+
+def selected_deployable_agents(
+    characters: list[Character], selected_agent_names: list[str]
+) -> list[Character]:
+    """Return selected agents, preserving roster order and deployment safety."""
+    selected_names = set(selected_agent_names)
+    return [
+        character
+        for character in characters
+        if character.name in selected_names and is_deployable(character)
+    ]
+
+
+def sanitize_selected_agent_names(
+    characters: list[Character], selected_agent_names: list[str]
+) -> list[str]:
+    """Drop unavailable or no-longer-rostered agents from deployment selection."""
+    deployable_names = {character.name for character in deployable_agents(characters)}
+    sanitized: list[str] = []
+    for name in selected_agent_names:
+        if name in deployable_names and name not in sanitized:
+            sanitized.append(name)
+    return sanitized
+
+
+def toggle_agent_selection(
+    characters: list[Character], selected_agent_names: list[str], index: int
+) -> tuple[list[str], str]:
+    """Toggle a roster slot and return the updated selection plus a readable result."""
+    if index < 0 or index >= len(characters):
+        return (
+            sanitize_selected_agent_names(characters, selected_agent_names),
+            "No agent selected.",
+        )
+
+    character = characters[index]
+    sanitized = sanitize_selected_agent_names(characters, selected_agent_names)
+    if not is_deployable(character):
+        return sanitized, f"{character.name} is unavailable for deployment."
+
+    if character.name in sanitized:
+        sanitized.remove(character.name)
+        return sanitized, f"{character.name} removed from the squad."
+
+    sanitized.append(character.name)
+    return sanitized, f"{character.name} added to the squad."

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -56,6 +56,7 @@ class GameState:
         default_factory=lambda: [create_opening_consequence()]
     )
     latest_agent_aftermath: list[str] = field(default_factory=list)
+    selected_agent_names: list[str] = field(default_factory=list)
     event_log: list[str] = field(
         default_factory=lambda: [
             "Turn 1: Forward Base Kilo establishes overwatch in the Chrome Warrens."
@@ -193,6 +194,7 @@ class GameState:
                 self.active_mission.to_dict() if self.active_mission else None
             ),
             "selected_mission_index": self.selected_mission_index,
+            "selected_agent_names": list(self.selected_agent_names),
             "recent_consequences": [
                 consequence.to_dict() for consequence in self.recent_consequences
             ],
@@ -232,6 +234,7 @@ class GameState:
             else None
         )
         gs.selected_mission_index = data.get("selected_mission_index", 0)
+        gs.selected_agent_names = list(data.get("selected_agent_names", []))
         gs.recent_consequences = [
             Consequence.from_dict(consequence)
             for consequence in data.get("recent_consequences", [])
@@ -241,4 +244,9 @@ class GameState:
         from .character import Character
 
         gs.characters = [Character.from_dict(c) for c in data.get("characters", [])]
+        from .deployment import sanitize_selected_agent_names
+
+        gs.selected_agent_names = sanitize_selected_agent_names(
+            gs.characters, gs.selected_agent_names
+        )
         return gs

--- a/game/views.py
+++ b/game/views.py
@@ -11,6 +11,11 @@ from .combat_system import (
     is_occupied as combat_is_occupied,
     run_enemy_ai as run_enemy_ai_system,
 )
+from .deployment import (
+    sanitize_selected_agent_names,
+    selected_deployable_agents,
+    toggle_agent_selection,
+)
 from .dossier import build_agent_dossier_lines
 from .ui.drawing import draw_line_group
 from .ui.dashboard import (
@@ -164,6 +169,10 @@ class RPGView(GameView):
         self.message = ""
         self.pending_breakdown_confirmation = False
         self.pending_breakdown_mission_id = None
+        self.deployment_cursor_index = 0
+        self.game_state.selected_agent_names = sanitize_selected_agent_names(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
         ensure_mission_templates(self.game_state)
 
     def selected_mission(self) -> MissionTemplate:
@@ -171,6 +180,14 @@ class RPGView(GameView):
 
     def has_deployable_agent(self) -> bool:
         return any(is_deployable(char) for char in self.game_state.characters)
+
+    def selected_deployment(self) -> list[Character]:
+        self.game_state.selected_agent_names = sanitize_selected_agent_names(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
+        return selected_deployable_agents(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
 
     def launch_selected_mission(self) -> None:
         if not self.has_deployable_agent():
@@ -181,10 +198,17 @@ class RPGView(GameView):
             self.pending_breakdown_mission_id = None
             return
 
+        selected_squad = self.selected_deployment()
+        if not selected_squad:
+            self.message = (
+                "Select at least one deployable agent before launching an operation."
+            )
+            self.pending_breakdown_confirmation = False
+            self.pending_breakdown_mission_id = None
+            return
+
         selected_mission = self.selected_mission()
-        agents_at_risk = agents_at_breaking_risk(
-            self.game_state.characters, selected_mission
-        )
+        agents_at_risk = agents_at_breaking_risk(selected_squad, selected_mission)
         confirmation_matches = (
             self.pending_breakdown_confirmation
             and self.pending_breakdown_mission_id == selected_mission.id
@@ -217,10 +241,15 @@ class RPGView(GameView):
         self.clear()
         arcade.draw_text(self.text, 20, self.window.height - 40, arcade.color.WHITE, 20)
         y = self.window.height - 80
-        for char in self.game_state.characters:
+        selected_names = set(self.game_state.selected_agent_names)
+        for idx, char in enumerate(self.game_state.characters):
             info, dossier = build_agent_dossier_lines(char)
             if char.recovery_turns > 0:
                 info = f"{info} | Recovery: {char.recovery_turns} turns"
+            cursor = ">" if idx == self.deployment_cursor_index else " "
+            selected = "[X]" if char.name in selected_names else "[ ]"
+            availability = "" if is_deployable(char) else " | Unavailable"
+            info = f"{cursor} {selected} {info}{availability}"
             arcade.draw_text(info, 20, y, arcade.color.WHITE, 14)
             arcade.draw_text(dossier, 40, y - 15, arcade.color.LIGHT_GRAY, 12)
             y -= 15
@@ -294,7 +323,7 @@ class RPGView(GameView):
         if self.message:
             arcade.draw_text(self.message, 20, 42, arcade.color.YELLOW, 13)
         arcade.draw_text(
-            "Press N to recruit, 1-3 select mission, B to launch mission",
+            "Press N recruit, 1-3 mission, A/D agent, Enter toggle, B launch",
             20,
             20,
             arcade.color.AQUA,
@@ -304,6 +333,26 @@ class RPGView(GameView):
     def on_key_press(self, key, modifiers):
         if key == arcade.key.B:
             self.launch_selected_mission()
+        elif key in (arcade.key.A, arcade.key.D) and self.game_state.characters:
+            step = -1 if key == arcade.key.A else 1
+            self.deployment_cursor_index = (
+                self.deployment_cursor_index + step
+            ) % len(self.game_state.characters)
+            self.message = ""
+        elif (
+            key in (arcade.key.ENTER, arcade.key.RETURN)
+            and self.game_state.characters
+        ):
+            (
+                self.game_state.selected_agent_names,
+                self.message,
+            ) = toggle_agent_selection(
+                self.game_state.characters,
+                self.game_state.selected_agent_names,
+                self.deployment_cursor_index,
+            )
+            self.pending_breakdown_confirmation = False
+            self.pending_breakdown_mission_id = None
         elif key == arcade.key.N:
             if self.game_state.budget_pool >= 5:
                 self.recruiting = True
@@ -321,6 +370,7 @@ class RPGView(GameView):
                 }
                 role = role_map.get(key, "samurai")
                 recruit_agent(self.game_state.characters, role)
+                self.deployment_cursor_index = len(self.game_state.characters) - 1
                 self.recruiting = False
                 self.message = ""
         elif key in (arcade.key.KEY_1, arcade.key.KEY_2, arcade.key.KEY_3) and not any(
@@ -368,10 +418,18 @@ class BattleView(GameView):
         self.map_index = None
         self.background = None
         self.camera = arcade.Camera2D()
-        self.player_units = create_player_units(self.game_state.characters)
+        self.game_state.selected_agent_names = sanitize_selected_agent_names(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
+        selected_squad = selected_deployable_agents(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
+        self.player_units = create_player_units(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
         self.defeated_player_units = []
         self.enemy_units, self.initial_enemy_count = create_enemy_units(
-            self.mission, self.game_state.characters
+            self.mission, selected_squad
         )
         self.player_list = arcade.SpriteList()
         self.enemy_list = arcade.SpriteList()
@@ -456,6 +514,9 @@ class BattleView(GameView):
             surviving_participants.append(unit.character)
             if victory:
                 unit.character.gain_xp(50 * defeated)
+        self.game_state.selected_agent_names = sanitize_selected_agent_names(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
         self.resolve_mission_outcome(victory)
         aftermath_lines = apply_mission_aftermath(
             surviving_participants,

--- a/tests/test_recovery_status.py
+++ b/tests/test_recovery_status.py
@@ -25,6 +25,24 @@ class RecoveryStatusTest(unittest.TestCase):
 
         self.assertEqual([unit.character for unit in units], [ready])
 
+
+    def test_create_player_units_skips_unselected_roster_members(self):
+        selected = Character("Selected")
+        bench = Character("Bench")
+
+        units = create_player_units(
+            [selected, bench], selected_agent_names=["Selected"]
+        )
+
+        self.assertEqual([unit.character for unit in units], [selected])
+
+    def test_create_player_units_empty_selection_spawns_no_units(self):
+        ready = Character("Ready")
+
+        units = create_player_units([ready], selected_agent_names=[])
+
+        self.assertEqual(units, [])
+
     def test_advance_turn_reduces_recovery_and_restores_deployment(self):
         agent = Character("Stitch", recovery_turns=1)
         game_state = GameState(characters=[agent])

--- a/tests/test_rpg_view.py
+++ b/tests/test_rpg_view.py
@@ -158,6 +158,63 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
             )
         )
 
+
+    def test_rpg_view_shows_selected_agent_marker(self):
+        drawn_text = []
+        original_draw_text = views.arcade.draw_text
+        views.arcade.draw_text = lambda text, *args, **kwargs: drawn_text.append(text)
+        game_state = GameState(
+            characters=[Character("Marked")], selected_agent_names=["Marked"]
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+        try:
+            view.on_draw()
+        finally:
+            views.arcade.draw_text = original_draw_text
+
+        self.assertTrue(any("> [X] Marked" in text for text in drawn_text))
+
+    def test_launch_with_agents_but_none_selected_sets_selection_message(self):
+        game_state = GameState(
+            characters=[Character("Calm", stress=40)],
+            mission_templates=[_mission()],
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+
+        view.on_key_press(views.arcade.key.B, None)
+
+        self.assertIsNone(view.window.shown_view)
+        self.assertIsNone(game_state.active_mission)
+        self.assertEqual(
+            view.message,
+            "Select at least one deployable agent before launching an operation.",
+        )
+
+    def test_recovering_agent_cannot_be_selected_for_launch(self):
+        game_state = GameState(
+            characters=[Character("Wounded", recovery_turns=2)],
+            selected_agent_names=["Wounded"],
+            mission_templates=[_mission()],
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+
+        view.on_key_press(views.arcade.key.ENTER, None)
+        view.on_key_press(views.arcade.key.B, None)
+
+        self.assertEqual(game_state.selected_agent_names, [])
+        self.assertIsNone(view.window.shown_view)
+        self.assertIsNone(game_state.active_mission)
+        self.assertEqual(
+            view.message,
+            "Recruit at least one deployable agent before launching an operation.",
+        )
+
     def test_stable_agent_launches_without_breakdown_confirmation(self):
         game_state = GameState(
             characters=[Character("Calm", stress=40)],
@@ -169,6 +226,7 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
         original_battle_view = views.BattleView
         views.BattleView = _FakeBattleView
         try:
+            view.on_key_press(views.arcade.key.ENTER, None)
             view.on_key_press(views.arcade.key.B, None)
         finally:
             views.BattleView = original_battle_view
@@ -182,6 +240,7 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
     def test_breaking_risk_blocks_first_launch_attempt_with_warning(self):
         game_state = GameState(
             characters=[Character("Ghost", stress=80)],
+            selected_agent_names=["Ghost"],
             mission_templates=[_mission()],
         )
         view = views.RPGView(game_state)
@@ -202,6 +261,7 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
     def test_second_breaking_risk_launch_attempt_proceeds_and_logs_event(self):
         game_state = GameState(
             characters=[Character("Ghost", stress=80)],
+            selected_agent_names=["Ghost"],
             mission_templates=[_mission()],
         )
         view = views.RPGView(game_state)
@@ -228,6 +288,7 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
     def test_breaking_confirmation_only_applies_to_same_selected_mission(self):
         game_state = GameState(
             characters=[Character("Ghost", stress=80)],
+            selected_agent_names=["Ghost"],
             mission_templates=[
                 _mission("relay_burn", "Relay Burn"),
                 _mission("black_ice", "Black Ice Sweep"),
@@ -246,6 +307,30 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
         self.assertTrue(view.pending_breakdown_confirmation)
         self.assertEqual(view.pending_breakdown_mission_id, "black_ice")
 
+    def test_breakdown_warning_only_checks_selected_agents(self):
+        risky = Character("Ghost", stress=80)
+        calm = Character("Calm", stress=10)
+        game_state = GameState(
+            characters=[risky, calm],
+            selected_agent_names=["Calm"],
+            mission_templates=[_mission()],
+        )
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+        original_battle_view = views.BattleView
+        views.BattleView = _FakeBattleView
+        try:
+            view.on_key_press(views.arcade.key.B, None)
+        finally:
+            views.BattleView = original_battle_view
+
+        self.assertIsInstance(view.window.shown_view, _FakeBattleView)
+        self.assertFalse(view.pending_breakdown_confirmation)
+        self.assertFalse(
+            any("Command forced Ghost" in event for event in game_state.event_log)
+        )
+
     def test_recruit_then_launches_selected_mission(self):
         game_state = GameState()
         recruit_agent(game_state.characters, "samurai")
@@ -255,6 +340,7 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
         original_battle_view = views.BattleView
         views.BattleView = _FakeBattleView
         try:
+            view.on_key_press(views.arcade.key.ENTER, None)
             view.on_key_press(views.arcade.key.B, None)
         finally:
             views.BattleView = original_battle_view


### PR DESCRIPTION
### Motivation
- Let players choose which deployable agents participate in a mission so launch becomes a meaningful, emotional decision rather than an automatic flow. 
- Persist the selected deployment across saves and sanitize it when agents become unavailable or removed. 
- Ensure the launch/validation, enemy-scaling, and aftermath logic operate only on the selected squad to preserve narrative correctness and avoid surprising side-effects.

### Description
- Add a new `game/deployment.py` helper module with `deployable_agents`, `selected_deployable_agents`, `sanitize_selected_agent_names`, and `toggle_agent_selection` to centralize selection/sanitization logic. 
- Persist `selected_agent_names: list[str]` in `GameState` (save/load) and sanitize loaded selections against the current roster. 
- Update `RPGView` to show a deployment cursor and selection markers, let players cycle roster slots with `A`/`D` and toggle selection with `Enter`, and block mission launch when no selected deployable agents exist; breakdown-risk checks now evaluate only the selected squad. 
- Update combat/battle setup: `create_player_units` accepts an optional `selected_agent_names` argument (None preserves legacy behavior), `BattleView.setup` spawns player units only from the selected deployable agents and scales enemies against that selected squad, and mission aftermath is applied only to participating surviving agents.

### Testing
- Ran the full automated test suite with `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. pytest -q`, which passed: `39 passed`. 
- Note: an initial `pytest -q` run without setting `PYTHONPATH` failed to import the package (environment import path issue), then tests were re-run with `PYTHONPATH=.` to confirm all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0574ee9234832b8a5d8a1ac56f41f8)