### PR TITLE
Introduce XCOM2-inspired command-center UI shell and layout primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,20 @@ python main.py
 ## Controls
 
 ### Corp View
-- District Pulse and Latest Fallout panels surface unrest, media heat and consequences
+- XCOM2-inspired corporate command room frames budget, resources, upgrade sinks,
+  district meters and fallout as angled tactical panels over the city skyline
 - Each turn grants funds to invest in the corporation
 - `1-4` add funds to research, security, politics and black ops
 - Budget is refreshed automatically when all funds are spent
 - `S` save game / `L` load game
 
 ### City View
-- District Pressure, Faction Pressure and Operations Log panels show city consequences
+- City control room presents budget networks, district pressure meters, faction
+  pressure and operations feed in the same tactical command-shell language
 - `7-9` allocate city budget
 
 ### RPG View
-- Mega-city command deck frames planning with a squad bay, city ops table,
+- Squad command deck frames planning with a squad bay, city ops table,
   operation intel panel and readiness/fallout rail
 - Readiness Brief previews which agents may crack under the selected mission's stress
 - Mission Board shows each operation's objective type, risk, target faction,
@@ -37,6 +39,8 @@ python main.py
 - `B` start a battle
 
 ### Battle View
+- Tactical combat HUD uses the command-shell frame for map selection, mission
+  objective status, active HP and input actions
 - Arrow keys move the unit
 - `E` interact with tactical objective markers
 - `Space` melee attack

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,12 +1,16 @@
 TODO:
 [x] Create mission UI
 [x] Add mega-city tactical command deck to RPG UI
+[x] Redesign management and tactical UI shell for city/corporate XCOM2 mood
 [ ] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
 [ ] Create stress system
 
 Done:
+- City/corporate tactical UI shell: Corp, City, RPG, and Battle screens now share
+  angled command panels, city skyline scanlines, resource strips, pressure meters,
+  and bottom action bars inspired by XCOM2 command-room readability.
 - Mega-city tactical command deck: RPG View has separate squad, city ops,
   operation intel, and readiness/fallout panels over a holographic skyline.
 - Mission UI: RPG view mission board has selectable rows plus a selected-mission

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,6 +5,9 @@
   - Progress: RPG View now uses a focused mega-city command deck: squad bay,
     city ops table, operation intel, and readiness/fallout rails for a more
     tactical XCOM-like planning mood without changing combat systems.
+  - Progress: Corp, City, RPG, and Battle screens now share a city/corporate
+    command-shell UI with angled panels, scanline skyline, pressure meters, and
+    bottom action strips so the whole game reads as one tactical command center.
 - District system
 - Mission generation
 - Black ops

