### PR TITLE
Add agent equipment loadouts

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,7 +13,8 @@ TODO:
 [x] Fix pending-upgrade roster card rendering
 [x] Add click-select squad cards with generated portraits and point counters
 [x] Create dedicated corporate funds ledger and show available funds in command UI
-[ ] Create Agent data model
+[x] Add compact agent equipment loadouts with primary, sidearm, armor, utility, psi focus, and special gear slots
+[x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
 [ ] Create stress system
@@ -47,6 +48,10 @@ Done:
 - Corporate funds ledger: the global game state now owns a small funds module
   tracking available cash, income, expenses, and transaction history for
   management decisions.
+- Agent equipment loadouts: characters now reference modular loadouts with
+  explicit weapon, armor, utility, psi focus, and special gear slots; combat
+  setup reads those items for stat/action adjustments while the character model
+  stays data-focused.
 - City/corporate tactical command deck: RPG View has separate agent barracks,
   operations table, intel lab, and medbay/fallout panels over the tower base.
 - Mission UI: RPG view mission board has selectable rows plus a selected-mission

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,12 +31,18 @@
     badges/buttons for leveling.
   - Progress: Corporate management now has a dedicated funds ledger owned by
     GameState, with available funds shown in command HUD and room info.
+  - Progress: Agent barracks now supports a small modular equipment slice: each
+    agent has loadout slots for primary weapon, sidearm, armor, utility item,
+    psi focus/implant, and special gear, and combat unit creation applies those
+    bonuses without hard-coding combat behavior into Character.
 - District system
 - Mission generation
 - Black ops
 
 # Phase 2
 - Agent system
+  - Progress: Loadouts are now a first small agent-system slice, giving agents
+    memorable gear choices while preserving scope and modularity.
 - Media system
 - Relationships
 - outside the city missions (wastelands)

--- a/game/character.py
+++ b/game/character.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field, asdict
 
 
+from .management.equipment import AgentLoadout
 from .stats import PlayerStats
 
 
@@ -25,6 +26,7 @@ class Character:
     history: list[str] = field(default_factory=list)
     savage_tags: list[str] = field(default_factory=list)
     recovery_turns: int = 0
+    loadout: AgentLoadout = field(default_factory=AgentLoadout)
 
     def to_dict(self) -> dict:
         return {
@@ -45,6 +47,7 @@ class Character:
             "history": list(self.history),
             "savage_tags": list(self.savage_tags),
             "recovery_turns": self.recovery_turns,
+            "loadout": self.loadout.to_dict(),
         }
 
     @classmethod
@@ -69,6 +72,7 @@ class Character:
             history=list(data.get("history", [])),
             savage_tags=list(data.get("savage_tags", [])),
             recovery_turns=data.get("recovery_turns", 0),
+            loadout=AgentLoadout.from_dict(data.get("loadout")),
         )
 
     def gain_xp(self, amount: int) -> None:

--- a/game/combat_system.py
+++ b/game/combat_system.py
@@ -2,12 +2,13 @@
 
 import random
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from .character import Character
 from .deployment import deployable_agents, selected_deployable_agents
 from .mission_templates import MissionTemplate
-from .stats import EnemyStats
+from .management.equipment import Weapon
+from .stats import EnemyStats, PlayerStats
 from .unit import Unit
 
 GRID_SIZE = 32
