### PR TITLE
Add corporate funds ledger and integrate into GameState/UI

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -12,6 +12,7 @@ TODO:
 [x] Display the squad roster as graphical personalized agent cards
 [x] Fix pending-upgrade roster card rendering
 [x] Add click-select squad cards with generated portraits and point counters
+[x] Create dedicated corporate funds ledger and show available funds in command UI
 [ ] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -43,6 +44,9 @@ Done:
 - Squad card interaction: expanded squad rooms now distinguish the active agent
   from deployment selection, let card clicks choose the active agent, show
   remaining upgrade points, and use 24 generated portrait assets.
+- Corporate funds ledger: the global game state now owns a small funds module
+  tracking available cash, income, expenses, and transaction history for
+  management decisions.
 - City/corporate tactical command deck: RPG View has separate agent barracks,
   operations table, intel lab, and medbay/fallout panels over the tower base.
 - Mission UI: RPG view mission board has selectable rows plus a selected-mission

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,6 +29,8 @@
   - Progress: Agent cards now use 24 generated portrait assets, strong
     active-agent brackets, click-to-select behavior, and numbered upgrade-point
     badges/buttons for leveling.
+  - Progress: Corporate management now has a dedicated funds ledger owned by
+    GameState, with available funds shown in command HUD and room info.
 - District system
 - Mission generation
 - Black ops

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -6,6 +6,7 @@ from typing import List, TYPE_CHECKING
 
 from .consequences import Consequence, create_opening_consequence
 from .factions import Faction, create_vertical_slice_factions
+from .management.funds import CorporateFunds
 from .mission_templates import MissionTemplate, create_mission_templates
 from .operations import Operation, create_operation_templates
 from .world import District, create_vertical_slice_district
@@ -78,11 +79,19 @@ class GameState:
 
     # Turn management
     turn: int = 1
+    funds: CorporateFunds = field(default_factory=CorporateFunds)
     budget_pool: int = 0
 
     def __post_init__(self) -> None:
         if not self.budget_pool:
             self.budget_pool = self.compute_budget()
+        if self.funds.available_funds <= 0 and not self.funds.transaction_history:
+            self.funds.add_funds(
+                self.budget_pool,
+                "opening_budget",
+                "Initial corporate operating funds.",
+            )
+        self.budget_pool = self.funds.available_funds
 
     # ------------------------------------------------------------------
     # Turn and budget management
@@ -91,11 +100,35 @@ class GameState:
         """Compute the budget for the next turn based on current corp values."""
         return 100 + sum(self.corp_budget.values()) // 10
 
+    @property
+    def available_funds(self) -> int:
+        """Return corporate funds available for immediate spending."""
+        return self.funds.available_funds
+
+    def can_afford(self, amount: int) -> bool:
+        """Return whether the corporate ledger can cover an expense."""
+        return self.funds.can_afford(amount)
+
+    def add_funds(self, amount: int, source: str, note: str = "") -> bool:
+        """Add income to the corporate funds ledger and sync legacy budget UI."""
+        added = self.funds.add_funds(amount, source, note)
+        if added:
+            self.budget_pool = self.funds.available_funds
+        return added
+
+    def spend_funds(self, amount: int, sink: str, note: str = "") -> bool:
+        """Spend from the corporate funds ledger and sync legacy budget UI."""
+        spent = self.funds.spend_funds(amount, sink, note)
+        if spent:
+            self.budget_pool = self.funds.available_funds
+        return spent
+
     def allocate_corp_funds(self, key: str, amount: int) -> bool:
-        """Attempt to allocate funds from the current budget."""
-        if key in self.corp_budget and self.budget_pool >= amount:
+        """Attempt to allocate funds from the current corporate ledger."""
+        if key in self.corp_budget and self.spend_funds(
+            amount, f"corp_{key}", f"Allocated to {key}."
+        ):
             self.corp_budget[key] += amount
-            self.budget_pool -= amount
             return True
         return False
 
@@ -171,9 +204,14 @@ class GameState:
                     recovered_agents.append(character.name)
 
         self.turn += 1