--- a/game/ui/command_center.py
+++ b/game/ui/command_center.py
@@ -1,0 +1,103 @@
+"""XCOM2-inspired command-center layout primitives for CyberCity screens.
+
+The module stays intentionally small: it describes panel placement and terse
+copy. Arcade drawing remains in ``panels.py`` so layout rules can be tested
+without opening a window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CommandPanel:
+    """A named tactical panel in the city/corporate command center."""
+
+    key: str
+    title: str
+    left: int
+    bottom: int
+    width: int
+    height: int
+    accent: str = "blue"
+
+
+def build_command_center_layout(
+    width: int, height: int, mode: str
+) -> list[CommandPanel]:
+    """Build a consistent command-room layout for Corp and City screens."""
+    margin = 18
+    gutter = 14
+    status_height = 46
+    footer_height = 48
+    top = height - status_height - margin
+    body_bottom = footer_height
+    body_height = max(420, top - body_bottom)
+    left_width = max(380, int(width * 0.34))
+    right_width = max(420, width - (margin * 2) - gutter - left_width)
+    left = margin
+    right = left + left_width + gutter
+    half_height = (body_height - gutter) // 2
+
+    if mode == "city":
+        titles = {
+            "left": "City Situation Room",
+            "right_top": "District Pressure Map",
+            "right_bottom": "Faction / Operations Feed",
+        }
+    else:
+        titles = {
+            "left": "Corporate War Room",
+            "right_top": "Upgrade Foundry",
+            "right_bottom": "District Fallout Feed",
+        }
+
+    return [
+        CommandPanel(
+            "primary",
+            titles["left"],
+            left,
+            body_bottom,
+            left_width,
+            body_height,
+            "amber",
+        ),
+        CommandPanel(
+            "top_right",
+            titles["right_top"],
+            right,
+            body_bottom + half_height + gutter,
+            right_width,
+            body_height - half_height - gutter,
+            "blue",
+        ),
+        CommandPanel(
+            "bottom_right",
+            titles["right_bottom"],
+            right,
+            body_bottom,
+            right_width,
+            half_height,
+            "blue",
+        ),
+    ]
+
+
+def panel_by_key(panels: list[CommandPanel], key: str) -> CommandPanel:
+    """Fetch a command-center panel by key."""
+    for panel in panels:
+        if panel.key == key:
+            return panel
+    raise KeyError(key)
+
+
+def build_command_title(mode: str, base_name: str, district_name: str) -> str:
+    """Return a cinematic command-room title strip."""
+    label = "CITY CONTROL" if mode == "city" else "CORPORATE COMMAND"
+    return f"{label} // {base_name.upper()} // {district_name.upper()}"
+
+
+def build_action_strip(actions: list[str]) -> str:
+    """Join controls into an XCOM-like bottom input strip."""
+    return "  ▸  ".join(actions)

--- a/game/ui/palette.py
+++ b/game/ui/palette.py
@@ -1,21 +1,25 @@
-"""Cyberpunk command-HUD palette shared by management screens."""
+"""City-corporate tactical command palette shared by UI screens."""
 
 from __future__ import annotations
 
 # Arcade accepts RGB/RGBA tuples directly, which keeps these helpers easy to
 # test without importing arcade during static unit tests.
-BACKGROUND = (5, 8, 16)
-PANEL_FILL = (8, 16, 30, 220)
-PANEL_FILL_DARK = (3, 8, 16, 235)
-PANEL_BORDER = (0, 230, 255)
-PANEL_BORDER_MUTED = (45, 90, 120)
-HEADER = (255, 46, 208)
-TEXT = (225, 244, 255)
-MUTED_TEXT = (150, 180, 195)
-RESOURCE = (84, 255, 174)
-WARNING = (255, 201, 74)
-DANGER = (255, 77, 109)
-ACCENT = (0, 236, 255)
-SKYLINE_SHADOW = (7, 20, 38, 185)
-GRID_LINE = (18, 70, 94, 120)
-SELECTED_FILL = (13, 44, 62, 230)
+BACKGROUND = (3, 7, 11)
+PANEL_FILL = (9, 18, 27, 232)
+PANEL_FILL_DARK = (2, 6, 10, 242)
+PANEL_BORDER = (83, 186, 255)
+PANEL_BORDER_MUTED = (31, 82, 116)
+HEADER = (247, 171, 69)
+TEXT = (225, 241, 248)
+MUTED_TEXT = (134, 167, 181)
+RESOURCE = (96, 231, 193)
+WARNING = (255, 190, 76)
+DANGER = (255, 88, 76)
+ACCENT = (97, 207, 255)
+SKYLINE_SHADOW = (5, 19, 31, 205)
+GRID_LINE = (22, 84, 112, 132)
+SELECTED_FILL = (32, 75, 98, 238)
+AMBER_BORDER = (255, 172, 67)
+AMBER_FILL = (48, 31, 10, 190)
+SCANLINE = (120, 186, 220, 45)
+TACTICAL_GREEN = (120, 232, 180)

--- a/game/ui/panels.py
+++ b/game/ui/panels.py
@@ -11,32 +11,50 @@ from .command_deck import skyline_bands
 def draw_panel(
     left: int, bottom: int, width: int, height: int, title: str = ""
 ) -> None:
-    """Draw a dark translucent panel with a neon line frame."""
+    """Draw an angled tactical glass panel with XCOM-like command-room lines."""
     right = left + width
     top = bottom + height
+    cut = 18
     arcade.draw_lrbt_rectangle_filled(left, right, bottom, top, palette.PANEL_FILL)
-    arcade.draw_line(left, bottom, right, bottom, palette.PANEL_BORDER_MUTED, 1)
-    arcade.draw_line(left, top, right, top, palette.PANEL_BORDER, 2)
-    arcade.draw_line(left, bottom, left, top, palette.PANEL_BORDER_MUTED, 1)
-    arcade.draw_line(right, bottom, right, top, palette.PANEL_BORDER_MUTED, 1)
+    arcade.draw_lrbt_rectangle_filled(
+        left, right, top - 30, top, palette.PANEL_FILL_DARK
+    )
+    arcade.draw_line(left + cut, top, right, top, palette.PANEL_BORDER, 2)
+    arcade.draw_line(left, top - cut, left + cut, top, palette.PANEL_BORDER, 2)
+    arcade.draw_line(left, bottom, right - cut, bottom, palette.PANEL_BORDER_MUTED, 1)
+    arcade.draw_line(
+        right - cut, bottom, right, bottom + cut, palette.PANEL_BORDER_MUTED, 1
+    )
+    arcade.draw_line(left, bottom, left, top - cut, palette.PANEL_BORDER_MUTED, 1)
+    arcade.draw_line(right, bottom + cut, right, top, palette.PANEL_BORDER_MUTED, 1)
+    arcade.draw_line(left + 8, top - 30, right - 8, top - 30, palette.GRID_LINE, 1)
     if title:
-        arcade.draw_text(f"▣ {title.upper()}", left + 12, top - 24, palette.HEADER, 13)
+        arcade.draw_text(f"◆ {title.upper()}", left + 14, top - 22, palette.HEADER, 13)
 
 
 def draw_status_bar(text: str, width: int, height: int) -> None:
-    """Draw the top command-HUD status bar."""
+    """Draw the top Avenger-style command-HUD status bar."""
     arcade.draw_lrbt_rectangle_filled(
-        0, width, height - 34, height, palette.PANEL_FILL_DARK
+        0, width, height - 42, height, palette.PANEL_FILL_DARK
     )
-    arcade.draw_line(0, height - 35, width, height - 35, palette.PANEL_BORDER, 2)
-    arcade.draw_text(text, 18, height - 24, palette.RESOURCE, 12)
+    arcade.draw_lrbt_rectangle_filled(
+        0, min(width, 280), height - 42, height, palette.AMBER_FILL
+    )
+    arcade.draw_line(0, height - 43, width, height - 43, palette.PANEL_BORDER, 2)
+    arcade.draw_line(22, height - 8, 120, height - 8, palette.HEADER, 3)
+    arcade.draw_text(text, 18, height - 28, palette.RESOURCE, 12)
 
 
 def draw_megacity_backdrop(width: int, height: int) -> None:
     """Draw a moody holographic mega-city backdrop behind command panels."""
     if hasattr(arcade, "set_background_color"):
         arcade.set_background_color(palette.BACKGROUND)
-    for left, bottom, building_width, building_height in skyline_bands(width, height):
+    arcade.draw_lrbt_rectangle_filled(0, width, 0, height, palette.BACKGROUND)
+    for y in range(70, height, 72):
+        arcade.draw_line(0, y, width, y, palette.SCANLINE, 1)
+    for left, bottom, building_width, building_height in skyline_bands(
+        width, height, count=13
+    ):
         arcade.draw_lrbt_rectangle_filled(
             left,
             left + building_width,
@@ -49,14 +67,24 @@ def draw_megacity_backdrop(width: int, height: int) -> None:
             antenna_x,
             bottom + building_height,
             antenna_x,
-            bottom + building_height + 22,
+            bottom + building_height + 24,
             palette.PANEL_BORDER_MUTED,
             1,
         )
-    horizon = max(92, int(height * 0.2))
-    arcade.draw_line(0, horizon, width, horizon, palette.PANEL_BORDER_MUTED, 1)
-    for offset in range(0, width, 96):
-        arcade.draw_line(offset, 0, offset + 54, horizon, palette.GRID_LINE, 1)
+        arcade.draw_line(
+            left + 5,
+            bottom + building_height - 12,
+            left + building_width - 8,
+            bottom + building_height - 12,
+            palette.GRID_LINE,
+            1,
+        )
+    horizon = max(110, int(height * 0.22))
+    arcade.draw_line(0, horizon, width, horizon, palette.PANEL_BORDER_MUTED, 2)
+    for offset in range(-width, width * 2, 96):
+        arcade.draw_line(offset, 0, offset + 74, horizon, palette.GRID_LINE, 1)
+    for offset in range(0, width, 120):
+        arcade.draw_line(offset, 0, offset, horizon, palette.GRID_LINE, 1)
 
 
 def draw_deck_panel(panel) -> None:
@@ -70,4 +98,45 @@ def draw_deck_panel(panel) -> None:
         panel.bottom + panel.height - notch,
         palette.PANEL_BORDER,
         2,
+    )
+
+
+def draw_command_screen_frame(title: str, width: int, height: int) -> None:
+    """Draw global command-room chrome around any management screen."""
+    draw_megacity_backdrop(width, height)
+    arcade.draw_lrbt_rectangle_filled(
+        14, width - 14, height - 76, height - 46, palette.PANEL_FILL_DARK
+    )
+    arcade.draw_line(
+        14, height - 76, width - 14, height - 76, palette.PANEL_BORDER_MUTED, 1
+    )
+    arcade.draw_text(title, 28, height - 68, palette.HEADER, 16)
+
+
+def draw_action_strip(text: str, width: int) -> None:
+    """Draw the bottom keyboard command strip."""
+    arcade.draw_lrbt_rectangle_filled(0, width, 0, 42, palette.PANEL_FILL_DARK)
+    arcade.draw_line(0, 43, width, 43, palette.PANEL_BORDER, 2)
+    arcade.draw_text(text, 20, 16, palette.ACCENT, 13)
+
+
+def draw_tactical_meter(
+    left: int, bottom: int, width: int, label: str, value: int
+) -> None:
+    """Draw a compact 0-100 pressure meter for city/corp status panels."""
+    clamped = max(0, min(100, value))
+    arcade.draw_text(label.upper(), left, bottom + 9, palette.MUTED_TEXT, 10)
+    arcade.draw_lrbt_rectangle_filled(
+        left + 110, left + 110 + width, bottom + 8, bottom + 18, palette.PANEL_FILL_DARK
+    )
+    arcade.draw_lrbt_rectangle_filled(
+        left + 110,
+        left + 110 + int(width * clamped / 100),
+        bottom + 8,
+        bottom + 18,
+        (
+            palette.DANGER
+            if clamped >= 70
+            else palette.WARNING if clamped >= 40 else palette.TACTICAL_GREEN
+        ),
     )

--- a/game/views.py
+++ b/game/views.py
@@ -17,12 +17,14 @@ from .deployment import (
     toggle_agent_selection,
 )
 from .ui import palette
-from .ui.drawing import draw_line_group
 from .ui.panels import (
+    draw_action_strip,
+    draw_command_screen_frame,
     draw_deck_panel,
     draw_megacity_backdrop,
     draw_panel,
     draw_status_bar,
+    draw_tactical_meter,
 )
 from .ui.dashboard import (
     build_agent_aftermath_lines,
@@ -32,6 +34,12 @@ from .ui.dashboard import (
     build_faction_pressure_lines,
     build_recent_consequence_lines,
     build_resource_summary_line,
+)
+from .ui.command_center import (
+    build_action_strip,
+    build_command_center_layout,
+    build_command_title,
+    panel_by_key,
 )
 from .ui.mission_board import build_mission_board_lines, build_selected_mission_lines
 from .ui.command_deck import (
@@ -69,6 +77,13 @@ class CorpView(GameView):
 
     def on_draw(self):
         self.clear()
+        draw_command_screen_frame(
+            build_command_title(
+                "corp", self.game_state.base_name, self.game_state.district.name
+            ),
+            self.window.width,
+            self.window.height,
+        )
         draw_status_bar(
             build_command_status_line(
                 self.game_state.turn,
@@ -80,69 +95,82 @@ class CorpView(GameView):
             self.window.height,
         )
 
-        y = self.window.height - 58
-        draw_panel(14, y - 132, 360, 126, "Corp Allocation")
-        arcade.draw_text(self.text.upper(), 28, y - 26, palette.HEADER, 18)
+        panels = build_command_center_layout(
+            self.window.width, self.window.height, "corp"
+        )
+        for panel in panels:
+            draw_panel(panel.left, panel.bottom, panel.width, panel.height, panel.title)
+
+        primary = panel_by_key(panels, "primary")
+        arcade.draw_text(
+            "BOARD DIRECTIVE",
+            primary.left + 18,
+            primary.bottom + primary.height - 58,
+            palette.HEADER,
+            16,
+        )
         arcade.draw_text(
             f"Auto Budget Pool: {self.game_state.budget_pool}",
-            32,
-            y - 52,
+            primary.left + 18,
+            primary.bottom + primary.height - 86,
             palette.MUTED_TEXT,
             12,
         )
         arcade.draw_text(
             build_resource_summary_line(self.game_state.strategic_resources),
-            32,
-            y - 70,
+            primary.left + 18,
+            primary.bottom + primary.height - 108,
             palette.RESOURCE,
             11,
         )
-        budget_y = y - 94
+        budget_y = primary.bottom + primary.height - 140
         for k, v in self.game_state.corp_budget.items():
-            arcade.draw_text(f"{k}: {v}", 34, budget_y, palette.TEXT, 12)
-            budget_y -= 16
+            arcade.draw_text(
+                f"{k.upper()} ALLOCATION   {v}",
+                primary.left + 22,
+                budget_y,
+                palette.TEXT,
+                12,
+            )
+            budget_y -= 24
 
-        right_x = 392
-        draw_panel(
-            right_x,
-            y - 132,
-            max(360, self.window.width - right_x - 18),
-            126,
-            "Upgrade Sinks",
-        )
+        top_right = panel_by_key(panels, "top_right")
         upgrade_lines = [
-            "1 Research: 5 intel",
-            "2 Security: 10 credits + 2 salvage",
-            "3 Politics: 3 influence",
-            "4 Black Ops: 5 credits + 3 intel",
+            "1 RESEARCH LAB      5 intel",
+            "2 SECURITY GRID     10 credits + 2 salvage",
+            "3 POLITICAL FLOOR   3 influence",
+            "4 BLACK OPS CELL    5 credits + 3 intel",
         ]
-        line_y = y - 38
+        line_y = top_right.bottom + top_right.height - 58
         for line in upgrade_lines:
-            arcade.draw_text(line, right_x + 18, line_y, palette.ACCENT, 12)
-            line_y -= 20
+            arcade.draw_text(line, top_right.left + 18, line_y, palette.ACCENT, 12)
+            line_y -= 28
 
-        y -= 158
-        draw_panel(14, y - 104, self.window.width - 28, 104, "District Pulse")
-        next_y = draw_line_group(
-            "District Pulse",
-            build_district_status_lines(self.game_state.district),
-            30,
-            y - 28,
-            palette.TEXT,
+        bottom_right = panel_by_key(panels, "bottom_right")
+        meter_x = bottom_right.left + 18
+        meter_y = bottom_right.bottom + bottom_right.height - 70
+        draw_tactical_meter(
+            meter_x, meter_y, 180, "stability", self.game_state.district.stability
         )
-        draw_panel(14, next_y - 96, self.window.width - 28, 96, "Latest Fallout")
-        draw_line_group(
-            "Latest Fallout",
-            build_recent_consequence_lines(self.game_state.recent_consequences),
-            30,
-            next_y - 28,
-            palette.MUTED_TEXT,
+        draw_tactical_meter(
+            meter_x, meter_y - 28, 180, "unrest", self.game_state.district.unrest
         )
+        draw_tactical_meter(
+            meter_x,
+            meter_y - 56,
+            180,
+            "media heat",
+            self.game_state.district.media_heat,
+        )
+        y = meter_y - 90
+        for line in build_recent_consequence_lines(self.game_state.recent_consequences):
+            arcade.draw_text(line, bottom_right.left + 18, y, palette.MUTED_TEXT, 11)
+            y -= 20
 
-        arcade.draw_text(
-            "1-4 spend resources, S save, L load", 20, 40, palette.ACCENT, 14
+        draw_action_strip(
+            build_action_strip(["1-4 spend", "S save", "L load", "C city", "R squad"]),
+            self.window.width,
         )
-        arcade.draw_text("Press C for City, R for RPG", 20, 20, palette.ACCENT, 14)
 
     def _buy_corp_upgrade(self, key: str, costs: dict[str, int]) -> None:
         if self.game_state.spend_resources(costs):
@@ -189,6 +217,13 @@ class CityView(GameView):
 
     def on_draw(self):
         self.clear()
+        draw_command_screen_frame(
+            build_command_title(
+                "city", self.game_state.base_name, self.game_state.district.name
+            ),
+            self.window.width,
+            self.window.height,
+        )
         draw_status_bar(
             build_command_status_line(
                 self.game_state.turn,
@@ -200,67 +235,81 @@ class CityView(GameView):
             self.window.height,
         )
 
-        y = self.window.height - 58
-        draw_panel(14, y - 116, 360, 110, "City Grid")
-        arcade.draw_text(self.text.upper(), 28, y - 26, palette.HEADER, 18)
+        panels = build_command_center_layout(
+            self.window.width, self.window.height, "city"
+        )
+        for panel in panels:
+            draw_panel(panel.left, panel.bottom, panel.width, panel.height, panel.title)
+
+        primary = panel_by_key(panels, "primary")
+        arcade.draw_text(
+            "CITY BUDGET ROUTER",
+            primary.left + 18,
+            primary.bottom + primary.height - 58,
+            palette.HEADER,
+            16,
+        )
         arcade.draw_text(
             build_resource_summary_line(self.game_state.strategic_resources),
-            32,
-            y - 52,
+            primary.left + 18,
+            primary.bottom + primary.height - 86,
             palette.RESOURCE,
             11,
         )
-        budget_y = y - 78
+        budget_y = primary.bottom + primary.height - 122
         for k, v in self.game_state.city_budget.items():
-            arcade.draw_text(f"{k}: {v}", 34, budget_y, palette.TEXT, 12)
-            budget_y -= 18
+            arcade.draw_text(
+                f"{k.upper()} NETWORK   {v}",
+                primary.left + 22,
+                budget_y,
+                palette.TEXT,
+                12,
+            )
+            budget_y -= 26
+        y = budget_y - 18
+        for line in [
+            "7 ARMAMENTS      5 credits + 3 salvage",
+            "8 GARRISONS      10 credits + 2 influence",
+            "9 DEFENSE ZONES  5 credits + 5 salvage",
+        ]:
+            arcade.draw_text(line, primary.left + 22, y, palette.ACCENT, 12)
+            y -= 24
 
-        right_x = 392
-        draw_panel(
-            right_x,
-            y - 116,
-            max(360, self.window.width - right_x - 18),
-            110,
-            "District Investments",
+        top_right = panel_by_key(panels, "top_right")
+        meter_x = top_right.left + 18
+        meter_y = top_right.bottom + top_right.height - 66
+        draw_tactical_meter(
+            meter_x, meter_y, 220, "stability", self.game_state.district.stability
         )
-        upgrade_lines = [
-            "7 Armaments: 5 credits + 3 salvage",
-            "8 Garrisons: 10 credits + 2 influence",
-            "9 Defense Zones: 5 credits + 5 salvage",
-        ]
-        line_y = y - 38
-        for line in upgrade_lines:
-            arcade.draw_text(line, right_x + 18, line_y, palette.ACCENT, 12)
-            line_y -= 22
+        draw_tactical_meter(
+            meter_x, meter_y - 30, 220, "unrest", self.game_state.district.unrest
+        )
+        draw_tactical_meter(
+            meter_x,
+            meter_y - 60,
+            220,
+            "media heat",
+            self.game_state.district.media_heat,
+        )
+        y = meter_y - 96
+        for line in build_district_status_lines(self.game_state.district):
+            arcade.draw_text(line, top_right.left + 18, y, palette.TEXT, 11)
+            y -= 20
 
-        y -= 140
-        draw_panel(14, y - 104, self.window.width - 28, 104, "District Pressure")
-        y = draw_line_group(
-            "District Pressure",
-            build_district_status_lines(self.game_state.district),
-            30,
-            y - 28,
-            palette.TEXT,
-        )
-        draw_panel(14, y - 104, self.window.width - 28, 104, "Faction Pressure")
-        y = draw_line_group(
-            "Faction Pressure",
-            build_faction_pressure_lines(self.game_state.factions),
-            30,
-            y - 28,
-            palette.MUTED_TEXT,
-        )
-        draw_panel(14, y - 116, self.window.width - 28, 116, "Operations Log")
-        draw_line_group(
-            "Operations Log",
-            build_event_log_lines(self.game_state.event_log),
-            30,
-            y - 28,
-            palette.MUTED_TEXT,
-        )
+        bottom_right = panel_by_key(panels, "bottom_right")
+        y = bottom_right.bottom + bottom_right.height - 58
+        for line in build_faction_pressure_lines(self.game_state.factions, limit=2):
+            arcade.draw_text(line, bottom_right.left + 18, y, palette.MUTED_TEXT, 10)
+            y -= 22
+        y -= 12
+        for line in build_event_log_lines(self.game_state.event_log, limit=4):
+            arcade.draw_text(line, bottom_right.left + 18, y, palette.TEXT, 10)
+            y -= 18
 
-        arcade.draw_text("7-9 spend resources", 20, 40, palette.ACCENT, 14)
-        arcade.draw_text("Press R for RPG", 20, 20, palette.ACCENT, 14)
+        draw_action_strip(
+            build_action_strip(["7-9 invest", "R squad deck"]),
+            self.window.width,
+        )
 
     def _buy_city_upgrade(self, key: str, costs: dict[str, int]) -> None:
         if self.game_state.spend_resources(costs):
@@ -364,7 +413,11 @@ class RPGView(GameView):
 
     def on_draw(self):
         self.clear()
-        draw_megacity_backdrop(self.window.width, self.window.height)
+        draw_command_screen_frame(
+            "SQUAD COMMAND DECK // CITY INSERTION TABLE",
+            self.window.width,
+            self.window.height,
+        )
         draw_status_bar(
             build_command_status_line(
                 self.game_state.turn,
@@ -460,7 +513,9 @@ class RPGView(GameView):
                 "READINESS BRIEF", briefs_panel.left + 14, y, palette.HEADER, 12
             )
             y -= 20
-            for line in build_agent_readiness_lines(self.game_state.characters, mission):
+            for line in build_agent_readiness_lines(
+                self.game_state.characters, mission
+            ):
                 arcade.draw_text(line, briefs_panel.left + 14, y, palette.TEXT, 10)
                 y -= 16
             y -= 12
@@ -478,12 +533,11 @@ class RPGView(GameView):
 
         if self.message:
             arcade.draw_text(self.message, 20, 42, palette.WARNING, 13)
-        arcade.draw_text(
-            "N recruit  |  1-3 select op  |  A/D agent  |  Enter toggle  |  B launch",
-            20,
-            20,
-            palette.ACCENT,
-            14,
+        draw_action_strip(
+            build_action_strip(
+                ["N recruit", "1-3 select op", "A/D agent", "Enter toggle", "B launch"]
+            ),
+            self.window.width,
         )
 
     def on_key_press(self, key, modifiers):
@@ -734,21 +788,37 @@ class BattleView(GameView):
         self.clear()
         self.camera.use()
         if self.map_index is None:
-            y = self.window.height - 40
-            arcade.draw_text("Select battle map:", 20, y, arcade.color.WHITE, 20)
+            draw_command_screen_frame(
+                "TACTICAL INSERTION // SELECT CITY COMBAT ZONE",
+                self.window.width,
+                self.window.height,
+            )
+            draw_panel(
+                18,
+                80,
+                min(620, self.window.width - 36),
+                self.window.height - 160,
+                "Drop Zone Uplink",
+            )
+            y = self.window.height - 130
+            arcade.draw_text("SELECT BATTLE MAP", 42, y, palette.HEADER, 20)
             y -= 40
             if not self.available_maps:
                 arcade.draw_text(
                     "No maps found in assets/maps",
-                    20,
+                    42,
                     y,
-                    arcade.color.RED,
+                    palette.DANGER,
                     14,
                 )
             else:
                 for idx, name in enumerate(self.available_maps, start=1):
-                    arcade.draw_text(f"{idx} - {name}", 20, y, arcade.color.AQUA, 14)
-                    y -= 20
+                    arcade.draw_text(f"{idx}  ▸  {name}", 42, y, palette.ACCENT, 14)
+                    y -= 24
+            draw_action_strip(
+                build_action_strip(["1-9 choose drop zone", "Esc return"]),
+                self.window.width,
+            )
             return
         if self.background:
             # Build a rectangle: left, bottom, width, height
@@ -766,9 +836,9 @@ class BattleView(GameView):
         if self.battle_objective:
             ox, oy = self.battle_objective.position
             marker_color = (
-                arcade.color.GREEN
+                palette.TACTICAL_GREEN
                 if self.battle_objective.completed
-                else arcade.color.YELLOW
+                else palette.WARNING
             )
             arcade.draw_lrbt_rectangle_filled(
                 ox - 14,
@@ -779,14 +849,14 @@ class BattleView(GameView):
             )
             arcade.draw_rect_outline(
                 arcade.LBWH(ox - 18, oy - 18, 36, 36),
-                arcade.color.AQUA,
+                palette.ACCENT,
                 border_width=2,
             )
             arcade.draw_text(
                 self.battle_objective.label,
                 ox - 28,
                 oy + 24,
-                arcade.color.WHITE,
+                palette.TEXT,
                 12,
             )
 
@@ -803,7 +873,7 @@ class BattleView(GameView):
                     right,
                     bottom,
                     top,
-                    arcade.color.DARK_RED,
+                    palette.DANGER,
                 )
                 current = bar_width * enemy.health / enemy.stats.max_hp
                 arcade.draw_lrbt_rectangle_filled(
@@ -811,7 +881,7 @@ class BattleView(GameView):
                     left + current,
                     bottom,
                     top,
-                    arcade.color.GREEN,
+                    palette.TACTICAL_GREEN,
                 )
         if self.selecting_target and self.target_candidates:
             target = self.target_candidates[self.selected_target_idx]
@@ -823,7 +893,7 @@ class BattleView(GameView):
                 full_rect = arcade.LBWH(cx - width / 2, cy - height / 2, width, height)
                 arcade.draw_rect_outline(
                     full_rect,
-                    arcade.color.YELLOW,
+                    palette.WARNING,
                     border_width=2,
                 )
                 # Display hit chance above target
@@ -841,64 +911,76 @@ class BattleView(GameView):
                     prob_text,
                     cx - width / 2,
                     cy + height / 2 + 4,
-                    arcade.color.YELLOW,
+                    palette.WARNING,
                     12,
                 )
         if self.attack_line:
             x1, y1, x2, y2 = self.attack_line
-            arcade.draw_line(x1, y1, x2, y2, arcade.color.YELLOW, 2)
+            arcade.draw_line(x1, y1, x2, y2, palette.WARNING, 2)
         current_hp = (
             self.player_units[self.active_index].health if self.player_units else 0
         )
-        status = f"Turn {self.turn_number} - {self.turn.capitalize()}  Player HP: {current_hp}"
+        status = (
+            f"TURN {self.turn_number} // {self.turn.upper()} // ACTIVE HP {current_hp}"
+        )
         if self.mission:
-            status = f"{self.mission.title} | {status}"
-        arcade.draw_text(status, 20, self.window.height - 20, arcade.color.AQUA, 14)
+            status = f"{self.mission.title.upper()} // {status}"
+        draw_panel(
+            14,
+            self.window.height - 112,
+            self.window.width - 28,
+            98,
+            "Tactical Combat HUD",
+        )
+        arcade.draw_text(status, 32, self.window.height - 48, palette.ACCENT, 14)
         if self.mission:
             arcade.draw_text(
                 self.mission.objective_text,
-                20,
-                self.window.height - 42,
-                arcade.color.LIGHT_GRAY,
+                32,
+                self.window.height - 70,
+                palette.MUTED_TEXT,
                 12,
             )
         if self.battle_objective:
             arcade.draw_text(
                 self.battle_objective.status_text,
-                20,
-                self.window.height - 62,
-                arcade.color.AQUA,
+                32,
+                self.window.height - 90,
+                palette.RESOURCE,
                 12,
             )
         if self.message:
-            message_y = (
-                self.window.height - 84
-                if self.battle_objective
-                else self.window.height - 62
+            arcade.draw_text(
+                self.message, 32, self.window.height - 132, palette.WARNING, 16
             )
-            arcade.draw_text(self.message, 20, message_y, arcade.color.YELLOW, 16)
         if self.turn == "ended":
             if not self.enemy_units:
                 msg = "Victory!"
             else:
                 msg = "Defeat..."
-            arcade.draw_text(msg, 20, 40, arcade.color.YELLOW, 20)
+            arcade.draw_text(msg, 20, 40, palette.WARNING, 20)
         else:
             if self.selecting_target:
-                arcade.draw_text(
-                    "Select target with Left/Right, Enter to confirm, Esc to cancel",
-                    20,
-                    20,
-                    arcade.color.AQUA,
-                    14,
+                draw_action_strip(
+                    build_action_strip(
+                        ["Left/Right target", "Enter confirm", "Esc cancel"]
+                    ),
+                    self.window.width,
                 )
             else:
-                arcade.draw_text(
-                    "Arrows move, E objective, Space melee, F shoot, P psi atk, V psi def, D defend, Esc exit",
-                    20,
-                    20,
-                    arcade.color.AQUA,
-                    14,
+                draw_action_strip(
+                    build_action_strip(
+                        [
+                            "Arrows move",
+                            "E objective",
+                            "Space melee",
+                            "F shoot",
+                            "P psi",
+                            "V/D defend",
+                            "Esc exit",
+                        ]
+                    ),
+                    self.window.width,
                 )
 
     def on_key_press(self, key, modifiers):

--- a/tests/test_command_center_ui.py
+++ b/tests/test_command_center_ui.py
@@ -1,0 +1,44 @@
+"""Command-center presentation rules for the city/corporate UI shell."""
+
+import unittest
+
+from game.ui.command_center import (
+    build_action_strip,
+    build_command_center_layout,
+    build_command_title,
+    panel_by_key,
+)
+
+
+class CommandCenterUITest(unittest.TestCase):
+    def test_management_layout_keeps_war_room_and_city_feed_readable(self):
+        panels = build_command_center_layout(1280, 720, "corp")
+
+        self.assertEqual(
+            [panel.key for panel in panels], ["primary", "top_right", "bottom_right"]
+        )
+        self.assertLess(
+            panel_by_key(panels, "primary").left, panel_by_key(panels, "top_right").left
+        )
+        self.assertEqual(
+            panel_by_key(panels, "top_right").left,
+            panel_by_key(panels, "bottom_right").left,
+        )
+        self.assertIn("Corporate War Room", panel_by_key(panels, "primary").title)
+
+    def test_city_mode_uses_city_control_language(self):
+        panels = build_command_center_layout(1280, 720, "city")
+
+        self.assertIn("City Situation Room", panel_by_key(panels, "primary").title)
+        self.assertIn("District Pressure", panel_by_key(panels, "top_right").title)
+
+    def test_command_title_and_action_strip_feel_like_tactical_console(self):
+        title = build_command_title("city", "Ghost Tower", "Chrome Warrens")
+        strip = build_action_strip(["7-9 invest", "R squad deck"])
+
+        self.assertEqual(title, "CITY CONTROL // GHOST TOWER // CHROME WARRENS")
+        self.assertEqual(strip, "7-9 invest  ▸  R squad deck")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Unify management, RPG and battle screens under a single XCOM2-inspired command-room aesthetic to improve visual coherence and readability.
- Provide testable layout and presentation primitives so screen layout logic can be validated without opening a window.

### Description
- Add `game/ui/command_center.py` with `CommandPanel`, `build_command_center_layout`, `panel_by_key`, `build_command_title`, and `build_action_strip` to describe panel placement and terse copy.
- Update `game/ui/palette.py` with revised colors and new palette entries like `AMBER_FILL`, `SCANLINE`, and `TACTICAL_GREEN` used by the command-shell visuals.
- Rewrite `game/ui/panels.py` to draw angled tactical glass panels and global chrome, and add `draw_command_screen_frame`, `draw_action_strip`, and `draw_tactical_meter` helpers used across screens.
- Refactor `game/views.py` to use the new layout and drawing helpers in `CorpView`, `CityView`, `RPGView`, and `BattleView`, and replace many hard-coded draws with layout-driven rendering and action strips.
- Update documentation files (`README.md`, `docs/backlog.md`, `docs/roadmap.md`) to describe the new command-room UI and mood changes.
- Add unit tests `tests/test_command_center_ui.py` that exercise `build_command_center_layout`, `panel_by_key`, `build_command_title`, and `build_action_strip`.

### Testing
- Run the new unit test `python -m unittest tests.test_command_center_ui` and it passed.
- The new layout primitives are exercised by the test which asserts panel positions, titles, and action-strip formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07158f2fa0832b9d99c0c942d90e25)