### PR TITLE
Add strategic resources and cyberpunk command HUDs

### DIFF
--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -28,6 +28,16 @@ class GameState:
         }
     )
 
+    # Strategic resources extracted from tactical missions and spent on upgrades
+    strategic_resources: dict = field(
+        default_factory=lambda: {
+            "credits": 0,
+            "intel": 0,
+            "salvage": 0,
+            "influence": 0,
+        }
+    )
+
     # Management data for the city phase
     city_budget: dict = field(
         default_factory=lambda: {
@@ -89,6 +99,68 @@ class GameState:
             return True
         return False
 
+    def award_mission_resources(
+        self, mission: MissionTemplate | None, victory: bool, defeated: int
+    ) -> dict:
+        """Award compact strategic resources from mission risk and performance."""
+        if not mission:
+            return {}
+
+        risk = max(1, int(getattr(mission, "risk_level", 1)))
+        defeated = max(0, int(defeated))
+        rewards = {key: 0 for key in self.strategic_resources}
+
+        if victory:
+            objective_type = getattr(mission, "objective_type", "eliminate")
+            rewards["credits"] = 10 + risk * 5 + defeated * 2
+            rewards["intel"] = max(1, risk // 2)
+            rewards["salvage"] = max(1, defeated // 2)
+            rewards["influence"] = 1 if risk >= 3 else 0
+
+            if objective_type in {"data_theft", "extract"}:
+                rewards["intel"] += 1
+            if objective_type in {"sabotage", "eliminate"}:
+                rewards["salvage"] += 1
+            if objective_type == "extract":
+                rewards["influence"] += 1
+        elif defeated >= 2:
+            rewards["salvage"] = 1
+
+        rewards = {key: value for key, value in rewards.items() if value > 0}
+        for key, value in rewards.items():
+            self.strategic_resources[key] = self.strategic_resources.get(key, 0) + value
+
+        if rewards:
+            reward_text = ", ".join(f"+{value} {key}" for key, value in rewards.items())
+            self.add_event(f"Extraction secured: {reward_text}.")
+        else:
+            self.add_event("Extraction failed: no strategic resources recovered.")
+        return rewards
+
+    def spend_resource(self, resource_key: str, amount: int) -> bool:
+        """Spend one strategic resource safely when enough stock is available."""
+        if amount < 0:
+            return False
+        if self.strategic_resources.get(resource_key, 0) < amount:
+            return False
+        self.strategic_resources[resource_key] -= amount
+        return True
+
+    def can_spend_resources(self, costs: dict[str, int]) -> bool:
+        """Return whether all strategic-resource costs are currently affordable."""
+        return all(
+            self.strategic_resources.get(resource_key, 0) >= amount
+            for resource_key, amount in costs.items()
+        )
+
+    def spend_resources(self, costs: dict[str, int]) -> bool:
+        """Atomically spend several strategic resources when all costs are affordable."""
+        if not self.can_spend_resources(costs):
+            return False
+        for resource_key, amount in costs.items():
+            self.strategic_resources[resource_key] -= amount
+        return True
+
     def advance_turn(self) -> None:
         """Move to the next turn, tick recovery timers, and refresh the budget."""
         recovered_agents = []
@@ -136,7 +208,9 @@ class GameState:
                 if "faction_legitimacy" in effects:
                     faction.public_legitimacy += effects["faction_legitimacy"]
                 for tag in consequence.tags:
-                    if all(existing.name != tag.name for existing in faction.active_tags):
+                    if all(
+                        existing.name != tag.name for existing in faction.active_tags
+                    ):
                         faction.active_tags.append(tag)
                 faction.clamp_pressure()
 
@@ -179,6 +253,7 @@ class GameState:
             "budget_pool": self.budget_pool,
             "corp_budget": self.corp_budget,
             "city_budget": self.city_budget,
+            "strategic_resources": self.strategic_resources,
             "characters": [c.to_dict() for c in self.characters],
             "x": self.x,
             "base_name": self.base_name,
@@ -211,6 +286,7 @@ class GameState:
         gs = cls()
         gs.corp_budget.update(data.get("corp_budget", {}))
         gs.city_budget.update(data.get("city_budget", {}))
+        gs.strategic_resources.update(data.get("strategic_resources", {}))
         gs.turn = data.get("turn", 1)
         gs.budget_pool = data.get("budget_pool", gs.compute_budget())
         gs.x = data.get("x", 0)

--- a/game/ui/dashboard.py
+++ b/game/ui/dashboard.py
@@ -34,6 +34,35 @@ def pressure_label(value: int, *, inverse: bool = False) -> str:
     return "contained"
 
 
+def build_resource_summary_line(resources: dict[str, int]) -> str:
+    """Build a compact strategic-resource strip for command status bars."""
+    ordered_keys = ("credits", "intel", "salvage", "influence")
+    parts = [f"{key.title()} {int(resources.get(key, 0))}" for key in ordered_keys]
+    return " | ".join(parts)
+
+
+def district_pressure_severity(district: District) -> str:
+    """Summarize the worst current district pressure as a short severity string."""
+    instability = 100 - district.stability
+    worst = max(instability, district.unrest, district.media_heat)
+    if worst >= 70:
+        return "CRITICAL"
+    if worst >= 40:
+        return "VOLATILE"
+    return "CONTAINED"
+
+
+def build_command_status_line(
+    turn: int, base_name: str, resources: dict[str, int], district: District
+) -> str:
+    """Build the top-line command HUD status for Corp and City screens."""
+    return (
+        f"TURN {turn} // {base_name} // "
+        f"{build_resource_summary_line(resources)} // "
+        f"DISTRICT PRESSURE {district_pressure_severity(district)}"
+    )
+
+
 def build_district_status_lines(district: District) -> list[str]:
     """Build concise district pulse lines for management screens."""
     return [

--- a/game/ui/palette.py
+++ b/game/ui/palette.py
@@ -1,0 +1,18 @@
+"""Cyberpunk command-HUD palette shared by management screens."""
+
+from __future__ import annotations
+
+# Arcade accepts RGB/RGBA tuples directly, which keeps these helpers easy to
+# test without importing arcade during static unit tests.
+BACKGROUND = (5, 8, 16)
+PANEL_FILL = (8, 16, 30, 220)
+PANEL_FILL_DARK = (3, 8, 16, 235)
+PANEL_BORDER = (0, 230, 255)
+PANEL_BORDER_MUTED = (45, 90, 120)
+HEADER = (255, 46, 208)
+TEXT = (225, 244, 255)
+MUTED_TEXT = (150, 180, 195)
+RESOURCE = (84, 255, 174)
+WARNING = (255, 201, 74)
+DANGER = (255, 77, 109)
+ACCENT = (0, 236, 255)

--- a/game/ui/panels.py
+++ b/game/ui/panels.py
@@ -1,0 +1,31 @@
+"""Reusable panel and status-bar drawing helpers for command screens."""
+
+from __future__ import annotations
+
+import arcade
+
+from . import palette
+
+
+def draw_panel(
+    left: int, bottom: int, width: int, height: int, title: str = ""
+) -> None:
+    """Draw a dark translucent panel with a neon line frame."""
+    right = left + width
+    top = bottom + height
+    arcade.draw_lrbt_rectangle_filled(left, right, bottom, top, palette.PANEL_FILL)
+    arcade.draw_line(left, bottom, right, bottom, palette.PANEL_BORDER_MUTED, 1)
+    arcade.draw_line(left, top, right, top, palette.PANEL_BORDER, 2)
+    arcade.draw_line(left, bottom, left, top, palette.PANEL_BORDER_MUTED, 1)
+    arcade.draw_line(right, bottom, right, top, palette.PANEL_BORDER_MUTED, 1)
+    if title:
+        arcade.draw_text(f"▣ {title.upper()}", left + 12, top - 24, palette.HEADER, 13)
+
+
+def draw_status_bar(text: str, width: int, height: int) -> None:
+    """Draw the top command-HUD status bar."""
+    arcade.draw_lrbt_rectangle_filled(
+        0, width, height - 34, height, palette.PANEL_FILL_DARK
+    )
+    arcade.draw_line(0, height - 35, width, height - 35, palette.PANEL_BORDER, 2)
+    arcade.draw_text(text, 18, height - 24, palette.RESOURCE, 12)

--- a/game/views.py
+++ b/game/views.py
@@ -17,13 +17,17 @@ from .deployment import (
     toggle_agent_selection,
 )
 from .dossier import build_agent_dossier_lines
+from .ui import palette
 from .ui.drawing import draw_line_group
+from .ui.panels import draw_panel, draw_status_bar
 from .ui.dashboard import (
     build_agent_aftermath_lines,
+    build_command_status_line,
     build_district_status_lines,
     build_event_log_lines,
     build_faction_pressure_lines,
     build_recent_consequence_lines,
+    build_resource_summary_line,
 )
 from .gamestate import GameState
 from .mission_objectives import create_battle_objective, interact_with_objective
@@ -40,6 +44,13 @@ from .unit import Unit
 
 
 class CorpView(GameView):
+    CORP_UPGRADE_COSTS = {
+        arcade.key.KEY_1: ("research", {"intel": 5}),
+        arcade.key.KEY_2: ("security", {"credits": 10, "salvage": 2}),
+        arcade.key.KEY_3: ("politics", {"influence": 3}),
+        arcade.key.KEY_4: ("black_ops", {"credits": 5, "intel": 3}),
+    }
+
     def setup(self):
         self.text = "Corporation Management"
         if self.game_state.budget_pool <= 0:
@@ -47,41 +58,93 @@ class CorpView(GameView):
 
     def on_draw(self):
         self.clear()
-        y = self.window.height - 40
-        arcade.draw_text(self.text, 20, y, arcade.color.WHITE, 20)
-        y -= 40
-        arcade.draw_text(
-            f"Turn {self.game_state.turn} - Budget: {self.game_state.budget_pool}",
-            20,
-            y,
-            arcade.color.AQUA,
-            14,
+        draw_status_bar(
+            build_command_status_line(
+                self.game_state.turn,
+                self.game_state.base_name,
+                self.game_state.strategic_resources,
+                self.game_state.district,
+            ),
+            self.window.width,
+            self.window.height,
         )
-        y -= 22
-        for k, v in self.game_state.corp_budget.items():
-            arcade.draw_text(f"{k}: {v}", 20, y, arcade.color.WHITE, 14)
-            y -= 18
 
-        y -= 8
-        y = draw_line_group(
+        y = self.window.height - 58
+        draw_panel(14, y - 132, 360, 126, "Corp Allocation")
+        arcade.draw_text(self.text.upper(), 28, y - 26, palette.HEADER, 18)
+        arcade.draw_text(
+            f"Auto Budget Pool: {self.game_state.budget_pool}",
+            32,
+            y - 52,
+            palette.MUTED_TEXT,
+            12,
+        )
+        arcade.draw_text(
+            build_resource_summary_line(self.game_state.strategic_resources),
+            32,
+            y - 70,
+            palette.RESOURCE,
+            11,
+        )
+        budget_y = y - 94
+        for k, v in self.game_state.corp_budget.items():
+            arcade.draw_text(f"{k}: {v}", 34, budget_y, palette.TEXT, 12)
+            budget_y -= 16
+
+        right_x = 392
+        draw_panel(
+            right_x,
+            y - 132,
+            max(360, self.window.width - right_x - 18),
+            126,
+            "Upgrade Sinks",
+        )
+        upgrade_lines = [
+            "1 Research: 5 intel",
+            "2 Security: 10 credits + 2 salvage",
+            "3 Politics: 3 influence",
+            "4 Black Ops: 5 credits + 3 intel",
+        ]
+        line_y = y - 38
+        for line in upgrade_lines:
+            arcade.draw_text(line, right_x + 18, line_y, palette.ACCENT, 12)
+            line_y -= 20
+
+        y -= 158
+        draw_panel(14, y - 104, self.window.width - 28, 104, "District Pulse")
+        next_y = draw_line_group(
             "District Pulse",
             build_district_status_lines(self.game_state.district),
-            20,
-            y,
-            arcade.color.LIGHT_GRAY,
+            30,
+            y - 28,
+            palette.TEXT,
         )
+        draw_panel(14, next_y - 96, self.window.width - 28, 96, "Latest Fallout")
         draw_line_group(
             "Latest Fallout",
             build_recent_consequence_lines(self.game_state.recent_consequences),
-            20,
-            y,
-            arcade.color.LIGHT_GRAY,
+            30,
+            next_y - 28,
+            palette.MUTED_TEXT,
         )
 
         arcade.draw_text(
-            "1-4 to invest, S to save, L to load", 20, 40, arcade.color.AQUA, 14
+            "1-4 spend resources, S save, L load", 20, 40, palette.ACCENT, 14
         )
-        arcade.draw_text("Press C for City, R for RPG", 20, 20, arcade.color.AQUA, 14)
+        arcade.draw_text("Press C for City, R for RPG", 20, 20, palette.ACCENT, 14)
+
+    def _buy_corp_upgrade(self, key: str, costs: dict[str, int]) -> None:
+        if self.game_state.spend_resources(costs):
+            self.game_state.corp_budget[key] += 10
+            cost_text = ", ".join(
+                f"-{amount} {resource}" for resource, amount in costs.items()
+            )
+            self.game_state.add_event(f"Corp upgrade authorized: {key} ({cost_text}).")
+            return
+        cost_text = ", ".join(
+            f"{amount} {resource}" for resource, amount in costs.items()
+        )
+        self.game_state.add_event(f"Upgrade denied: {key} requires {cost_text}.")
 
     def on_key_press(self, key, modifiers):
         if key == arcade.key.C:
@@ -92,14 +155,9 @@ class CorpView(GameView):
             rpg_view = RPGView(self.game_state)
             rpg_view.setup()
             self.window.show_view(rpg_view)
-        elif key == arcade.key.KEY_1:
-            self.game_state.allocate_corp_funds("research", 10)
-        elif key == arcade.key.KEY_2:
-            self.game_state.allocate_corp_funds("security", 10)
-        elif key == arcade.key.KEY_3:
-            self.game_state.allocate_corp_funds("politics", 10)
-        elif key == arcade.key.KEY_4:
-            self.game_state.allocate_corp_funds("black_ops", 10)
+        elif key in self.CORP_UPGRADE_COSTS:
+            budget_key, costs = self.CORP_UPGRADE_COSTS[key]
+            self._buy_corp_upgrade(budget_key, costs)
         elif key == arcade.key.S:
             self.game_state.save("savegame.json")
         elif key == arcade.key.L:
@@ -109,55 +167,111 @@ class CorpView(GameView):
 
 
 class CityView(GameView):
+    CITY_UPGRADE_COSTS = {
+        arcade.key.KEY_7: ("armaments", {"credits": 5, "salvage": 3}),
+        arcade.key.KEY_8: ("garrisons", {"credits": 10, "influence": 2}),
+        arcade.key.KEY_9: ("defense_zones", {"credits": 5, "salvage": 5}),
+    }
+
     def setup(self):
         self.text = "City Management"
 
     def on_draw(self):
         self.clear()
-        y = self.window.height - 40
-        arcade.draw_text(self.text, 20, y, arcade.color.WHITE, 20)
-        y -= 40
-        for k, v in self.game_state.city_budget.items():
-            arcade.draw_text(f"{k}: {v}", 20, y, arcade.color.WHITE, 14)
-            y -= 20
+        draw_status_bar(
+            build_command_status_line(
+                self.game_state.turn,
+                self.game_state.base_name,
+                self.game_state.strategic_resources,
+                self.game_state.district,
+            ),
+            self.window.width,
+            self.window.height,
+        )
 
-        y -= 12
+        y = self.window.height - 58
+        draw_panel(14, y - 116, 360, 110, "City Grid")
+        arcade.draw_text(self.text.upper(), 28, y - 26, palette.HEADER, 18)
+        arcade.draw_text(
+            build_resource_summary_line(self.game_state.strategic_resources),
+            32,
+            y - 52,
+            palette.RESOURCE,
+            11,
+        )
+        budget_y = y - 78
+        for k, v in self.game_state.city_budget.items():
+            arcade.draw_text(f"{k}: {v}", 34, budget_y, palette.TEXT, 12)
+            budget_y -= 18
+
+        right_x = 392
+        draw_panel(
+            right_x,
+            y - 116,
+            max(360, self.window.width - right_x - 18),
+            110,
+            "District Investments",
+        )
+        upgrade_lines = [
+            "7 Armaments: 5 credits + 3 salvage",
+            "8 Garrisons: 10 credits + 2 influence",
+            "9 Defense Zones: 5 credits + 5 salvage",
+        ]
+        line_y = y - 38
+        for line in upgrade_lines:
+            arcade.draw_text(line, right_x + 18, line_y, palette.ACCENT, 12)
+            line_y -= 22
+
+        y -= 140
+        draw_panel(14, y - 104, self.window.width - 28, 104, "District Pressure")
         y = draw_line_group(
             "District Pressure",
             build_district_status_lines(self.game_state.district),
-            20,
-            y,
-            arcade.color.LIGHT_GRAY,
+            30,
+            y - 28,
+            palette.TEXT,
         )
+        draw_panel(14, y - 104, self.window.width - 28, 104, "Faction Pressure")
         y = draw_line_group(
             "Faction Pressure",
             build_faction_pressure_lines(self.game_state.factions),
-            20,
-            y,
-            arcade.color.LIGHT_GRAY,
+            30,
+            y - 28,
+            palette.MUTED_TEXT,
         )
+        draw_panel(14, y - 116, self.window.width - 28, 116, "Operations Log")
         draw_line_group(
             "Operations Log",
             build_event_log_lines(self.game_state.event_log),
-            20,
-            y,
-            arcade.color.LIGHT_GRAY,
+            30,
+            y - 28,
+            palette.MUTED_TEXT,
         )
 
-        arcade.draw_text("7-9 to invest", 20, 40, arcade.color.AQUA, 14)
-        arcade.draw_text("Press R for RPG", 20, 20, arcade.color.AQUA, 14)
+        arcade.draw_text("7-9 spend resources", 20, 40, palette.ACCENT, 14)
+        arcade.draw_text("Press R for RPG", 20, 20, palette.ACCENT, 14)
+
+    def _buy_city_upgrade(self, key: str, costs: dict[str, int]) -> None:
+        if self.game_state.spend_resources(costs):
+            self.game_state.city_budget[key] += 10
+            cost_text = ", ".join(
+                f"-{amount} {resource}" for resource, amount in costs.items()
+            )
+            self.game_state.add_event(f"City investment routed: {key} ({cost_text}).")
+            return
+        cost_text = ", ".join(
+            f"{amount} {resource}" for resource, amount in costs.items()
+        )
+        self.game_state.add_event(f"Investment denied: {key} requires {cost_text}.")
 
     def on_key_press(self, key, modifiers):
         if key == arcade.key.R:
             rpg_view = RPGView(self.game_state)
             rpg_view.setup()
             self.window.show_view(rpg_view)
-        elif key == arcade.key.KEY_7:
-            self.game_state.adjust_city_budget("armaments", 10)
-        elif key == arcade.key.KEY_8:
-            self.game_state.adjust_city_budget("garrisons", 10)
-        elif key == arcade.key.KEY_9:
-            self.game_state.adjust_city_budget("defense_zones", 10)
+        elif key in self.CITY_UPGRADE_COSTS:
+            budget_key, costs = self.CITY_UPGRADE_COSTS[key]
+            self._buy_city_upgrade(budget_key, costs)
 
 
 class RPGView(GameView):
@@ -335,13 +449,12 @@ class RPGView(GameView):
             self.launch_selected_mission()
         elif key in (arcade.key.A, arcade.key.D) and self.game_state.characters:
             step = -1 if key == arcade.key.A else 1
-            self.deployment_cursor_index = (
-                self.deployment_cursor_index + step
-            ) % len(self.game_state.characters)
+            self.deployment_cursor_index = (self.deployment_cursor_index + step) % len(
+                self.game_state.characters
+            )
             self.message = ""
         elif (
-            key in (arcade.key.ENTER, arcade.key.RETURN)
-            and self.game_state.characters
+            key in (arcade.key.ENTER, arcade.key.RETURN) and self.game_state.characters
         ):
             (
                 self.game_state.selected_agent_names,
@@ -497,8 +610,10 @@ class BattleView(GameView):
 
     def end_battle(self, victory: bool) -> None:
         """Finish the battle, apply mission fallout, and return to the RPG view."""
-        defeated = self.initial_enemy_count if victory else 0
+        remaining_enemies = len(getattr(self, "enemy_units", []))
+        defeated = max(0, self.initial_enemy_count - remaining_enemies)
         if victory:
+            defeated = self.initial_enemy_count
             self.game_state.x += 50 * defeated
         processed_character_ids = set()
         surviving_participants = []
@@ -517,6 +632,7 @@ class BattleView(GameView):
         self.game_state.selected_agent_names = sanitize_selected_agent_names(
             self.game_state.characters, self.game_state.selected_agent_names
         )
+        self.game_state.award_mission_resources(self.mission, victory, defeated)
         self.resolve_mission_outcome(victory)
         aftermath_lines = apply_mission_aftermath(
             surviving_participants,
@@ -818,9 +934,7 @@ class BattleView(GameView):
         # Normal input handling when not selecting target
         if key == arcade.key.E:
             if not self.battle_objective:
-                self.message = (
-                    "No battlefield objective on this mission. Eliminate enemies to win."
-                )
+                self.message = "No battlefield objective on this mission. Eliminate enemies to win."
             else:
                 completed, message = interact_with_objective(
                     player.position, self.battle_objective

--- a/tests/test_strategic_resources.py
+++ b/tests/test_strategic_resources.py
@@ -1,0 +1,75 @@
+"""Strategic resource economy rules."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from game.gamestate import GameState
+from game.mission_templates import MissionTemplate
+
+
+def _mission(risk_level=3, objective_type="data_theft"):
+    return MissionTemplate(
+        id="resource_test",
+        title="Resource Test",
+        objective_text="Extract leverage.",
+        target_faction="Test Faction",
+        district="Test District",
+        district_pressure={},
+        starting_enemy_count=2,
+        objective_type=objective_type,
+        risk_level=risk_level,
+    )
+
+
+class StrategicResourcesTest(unittest.TestCase):
+    def test_new_game_state_has_resource_defaults(self):
+        game_state = GameState()
+
+        self.assertEqual(
+            game_state.strategic_resources,
+            {"credits": 0, "intel": 0, "salvage": 0, "influence": 0},
+        )
+
+    def test_resource_save_load_roundtrip(self):
+        game_state = GameState()
+        game_state.strategic_resources.update(
+            {"credits": 25, "intel": 4, "salvage": 2, "influence": 1}
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_path = Path(temp_dir) / "savegame.json"
+            game_state.save(str(save_path))
+
+            loaded = GameState.load(str(save_path))
+
+        self.assertEqual(loaded.strategic_resources["credits"], 25)
+        self.assertEqual(loaded.strategic_resources["intel"], 4)
+        self.assertEqual(loaded.strategic_resources["salvage"], 2)
+        self.assertEqual(loaded.strategic_resources["influence"], 1)
+
+    def test_successful_mission_victory_awards_resources_and_logs(self):
+        game_state = GameState()
+
+        rewards = game_state.award_mission_resources(
+            _mission(risk_level=3, objective_type="data_theft"), True, defeated=2
+        )
+
+        self.assertGreaterEqual(rewards["credits"], 20)
+        self.assertGreaterEqual(rewards["intel"], 2)
+        self.assertGreaterEqual(rewards["salvage"], 1)
+        self.assertGreaterEqual(rewards["influence"], 1)
+        self.assertIn("Extraction secured:", game_state.event_log[-1])
+
+    def test_spending_fails_safely_when_resources_are_insufficient(self):
+        game_state = GameState()
+        game_state.strategic_resources["intel"] = 2
+
+        self.assertFalse(game_state.spend_resource("intel", 5))
+        self.assertEqual(game_state.strategic_resources["intel"], 2)
+        self.assertFalse(game_state.spend_resources({"credits": 1, "intel": 1}))
+        self.assertEqual(game_state.strategic_resources["intel"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Introduce a lightweight strategic resource loop so tactical mission victories yield persistent, spendable rewards (credits, intel, salvage, influence) that feed simple Corp/City upgrades. 
- Surface those resources and contextual status in a compact cyberpunk command-HUD to make management screens feel like an ops console rather than raw text. 
- Keep the change minimal and reversible: no large upgrade trees, small fixed costs, and backward-compatible save/load behavior.

### Description

- Add a `strategic_resources` dictionary and helpers to `GameState` plus persistence: `award_mission_resources(...)`, `spend_resource`, `can_spend_resources`, and `spend_resources`, and write/read `strategic_resources` in `GameState.save()`/`GameState.load()`. (file: `game/gamestate.py`)
- Wire mission rewards into the tactical flow by calling `GameState.award_mission_resources(...)` from `BattleView.end_battle()` before resolving mission fallout to ensure rewards are logged and applied. (file: `game/views.py`)
- Implement simple upgrade spending for Corp and City management: keep keys `1-4` and `7-9` but route purchases through fixed strategic-resource costs, add approval/denial event-log messages, and increment the corresponding `corp_budget`/`city_budget` when paid. (file: `game/views.py`)
- Add separated UI helpers to keep the presentation tidy: `game/ui/palette.py` (colors), `game/ui/panels.py` (panel/status-bar drawing), and extend `game/ui/dashboard.py` with resource-summary and command-status builders; refresh `CorpView` and `CityView` to draw a top status bar, framed panels, and resource lines for a cyberpunk HUD feel. (files: `game/ui/*.py`, `game/views.py`)
- Add unit tests covering resource defaults, save/load roundtrip, mission reward grants on victory, and safe failure when spending insufficient resources; tests added at `tests/test_strategic_resources.py`.

### Testing

- Ran the full test suite with `python -m unittest discover -s tests`, executing 43 tests and observed all tests passing (`OK`).
- Executed the new resource tests directly with `python -m unittest tests/test_strategic_resources.py`, which passed locally (`OK`).
- Verified syntax/bytecode sanity via `python -m py_compile` on modified modules (`game/gamestate.py`, `game/views.py`, `game/ui/dashboard.py`, `game/ui/drawing.py`, `game/ui/palette.py`, `game/ui/panels.py`) and received no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0577719320832b92e7442d30aa9b9e)