@@ -39,6 +40,31 @@ def is_occupied(
     return False
 
 
+def equipped_player_stats(character: Character) -> PlayerStats:
+    """Return combat stats with loadout bonuses applied without mutating the agent."""
+    stats = replace(character.stats)
+    for stat_key, amount in character.loadout.total_stat_bonuses().items():
+        if not hasattr(stats, stat_key):
+            continue
+        setattr(stats, stat_key, max(0, getattr(stats, stat_key) + amount))
+    if stats.max_hp < 1:
+        stats.recalculate_hp()
+    stats.hp = max(0, min(stats.hp, stats.max_hp))
+    return stats
+
+
+def primary_attack_range(character: Character) -> int:
+    """Return the longest directly equipped weapon range for initial combat setup."""
+    weapons = [
+        item
+        for item in (character.loadout.primary_weapon, character.loadout.sidearm)
+        if isinstance(item, Weapon)
+    ]
+    if not weapons:
+        return 1
+    return max(weapon.range_cells for weapon in weapons)
+
+
 def create_player_units(
     characters: list[Character], selected_agent_names: list[str] | None = None
 ) -> list[Unit]:
@@ -52,15 +78,20 @@ def create_player_units(
         if selected_agent_names is None
         else selected_deployable_agents(characters, selected_agent_names)
     )
-    return [
-        Unit(
-            position=(64 + i * 64, 64),
-            stats=char.stats,
-            health=char.stats.hp,
-            character=char,
+    player_units: list[Unit] = []
+    for i, char in enumerate(deployable_characters):
+        stats = equipped_player_stats(char)
+        player_units.append(
+            Unit(
+                position=(64 + i * 64, 64),
+                stats=stats,
+                health=stats.hp,
+                character=char,
+                attack_range=primary_attack_range(char),
+                available_actions=char.loadout.combat_actions(),
+            )
         )
-        for i, char in enumerate(deployable_characters)
-    ]
+    return player_units
 
 
 def create_enemy_units(

--- a/game/management/__init__.py
+++ b/game/management/__init__.py
@@ -1,5 +1,14 @@
 """Management-phase domain modules."""
 
+from .equipment import AgentLoadout, Armor, EquipmentItem, Weapon
 from .funds import CorporateFunds, FundsLedger, FundsTransaction
 
-__all__ = ["CorporateFunds", "FundsLedger", "FundsTransaction"]
+__all__ = [
+    "AgentLoadout",
+    "Armor",
+    "EquipmentItem",
+    "Weapon",
+    "CorporateFunds",
+    "FundsLedger",
+    "FundsTransaction",
+]

--- a/game/management/equipment.py
+++ b/game/management/equipment.py
@@ -1,0 +1,335 @@
+"""Small equipment models for agent loadouts.
+
+Equipment is intentionally data-only: characters own a loadout, while combat
+systems decide how those items become tactical stats or actions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+EQUIPMENT_SLOTS = (
+    "primary_weapon",
+    "sidearm",
+    "armor",
+    "utility_item",
+    "psi_focus",
+    "special_gear",
+)
+
+COMBAT_STAT_KEYS = ("defense", "psi", "str", "agi", "con", "hp", "max_hp")
+
+
+@dataclass(frozen=True)
+class EquipmentItem:
+    """Base item that can be assigned to one or more agent equipment slots."""
+
+    id: str
+    name: str
+    slot: str
+    stat_bonuses: dict[str, int] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    description: str = ""
+    allowed_slots: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        slots = self.allowed_slots or (self.slot,)
+        invalid_slots = [slot for slot in slots if slot not in EQUIPMENT_SLOTS]
+        if self.slot not in EQUIPMENT_SLOTS:
+            invalid_slots.append(self.slot)
+        if invalid_slots:
+            raise ValueError(f"Unknown equipment slot: {invalid_slots[0]}")
+        invalid_stats = [key for key in self.stat_bonuses if key not in COMBAT_STAT_KEYS]
+        if invalid_stats:
+            raise ValueError(f"Unknown equipment stat bonus: {invalid_stats[0]}")
+        object.__setattr__(self, "allowed_slots", tuple(slots))
+        object.__setattr__(self, "tags", list(self.tags))
+        object.__setattr__(self, "stat_bonuses", dict(self.stat_bonuses))
+
+    def can_equip_to(self, slot: str) -> bool:
+        """Return whether this item fits the requested loadout slot."""
+        return slot in self.allowed_slots
+
+    def to_dict(self) -> dict:
+        return {
+            "type": self.__class__.__name__,
+            "id": self.id,
+            "name": self.name,
+            "slot": self.slot,
+            "stat_bonuses": dict(self.stat_bonuses),
+            "tags": list(self.tags),
+            "description": self.description,
+            "allowed_slots": list(self.allowed_slots),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "EquipmentItem":
+        item_type = data.get("type", "EquipmentItem")
+        item_cls = {"Weapon": Weapon, "Armor": Armor}.get(item_type, EquipmentItem)
+        if item_cls is Weapon:
+            return Weapon(
+                id=data.get("id", "unknown_weapon"),
+                name=data.get("name", "Unknown weapon"),
+                slot=data.get("slot", "primary_weapon"),
+                stat_bonuses=dict(data.get("stat_bonuses", {})),
+                tags=list(data.get("tags", [])),
+                description=data.get("description", ""),
+                allowed_slots=tuple(data.get("allowed_slots", []) or ()),
+                attack_stat=data.get("attack_stat", "agi"),
+                damage_bonus=data.get("damage_bonus", 0),
+                range_cells=data.get("range_cells", 1),
+                action_name=data.get("action_name", "Attack"),
+            )
+        if item_cls is Armor:
+            return Armor(
+                id=data.get("id", "unknown_armor"),
+                name=data.get("name", "Unknown armor"),
+                slot=data.get("slot", "armor"),
+                stat_bonuses=dict(data.get("stat_bonuses", {})),
+                tags=list(data.get("tags", [])),
+                description=data.get("description", ""),
+                allowed_slots=tuple(data.get("allowed_slots", []) or ()),
+                mitigation=data.get("mitigation", 0),
+            )
+        return cls(
+            id=data.get("id", "unknown_item"),
+            name=data.get("name", "Unknown item"),
+            slot=data.get("slot", "utility_item"),
+            stat_bonuses=dict(data.get("stat_bonuses", {})),
+            tags=list(data.get("tags", [])),
+            description=data.get("description", ""),
+            allowed_slots=tuple(data.get("allowed_slots", []) or ()),
+        )
+
+
+@dataclass(frozen=True)
+class Weapon(EquipmentItem):
+    """Weapon data used by combat setup to expose an attack option."""
+
+    attack_stat: str = "agi"
+    damage_bonus: int = 0
+    range_cells: int = 1
+    action_name: str = "Attack"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.attack_stat not in {"str", "agi", "psi"}:
+            raise ValueError(f"Unsupported weapon attack stat: {self.attack_stat}")
+        if self.range_cells < 1:
+            raise ValueError("Weapon range must be at least 1 cell")
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data.update(
+            {
+                "attack_stat": self.attack_stat,
+                "damage_bonus": self.damage_bonus,
+                "range_cells": self.range_cells,
+                "action_name": self.action_name,
+            }
+        )
+        return data
+
+
+@dataclass(frozen=True)
+class Armor(EquipmentItem):
+    """Armor data used by combat setup to increase survivability."""
+
+    mitigation: int = 0
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.slot != "armor" or not self.can_equip_to("armor"):
+            raise ValueError("Armor must be equippable to the armor slot")
+        if self.mitigation < 0:
+            raise ValueError("Armor mitigation cannot be negative")
+
+    def to_dict(self) -> dict:
+        data = super().to_dict()
+        data["mitigation"] = self.mitigation
+        return data
+
+
+@dataclass
+class AgentLoadout:
+    """Equipment assigned to an agent, keyed by explicit loadout slot."""
+
+    primary_weapon: Weapon | None = None
+    sidearm: Weapon | None = None
+    armor: Armor | None = None
+    utility_item: EquipmentItem | None = None
+    psi_focus: EquipmentItem | None = None
+    special_gear: EquipmentItem | None = None
+
+    def item_for_slot(self, slot: str) -> EquipmentItem | None:
+        self._validate_slot_name(slot)
+        return getattr(self, slot)
+
+    def equip(self, slot: str, item: EquipmentItem | None) -> EquipmentItem | None:
+        """Assign an item to a slot, returning the replaced item if any."""
+        self._validate_slot_name(slot)
+        if item is not None and not item.can_equip_to(slot):
+            raise ValueError(f"{item.name} cannot be equipped to {slot}")
+        if (
+            slot in {"primary_weapon", "sidearm"}
+            and item is not None
+            and not isinstance(item, Weapon)
+        ):
+            raise ValueError(f"{slot} requires a Weapon")
+        if slot == "armor" and item is not None and not isinstance(item, Armor):
+            raise ValueError("armor requires Armor")
+        previous = getattr(self, slot)
+        setattr(self, slot, item)
+        return previous
+
+    def equipped_items(self) -> list[EquipmentItem]:
+        """Return currently assigned items in stable slot order."""
+        return [item for slot in EQUIPMENT_SLOTS if (item := getattr(self, slot))]
+
+    def total_stat_bonuses(self) -> dict[str, int]:
+        """Aggregate all stat bonuses from equipped items."""
+        totals: dict[str, int] = {}
+        for item in self.equipped_items():
+            for stat_key, amount in item.stat_bonuses.items():
+                totals[stat_key] = totals.get(stat_key, 0) + amount
+            if isinstance(item, Weapon) and item.damage_bonus:
+                totals[item.attack_stat] = (
+                    totals.get(item.attack_stat, 0) + item.damage_bonus
+                )
+            if isinstance(item, Armor) and item.mitigation:
+                totals["defense"] = totals.get("defense", 0) + item.mitigation
+        return totals
+
+    def combat_actions(self) -> list[str]:
+        """Describe equipment-provided actions for UI and battle setup."""
+        actions = ["Move", "Defend"]
+        for weapon in (self.primary_weapon, self.sidearm):
+            if weapon:
+                actions.append(weapon.action_name)
+        if self.psi_focus:
+            actions.append("Psi Focus")
+        if self.utility_item:
+            actions.append(self.utility_item.name)
+        return actions
+
+    def summary_lines(self) -> list[str]:
+        """Build compact human-readable slot lines for management UI."""
+        lines = []
+        for slot in EQUIPMENT_SLOTS:
+            item = getattr(self, slot)
+            label = slot.replace("_", " ").title()
+            lines.append(f"{label}: {item.name if item else 'Empty'}")
+        return lines
+
+    def to_dict(self) -> dict:
+        return {
+            slot: (getattr(self, slot).to_dict() if getattr(self, slot) else None)
+            for slot in EQUIPMENT_SLOTS
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | None) -> "AgentLoadout":
+        loadout = cls()
+        if not data:
+            return loadout
+        for slot in EQUIPMENT_SLOTS:
+            item_data = data.get(slot)
+            if item_data:
+                loadout.equip(slot, EquipmentItem.from_dict(item_data))
+        return loadout
+
+    @staticmethod
+    def _validate_slot_name(slot: str) -> None:
+        if slot not in EQUIPMENT_SLOTS:
+            raise ValueError(f"Unknown equipment slot: {slot}")
+
+
+def default_equipment_catalog() -> dict[str, list[EquipmentItem]]:
+    """Return a tiny starter catalog for barracks assignment actions."""
+    return {
+        "primary_weapon": [
+            Weapon(
+                "pulse_rifle",
+                "Pulse Rifle",
+                "primary_weapon",
+                {"agi": 1},
+                ["rifle"],
+                "Reliable mid-range corp rifle.",
+                ("primary_weapon",),
+                attack_stat="agi",
+                damage_bonus=1,
+                range_cells=8,
+                action_name="Rifle Burst",
+            ),
+            Weapon(
+                "monoblade",
+                "Monoblade",
+                "primary_weapon",
+                {"str": 1},
+                ["blade"],
+                "Close combat blade with a memory edge.",
+                ("primary_weapon",),
+                attack_stat="str",
+                damage_bonus=1,
+                range_cells=1,
+                action_name="Blade Strike",
+            ),
+        ],
+        "sidearm": [
+            Weapon(
+                "shock_pistol",
+                "Shock Pistol",
+                "sidearm",
+                {"agi": 1},
+                ["pistol"],
+                "Compact backup weapon.",
+                ("sidearm",),
+                attack_stat="agi",
+                damage_bonus=0,
+                range_cells=5,
+                action_name="Pistol Shot",
+            )
+        ],
+        "armor": [
+            Armor(
+                "kevlar_longcoat",
+                "Kevlar Longcoat",
+                "armor",
+                {"max_hp": 2},
+                ["coat"],
+                "Armored street coat with hidden plates.",
+                ("armor",),
+                mitigation=1,
+            )
+        ],
+        "utility_item": [
+            EquipmentItem(
+                "trauma_patch",
+                "Trauma Patch",
+                "utility_item",
+                {"hp": 1},
+                ["medical"],
+                "Emergency stabilizer carried into the zone.",
+            )
+        ],
+        "psi_focus": [
+            EquipmentItem(
+                "echo_implant",
+                "Echo Implant",
+                "psi_focus",
+                {"psi": 2},
+                ["implant", "psi"],
+                "Whispering wetware focus for psi agents.",
+            )
+        ],
+        "special_gear": [
+            EquipmentItem(
+                "ghost_cloak",
+                "Ghost Cloak",
+                "special_gear",
+                {"defense": 1},
+                ["stealth"],
+                "Corporate prototype optical smear.",
+            )
+        ],
+    }

--- a/game/unit.py
+++ b/game/unit.py
@@ -18,6 +18,7 @@ class Unit:
     attack_range: int = 1
     health: int = 3
     action_points: int = 2
+    available_actions: list[str] | None = None
     sprite: arcade.Sprite | None = None
     is_defending: bool = False
     is_psi_defending: bool = False
@@ -69,8 +70,8 @@ class Unit:
         return self._perform_attack(other, stat="str", range_=1)
 
     def shoot(self, other: "Unit") -> int:
-        """Ranged attack using agility with a 10 cell range."""
-        return self._perform_attack(other, stat="agi", range_=10)
+        """Ranged attack using agility and equipped weapon reach."""
+        return self._perform_attack(other, stat="agi", range_=max(1, self.attack_range))
 
     def psi_attack(self, other: "Unit") -> int:
         """Psi attack with a 10 cell range."""

--- a/game/views.py
+++ b/game/views.py
@@ -5,6 +5,7 @@ from .agent_aftermath import apply_mission_aftermath
 from .agent_readiness import agents_at_breaking_risk, build_agent_readiness_lines
 from .battle_outcomes import resolve_defeated_agent_outcome
 from .character import Character, is_deployable
+from .management.equipment import EQUIPMENT_SLOTS, default_equipment_catalog
 from .combat_system import (
     create_enemy_units,
     create_player_units,
@@ -68,6 +69,16 @@ def build_roster_cards(
                 "pending_points": character.pending_points,
                 "recovery_turns": character.recovery_turns,
                 "level": stats.level,
+                "primary_weapon": (
+                    character.loadout.primary_weapon.name
+                    if character.loadout.primary_weapon
+                    else "Unarmed"
+                ),
+                "armor": (
+                    character.loadout.armor.name
+                    if character.loadout.armor
+                    else "No armor"
+                ),
             }
         )
     return cards
@@ -398,6 +409,7 @@ class RPGView(GameView):
         self.pending_breakdown_confirmation = False
         self.pending_breakdown_mission_id = None
         self.deployment_cursor_index = 0
+        self.equipment_catalog = default_equipment_catalog()
         self.game_state.selected_agent_names = sanitize_selected_agent_names(
             self.game_state.characters, self.game_state.selected_agent_names
         )
@@ -667,6 +679,10 @@ class RPGView(GameView):
             self.pending_breakdown_mission_id = None
             self._refresh_squad_room_actions()
             return
+        if action_key.startswith("equip_"):
+            self._equip_active_agent(action_key.removeprefix("equip_"))
+            self._refresh_squad_room_actions()
+            return
         if action_key.startswith("level_"):
             self._level_active_agent(action_key.removeprefix("level_"))
             self._refresh_squad_room_actions()
@@ -693,6 +709,17 @@ class RPGView(GameView):
                     RoomAction("agent_next", "right", "Next agent"),
                 ]
             )
+            if room_key == "armory":
+                actions.extend(
+                    [
+                        RoomAction("equip_primary_weapon", "armory", "Primary"),
+                        RoomAction("equip_sidearm", "radar", "Sidearm"),
+                        RoomAction("equip_armor", "shield", "Armor"),
+                        RoomAction("equip_utility_item", "medical", "Utility"),
+                        RoomAction("equip_psi_focus", "research", "Psi focus"),
+                        RoomAction("equip_special_gear", "stealth", "Special"),
+                    ]
+                )
             active_agent = self._active_agent()
             if active_agent and active_agent.pending_points > 0:
                 points = active_agent.pending_points
@@ -720,6 +747,25 @@ class RPGView(GameView):
         self.room_ui.action_buttons = layout_action_buttons(
             self.window.width, self.window.height, actions
         )
+
+    def _equip_active_agent(self, slot: str) -> None:
+        """Cycle the active agent through the starter equipment catalog for a slot."""
+        active_agent = self._active_agent()
+        if not active_agent or slot not in EQUIPMENT_SLOTS:
+            return
+        options = self.equipment_catalog.get(slot, [])
+        if not options:
+            return
+        current = active_agent.loadout.item_for_slot(slot)
+        next_index = 0
+        if current:
+            for index, item in enumerate(options):
+                if item.id == current.id:
+                    next_index = (index + 1) % len(options)
+                    break
+        item = options[next_index]
+        active_agent.loadout.equip(slot, item)
+        self.message = f"{active_agent.name} equipped {item.name}."
 
     def _level_active_agent(self, stat_key: str) -> None:
         active_agent = self._active_agent()
@@ -771,21 +817,27 @@ class RPGView(GameView):
                 agent_line,
                 f"Selected squad {len(selected)}",
             ],
-            "armory": [
-                f"Selected squad {len(selected)}",
-                f"Deployable agents {sum(1 for char in self.game_state.characters if is_deployable(char))}",
-                f"Upgrade points {getattr(active_agent, 'pending_points', 0) if active_agent else 0}",
-            ],
+            "armory": (
+                [
+                    f"Selected squad {len(selected)}",
+                    f"Deployable agents {sum(1 for char in self.game_state.characters if is_deployable(char))}",
+                    f"Upgrade points {getattr(active_agent, 'pending_points', 0) if active_agent else 0}",
+                ]
+                + (active_agent.loadout.summary_lines() if active_agent else [])
+            ),
             "briefing": [
                 mission.title,
                 f"Breakdown risk agents {risk_count}",
                 f"Selected squad {len(selected)}",
             ],
-            "dossier": [
-                agent_line,
-                f"Upgrade points {getattr(active_agent, 'pending_points', 0) if active_agent else 0}",
-                f"Recovery turns {getattr(active_agent, 'recovery_turns', 0) if active_agent else 0}",
-            ],
+            "dossier": (
+                [
+                    agent_line,
+                    f"Upgrade points {getattr(active_agent, 'pending_points', 0) if active_agent else 0}",
+                    f"Recovery turns {getattr(active_agent, 'recovery_turns', 0) if active_agent else 0}",
+                ]
+                + (active_agent.loadout.summary_lines()[:3] if active_agent else [])
+            ),
             "insertion": [
                 mission.title,
                 f"Selected squad {len(selected)}",

--- a/tests/test_agent_equipment.py
+++ b/tests/test_agent_equipment.py
@@ -1,0 +1,98 @@
+"""Agent equipment loadout rules and combat integration."""
+
+import unittest
+
+from game.character import Character
+from game.combat_system import create_player_units
+from game.management.equipment import (
+    AgentLoadout,
+    Armor,
+    EquipmentItem,
+    Weapon,
+    default_equipment_catalog,
+)
+from game.stats import PlayerStats
+
+
+class AgentEquipmentTest(unittest.TestCase):
+    def test_assigning_equipment_to_valid_slots_updates_loadout(self):
+        loadout = AgentLoadout()
+        rifle = Weapon(
+            "test_rifle",
+            "Test Rifle",
+            "primary_weapon",
+            {"agi": 1},
+            allowed_slots=("primary_weapon",),
+            range_cells=7,
+            action_name="Test Burst",
+        )
+        armor = Armor(
+            "test_armor",
+            "Test Armor",
+            "armor",
+            {"max_hp": 3},
+            allowed_slots=("armor",),
+            mitigation=2,
+        )
+
+        self.assertIsNone(loadout.equip("primary_weapon", rifle))
+        self.assertIsNone(loadout.equip("armor", armor))
+
+        self.assertIs(loadout.primary_weapon, rifle)
+        self.assertIs(loadout.armor, armor)
+        self.assertEqual(loadout.total_stat_bonuses()["agi"], 1)
+        self.assertEqual(loadout.total_stat_bonuses()["defense"], 2)
+        self.assertIn("Test Burst", loadout.combat_actions())
+
+    def test_replacing_equipment_returns_previous_item(self):
+        loadout = AgentLoadout()
+        first = Weapon("first", "First", "sidearm", allowed_slots=("sidearm",))
+        second = Weapon("second", "Second", "sidearm", allowed_slots=("sidearm",))
+
+        loadout.equip("sidearm", first)
+        replaced = loadout.equip("sidearm", second)
+
+        self.assertIs(replaced, first)
+        self.assertIs(loadout.sidearm, second)
+
+    def test_validating_equipment_rejects_wrong_slot_and_type(self):
+        loadout = AgentLoadout()
+        armor = Armor("coat", "Coat", "armor", allowed_slots=("armor",))
+        utility = EquipmentItem("patch", "Patch", "utility_item")
+
+        with self.assertRaises(ValueError):
+            loadout.equip("primary_weapon", armor)
+        with self.assertRaises(ValueError):
+            loadout.equip("armor", utility)
+        with self.assertRaises(ValueError):
+            loadout.equip("unknown_slot", utility)
+
+    def test_character_serializes_loadout_without_losing_item_types(self):
+        catalog = default_equipment_catalog()
+        character = Character("Echo")
+        character.loadout.equip("primary_weapon", catalog["primary_weapon"][0])
+        character.loadout.equip("armor", catalog["armor"][0])
+
+        restored = Character.from_dict(character.to_dict())
+
+        self.assertIsInstance(restored.loadout.primary_weapon, Weapon)
+        self.assertIsInstance(restored.loadout.armor, Armor)
+        self.assertEqual(restored.loadout.primary_weapon.name, "Pulse Rifle")
+        self.assertEqual(restored.loadout.armor.name, "Kevlar Longcoat")
+
+    def test_create_player_units_applies_weapon_and_armor_bonuses(self):
+        character = Character("Kite", stats=PlayerStats(agi=2, defense=1))
+        catalog = default_equipment_catalog()
+        character.loadout.equip("primary_weapon", catalog["primary_weapon"][0])
+        character.loadout.equip("armor", catalog["armor"][0])
+
+        unit = create_player_units([character])[0]
+
+        self.assertEqual(character.stats.agi, 2)
+        self.assertGreater(unit.stats.agi, character.stats.agi)
+        self.assertGreater(unit.stats.defense, character.stats.defense)
+        self.assertEqual(unit.attack_range, 8)
+        self.assertIn("Rifle Burst", unit.available_actions)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a small, modular equipment slice so agents can hold explicit loadouts (weapons, armor, utility, psi focus, special gear) without moving combat logic into the `Character` model. 
- Make equipment data-driven so combat setup and UI can read bonuses and available actions, preserving separation of concerns and scope control. 
- Provide a minimal starter catalog and barracks/armory UI affordances so gear can be inspected and assigned in the RPG view.

### Description
- Add `game/management/equipment.py` with `EquipmentItem`, `Weapon`, `Armor`, `AgentLoadout`, `EQUIPMENT_SLOTS`, and `default_equipment_catalog` including validation, (de)serialization, stat-aggregation, and `combat_actions` summaries. 
- Extend `Character` in `game/character.py` to include a persisted `loadout: AgentLoadout` while keeping behavior in combat systems. 
- Update combat creation in `game/combat_system.py` to copy agent stats with loadout bonuses via `equipped_player_stats`, compute `primary_attack_range` from equipped weapons, and expose equipment actions on `Unit` instances. 
- Extend `Unit` (`game/unit.py`) with `available_actions` and make ranged `shoot` use the unit's `attack_range`. 
- Add armory UI support in `game/views.py` to show loadout summary lines, provide an `equipment_catalog`, and add `equip_*` actions that cycle starter items onto the active agent. 
- Add tests `tests/test_agent_equipment.py` covering assignment, replacement, validation, serialization, and combat integration. 
- Update `docs/backlog.md` and `docs/roadmap.md` to mark the equipment/loadout slice and related design notes.

### Testing
- Ran targeted tests with `python3 -m pytest tests/test_agent_equipment.py` which passed (`5 passed`).
- Ran the full test suite with `python3 -m pytest` which completed successfully (`87 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078d2917b0832b8fee2a885926a927)