-        self.budget_pool = self.compute_budget()
+        income = self.compute_budget()
+        self.add_funds(
+            income,
+            "turn_refresh",
+            f"Turn {self.turn} operating funds for {self.base_name}.",
+        )
         self.add_event(
-            f"Turn {self.turn}: Corporate budget refreshed for {self.base_name}."
+            f"Turn {self.turn}: Corporate funds refreshed by {income} for {self.base_name}."
         )
         for name in recovered_agents:
             self.add_event(f"Turn {self.turn}: {name} is deployable after recovery.")
@@ -251,6 +289,7 @@ class GameState:
         data = {
             "turn": self.turn,
             "budget_pool": self.budget_pool,
+            "funds": self.funds.to_dict(),
             "corp_budget": self.corp_budget,
             "city_budget": self.city_budget,
             "strategic_resources": self.strategic_resources,
@@ -288,7 +327,12 @@ class GameState:
         gs.city_budget.update(data.get("city_budget", {}))
         gs.strategic_resources.update(data.get("strategic_resources", {}))
         gs.turn = data.get("turn", 1)
-        gs.budget_pool = data.get("budget_pool", gs.compute_budget())
+        if "funds" in data:
+            gs.funds = CorporateFunds.from_dict(data["funds"])
+            gs.budget_pool = gs.funds.available_funds
+        else:
+            gs.budget_pool = data.get("budget_pool", gs.compute_budget())
+            gs.funds = CorporateFunds(current_funds=gs.budget_pool)
         gs.x = data.get("x", 0)
         gs.base_name = data.get("base_name", gs.base_name)
         gs.district = District.from_dict(data.get("district", gs.district.to_dict()))

--- a/game/management/__init__.py
+++ b/game/management/__init__.py
@@ -1,0 +1,5 @@
+"""Management-phase domain modules."""
+
+from .funds import CorporateFunds, FundsLedger, FundsTransaction
+
+__all__ = ["CorporateFunds", "FundsLedger", "FundsTransaction"]

--- a/game/management/funds.py
+++ b/game/management/funds.py
@@ -1,0 +1,110 @@
+"""Small corporate funds ledger for management-phase spending.
+
+The ledger is intentionally narrow: it tracks the cash the corporation can
+spend right now, aggregate income/expenses, and the short transaction history
+that gives those numbers a story trail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class FundsTransaction:
+    """One income or spending entry in the corporate ledger."""
+
+    kind: str
+    amount: int
+    source: str
+    note: str = ""
+    balance_after: int = 0
+
+    def to_dict(self) -> dict:
+        """Serialize the transaction for save files."""
+        return {
+            "kind": self.kind,
+            "amount": self.amount,
+            "source": self.source,
+            "note": self.note,
+            "balance_after": self.balance_after,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "FundsTransaction":
+        """Restore a transaction from save data."""
+        return cls(
+            kind=str(data.get("kind", "income")),
+            amount=int(data.get("amount", 0)),
+            source=str(data.get("source", "legacy")),
+            note=str(data.get("note", "")),
+            balance_after=int(data.get("balance_after", 0)),
+        )
+
+
+@dataclass
+class CorporateFunds:
+    """Track available corporate cash and its transaction history."""
+
+    current_funds: int = 0
+    income: int = 0
+    expenses: int = 0
+    transaction_history: list[FundsTransaction] = field(default_factory=list)
+
+    @property
+    def available_funds(self) -> int:
+        """Return the cash available for immediate management decisions."""
+        return self.current_funds
+
+    def can_afford(self, amount: int) -> bool:
+        """Return whether an amount can be spent without overdrafting."""
+        return amount >= 0 and self.current_funds >= amount
+
+    def add_funds(self, amount: int, source: str, note: str = "") -> bool:
+        """Record income from a named source."""
+        if amount <= 0:
+            return False
+        self.current_funds += amount
+        self.income += amount
+        self.transaction_history.append(
+            FundsTransaction("income", amount, source, note, self.current_funds)
+        )
+        return True
+
+    def spend_funds(self, amount: int, sink: str, note: str = "") -> bool:
+        """Spend funds atomically when the ledger can afford the amount."""
+        if amount <= 0 or not self.can_afford(amount):
+            return False
+        self.current_funds -= amount
+        self.expenses += amount
+        self.transaction_history.append(
+            FundsTransaction("expense", amount, sink, note, self.current_funds)
+        )
+        return True
+
+    def to_dict(self) -> dict:
+        """Serialize the ledger for save files."""
+        return {
+            "current_funds": self.current_funds,
+            "income": self.income,
+            "expenses": self.expenses,
+            "transaction_history": [
+                transaction.to_dict() for transaction in self.transaction_history
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CorporateFunds":
+        """Restore a ledger from save data."""
+        return cls(
+            current_funds=int(data.get("current_funds", 0)),
+            income=int(data.get("income", 0)),
+            expenses=int(data.get("expenses", 0)),
+            transaction_history=[
+                FundsTransaction.from_dict(transaction)
+                for transaction in data.get("transaction_history", [])
+            ],
+        )
+
+
+FundsLedger = CorporateFunds

--- a/game/ui/dashboard.py
+++ b/game/ui/dashboard.py
@@ -53,11 +53,19 @@ def district_pressure_severity(district: District) -> str:
 
 
 def build_command_status_line(
-    turn: int, base_name: str, resources: dict[str, int], district: District
+    turn: int,
+    base_name: str,
+    resources: dict[str, int],
+    district: District,
+    available_funds: int | None = None,
 ) -> str:
     """Build the top-line command HUD status for Corp and City screens."""
+    funds_text = (
+        f"FUNDS {available_funds} // " if available_funds is not None else ""
+    )
     return (
         f"TURN {turn} // {base_name} // "
+        f"{funds_text}"
         f"{build_resource_summary_line(resources)} // "
         f"DISTRICT PRESSURE {district_pressure_severity(district)}"
     )

--- a/game/ui/panels.py
+++ b/game/ui/panels.py
@@ -254,25 +254,46 @@ def draw_graphical_command_surface(
     resources: dict[str, int] | None = None,
     room_info_lines: dict[str, list[str]] | None = None,
     roster_cards: list[dict] | None = None,
+    available_funds: int | None = None,
 ) -> None:
     """Draw the image-first room UI without text panels."""
     draw_city_corporate_backdrop(width, height, state.mode)
-    draw_icon_resource_hud(width, height, resources or {})
-    draw_expanded_room_ui(width, height, state, room_info_lines or {}, roster_cards or [])
+    draw_icon_resource_hud(width, height, resources or {}, available_funds)
+    draw_expanded_room_ui(
+        width, height, state, room_info_lines or {}, roster_cards or []
+    )
 
 
-def draw_icon_resource_hud(width: int, height: int, resources: dict[str, int]) -> None:
-    """Draw compact icon-only resource meters."""
+def draw_icon_resource_hud(
+    width: int,
+    height: int,
+    resources: dict[str, int],
+    available_funds: int | None = None,
+) -> None:
+    """Draw compact icon resource meters and available corporate funds."""
+    if available_funds is not None:
+        arcade.draw_lrbt_rectangle_filled(
+            22, 178, height - 68, height - 42, palette.HUD_SLOT_FILL
+        )
+        _draw_icon("credits", 38, height - 55, 18, palette.RESOURCE)
+        meter_width = max(4, min(120, int(available_funds)))
+        arcade.draw_lrbt_rectangle_filled(
+            52, 52 + meter_width, height - 59, height - 51, palette.RESOURCE
+        )
     keys = ("credits", "intel", "salvage", "influence")
     size = 34
     gap = 12
-    left = 22
+    left = 196 if available_funds is not None else 22
     top = height - 18
     for index, key in enumerate(keys):
         x = left + index * (size + gap)
         bottom = top - size
-        arcade.draw_lrbt_rectangle_filled(x, x + size, bottom, top, palette.HUD_SLOT_FILL)
-        _draw_icon(key, x + size // 2, bottom + size // 2, size - 10, palette.RESOURCE)
+        arcade.draw_lrbt_rectangle_filled(
+            x, x + size, bottom, top, palette.HUD_SLOT_FILL
+        )
+        _draw_icon(
+            key, x + size // 2, bottom + size // 2, size - 10, palette.RESOURCE
+        )
         value = max(0, min(100, int(resources.get(key, 0))))
         bar_height = max(3, int((size - 8) * min(value, 40) / 40))
         arcade.draw_lrbt_rectangle_filled(

--- a/game/views.py
+++ b/game/views.py
@@ -90,8 +90,12 @@ class CorpView(GameView):
     def setup(self):
         self.text = "Corporation Management"
         self.room_ui = RoomUIState("corp")
-        if self.game_state.budget_pool <= 0:
-            self.game_state.budget_pool = self.game_state.compute_budget()
+        if self.game_state.available_funds <= 0:
+            self.game_state.add_funds(
+                self.game_state.compute_budget(),
+                "corp_setup",
+                "Emergency command-floor operating funds.",
+            )
 
     def on_draw(self):
         self.clear()
@@ -101,9 +105,10 @@ class CorpView(GameView):
             self.room_ui,
             self.game_state.strategic_resources,
             self._room_info_lines(),
-            build_roster_cards(
+            roster_cards=build_roster_cards(
                 self.game_state.characters, self.game_state.selected_agent_names
             ),
+            available_funds=self.game_state.available_funds,
         )
 
     def _buy_corp_upgrade(self, key: str, costs: dict[str, int]) -> None:
@@ -138,7 +143,7 @@ class CorpView(GameView):
             self.game_state.save("savegame.json")
         elif key == arcade.key.L:
             self.game_state = GameState.load("savegame.json")
-        if self.game_state.budget_pool <= 0:
+        if self.game_state.available_funds <= 0:
             self.game_state.advance_turn()
 
     def on_mouse_press(self, x, y, button, modifiers):
@@ -178,8 +183,9 @@ class CorpView(GameView):
             return
         if action_key.startswith("recruit_"):
             role = action_key.removeprefix("recruit_")
-            if self.game_state.budget_pool >= 5:
-                self.game_state.budget_pool -= 5
+            if self.game_state.spend_funds(
+                5, "recruitment", f"Recruited {role} from Black Ops."
+            ):
                 agent = recruit_agent(self.game_state.characters, role)
                 self.game_state.add_event(
                     f"Black ops recruited {agent.name} as {role}."
@@ -195,7 +201,7 @@ class CorpView(GameView):
         resources = self.game_state.strategic_resources
         return {
             "executive": [
-                f"Turn {self.game_state.turn} | Budget pool {self.game_state.budget_pool}",
+                f"Turn {self.game_state.turn} | Funds {self.game_state.available_funds}",
                 f"Politics allocation {self.game_state.corp_budget['politics']}",
                 f"Influence reserve {resources.get('influence', 0)}",
             ],
@@ -212,7 +218,7 @@ class CorpView(GameView):
             "black_ops": [
                 f"Black ops allocation {self.game_state.corp_budget['black_ops']}",
                 f"Credits {resources.get('credits', 0)} | Intel {resources.get('intel', 0)}",
-                f"Roster {len(self.game_state.characters)} agents | Recruit cost 5 budget",
+                f"Roster {len(self.game_state.characters)} agents | Recruit cost 5 funds",
                 "Fund cost: 5 credits + 3 intel",
             ],
             "media": [
@@ -262,9 +268,10 @@ class CityView(GameView):
             self.room_ui,
             self.game_state.strategic_resources,
             self._room_info_lines(),
-            build_roster_cards(
+            roster_cards=build_roster_cards(
                 self.game_state.characters, self.game_state.selected_agent_names
             ),
+            available_funds=self.game_state.available_funds,
         )
 
     def _buy_city_upgrade(self, key: str, costs: dict[str, int]) -> None:
@@ -466,11 +473,12 @@ class RPGView(GameView):
             self.room_ui,
             self.game_state.strategic_resources,
             self._room_info_lines(),
-            build_roster_cards(
+            roster_cards=build_roster_cards(
                 self.game_state.characters,
                 self.game_state.selected_agent_names,
                 self.deployment_cursor_index,
             ),
+            available_funds=self.game_state.available_funds,
         )
 
     def on_key_press(self, key, modifiers):
@@ -499,11 +507,12 @@ class RPGView(GameView):
             self.pending_breakdown_confirmation = False
             self.pending_breakdown_mission_id = None
         elif key == arcade.key.N:
-            if self.game_state.budget_pool >= 5:
+            if self.game_state.spend_funds(
+                5, "recruitment", "Reserved funds for a new agent."
+            ):
                 self.recruiting = True
                 self.selected_role = None
                 self.message = ""
-                self.game_state.budget_pool -= 5
             else:
                 pass
         elif self.recruiting:
@@ -611,8 +620,9 @@ class RPGView(GameView):
     def _perform_room_action(self, action_key: str) -> None:
         if action_key.startswith("recruit_"):
             role = action_key.removeprefix("recruit_")
-            if self.game_state.budget_pool >= 5:
-                self.game_state.budget_pool -= 5
+            if self.game_state.spend_funds(
+                5, "recruitment", "Recruited from squad room."
+            ):
                 recruit_agent(self.game_state.characters, role)
                 self.deployment_cursor_index = len(self.game_state.characters) - 1
                 self.message = ""
@@ -743,8 +753,8 @@ class RPGView(GameView):
         return {
             "barracks": [
                 f"Roster {len(self.game_state.characters)} agents",
-                f"Recruit budget pool {self.game_state.budget_pool}",
-                "Recruit cost: 5 budget",
+                f"Available funds {self.game_state.available_funds}",
+                "Recruit cost: 5 funds",
             ],
             "ops": [
                 mission.title,
@@ -968,6 +978,7 @@ class BattleView(GameView):
                 self.room_ui,
                 self.game_state.strategic_resources,
                 self._room_info_lines(),
+                available_funds=self.game_state.available_funds,
             )
             return
         if self.background:

--- a/tests/test_command_center_ui.py
+++ b/tests/test_command_center_ui.py
@@ -2,12 +2,14 @@
 
 import unittest
 
+from game.gamestate import GameState
 from game.ui.command_center import (
     build_action_strip,
     build_command_center_layout,
     build_command_title,
     panel_by_key,
 )
+from game.ui.dashboard import build_command_status_line
 
 
 class CommandCenterUITest(unittest.TestCase):
@@ -40,6 +42,19 @@ class CommandCenterUITest(unittest.TestCase):
             title, "CITY CONTROL TOWER // GHOST TOWER // CHROME WARRENS"
         )
         self.assertEqual(strip, "7-9 invest  >  R squad deck")
+
+    def test_dashboard_status_line_shows_available_funds(self):
+        game_state = GameState()
+        line = build_command_status_line(
+            game_state.turn,
+            game_state.base_name,
+            game_state.strategic_resources,
+            game_state.district,
+            game_state.available_funds,
+        )
+
+        self.assertIn(f"FUNDS {game_state.available_funds}", line)
+        self.assertIn("DISTRICT PRESSURE", line)
 
 
 if __name__ == "__main__":

--- a/tests/test_funds_management.py
+++ b/tests/test_funds_management.py
@@ -1,0 +1,65 @@
+"""Corporate funds ledger and GameState integration tests."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from game.gamestate import GameState
+from game.management.funds import CorporateFunds
+
+
+class FundsManagementTest(unittest.TestCase):
+    def test_income_updates_available_funds_and_history(self):
+        ledger = CorporateFunds()
+
+        self.assertTrue(ledger.add_funds(35, "sponsor", "Board advance."))
+
+        self.assertEqual(ledger.available_funds, 35)
+        self.assertEqual(ledger.income, 35)
+        self.assertEqual(len(ledger.transaction_history), 1)
+        self.assertEqual(ledger.transaction_history[0].source, "sponsor")
+        self.assertEqual(ledger.transaction_history[0].balance_after, 35)
+
+    def test_spending_updates_expenses_and_balance(self):
+        ledger = CorporateFunds(current_funds=50)
+
+        self.assertTrue(ledger.spend_funds(15, "recruitment", "Found a sniper."))
+
+        self.assertEqual(ledger.available_funds, 35)
+        self.assertEqual(ledger.expenses, 15)
+        self.assertEqual(ledger.transaction_history[0].kind, "expense")
+        self.assertEqual(ledger.transaction_history[0].source, "recruitment")
+
+    def test_insufficient_funds_fail_without_mutating_history(self):
+        ledger = CorporateFunds(current_funds=10)
+
+        self.assertFalse(ledger.spend_funds(25, "security", "Too expensive."))
+
+        self.assertEqual(ledger.available_funds, 10)
+        self.assertEqual(ledger.expenses, 0)
+        self.assertEqual(ledger.transaction_history, [])
+        self.assertFalse(ledger.can_afford(25))
+
+    def test_game_state_owns_funds_helpers_and_save_history(self):
+        game_state = GameState()
+        opening_funds = game_state.available_funds
+
+        self.assertTrue(game_state.add_funds(20, "mission_bonus", "Clean extraction."))
+        self.assertTrue(game_state.spend_funds(5, "black_ops", "Quiet retainer."))
+        self.assertEqual(game_state.available_funds, opening_funds + 15)
+        self.assertEqual(game_state.budget_pool, game_state.available_funds)
+        self.assertEqual(game_state.funds.transaction_history[-1].source, "black_ops")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_path = Path(temp_dir) / "savegame.json"
+            game_state.save(str(save_path))
+
+            loaded = GameState.load(str(save_path))
+
+        self.assertEqual(loaded.available_funds, game_state.available_funds)
+        self.assertEqual(len(loaded.funds.transaction_history), 3)
+        self.assertEqual(loaded.funds.transaction_history[-1].note, "Quiet retainer.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a narrow, testable funds ledger to track corporate cash, income/expenses, and a short transaction history for management decisions.
- Replace ad-hoc use of `budget_pool` for immediate spending with a dedicated ledger owned by the global `GameState` to improve clarity and save/load fidelity.

### Description
- Added `game/management/funds.py` implementing `FundsTransaction` and `CorporateFunds` (alias `FundsLedger`) with `add_funds`, `spend_funds`, `can_afford`, `available_funds`, and serialization methods.
- Integrated `CorporateFunds` into `GameState` (`funds` field) and added `available_funds`, `can_afford`, `add_funds`, and `spend_funds` helpers plus save/load support and an initial opening fund seeding on construction and turn refresh.
- Updated UI layers to surface available funds: extended `build_command_status_line` to accept `available_funds`, threaded `available_funds` through `draw_graphical_command_surface`/`draw_icon_resource_hud`, and updated room info strings and recruitment flows to use `spend_funds` rather than mutating `budget_pool` directly.
- Added `tests/test_funds_management.py` to cover income, spending, insufficient funds, transaction history, and `GameState` integration, and updated `tests/test_command_center_ui.py` to assert the HUD shows funds; also updated `docs/backlog.md` and `docs/roadmap.md` to mark the task complete.

### Testing
- Ran unit test suite with `PYTHONPATH=. pytest -q` which executed the full test set including the new `tests/test_funds_management.py` and `tests/test_command_center_ui.py`, and all tests passed (`82 passed`).
- Performed static checks by compiling relevant modules with `python3 -m py_compile game/gamestate.py game/management/funds.py game/management/__init__.py game/ui/dashboard.py game/ui/panels.py game/views.py tests/test_funds_management.py tests/test_command_center_ui.py`, which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078b815d84832b9aa71400c2ef5a1d)