### PR TITLE
Add strategic calendar management

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -13,6 +13,7 @@ TODO:
 [x] Fix pending-upgrade roster card rendering
 [x] Add click-select squad cards with generated portraits and point counters
 [x] Create dedicated corporate funds ledger and show available funds in command UI
+[x] Add strategic calendar with daily income, pending fallout, and recovery ticks
 [x] Add compact agent equipment loadouts with primary, sidearm, armor, utility, psi focus, and special gear slots
 [x] Create Agent data model
 [ ] Create district data model
@@ -48,6 +49,9 @@ Done:
 - Corporate funds ledger: the global game state now owns a small funds module
   tracking available cash, income, expenses, and transaction history for
   management decisions.
+- Strategic calendar: GameState now owns a small campaign calendar that advances
+  after mission success/failure or manual command-deck orders, then ticks passive
+  income, pending fallout review, weekly planning beats, and agent recovery.
 - Agent equipment loadouts: characters now reference modular loadouts with
   explicit weapon, armor, utility, psi focus, and special gear slots; combat
   setup reads those items for stat/action adjustments while the character model

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,9 @@
     badges/buttons for leveling.
   - Progress: Corporate management now has a dedicated funds ledger owned by
     GameState, with available funds shown in command HUD and room info.
+  - Progress: Strategic time now has a small calendar owned by GameState;
+    resolved missions and manual command-deck day advances trigger daily income,
+    pending fallout review, weekly planning beats, and recovery timers.
   - Progress: Agent barracks now supports a small modular equipment slice: each
     agent has loadout slots for primary weapon, sidearm, armor, utility item,
     psi focus/implant, and special gear, and combat unit creation applies those

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -6,6 +6,7 @@ from typing import List, TYPE_CHECKING
 
 from .consequences import Consequence, create_opening_consequence
 from .factions import Faction, create_vertical_slice_factions
+from .management.calendar import StrategicCalendar
 from .management.funds import CorporateFunds
 from .mission_templates import MissionTemplate, create_mission_templates
 from .operations import Operation, create_operation_templates
@@ -79,6 +80,7 @@ class GameState:
 
     # Turn management
     turn: int = 1
+    calendar: StrategicCalendar = field(default_factory=StrategicCalendar)
     funds: CorporateFunds = field(default_factory=CorporateFunds)
     budget_pool: int = 0
 
@@ -194,8 +196,8 @@ class GameState:
             self.strategic_resources[resource_key] -= amount
         return True
 
-    def advance_turn(self) -> None:
-        """Move to the next turn, tick recovery timers, and refresh the budget."""
+    def advance_one_day(self, reason: str = "manual") -> None:
+        """Move the shared strategic clock one day and process daily systems."""
         recovered_agents = []
         for character in self.characters:
             if character.recovery_turns > 0:
@@ -203,18 +205,42 @@ class GameState:
                 if character.recovery_turns == 0:
                     recovered_agents.append(character.name)
 
-        self.turn += 1
+        self.calendar.advance_one_day()
+        self.turn = self.calendar.current_day
         income = self.compute_budget()
         self.add_funds(
             income,
-            "turn_refresh",
-            f"Turn {self.turn} operating funds for {self.base_name}.",
+            "daily_income",
+            f"{self.calendar.campaign_date_label} passive income for {self.base_name}.",
         )
         self.add_event(
-            f"Turn {self.turn}: Corporate funds refreshed by {income} for {self.base_name}."
+            f"{self.calendar.campaign_date_label}: Day advanced ({reason}); "
+            f"passive income +{income}."
         )
+        if self.recent_consequences:
+            self.add_event(
+                f"{self.calendar.campaign_date_label}: Pending fallout reviewed "
+                f"({len(self.recent_consequences)} active beats)."
+            )
+        if self.calendar.is_new_week:
+            self.add_event(
+                f"Week {self.calendar.current_week}: Strategic planning cycle opens."
+            )
         for name in recovered_agents:
-            self.add_event(f"Turn {self.turn}: {name} is deployable after recovery.")
+            self.add_event(
+                f"{self.calendar.campaign_date_label}: {name} is deployable after recovery."
+            )
+
+    def advance_days(self, days: int, reason: str = "manual") -> None:
+        """Advance multiple days while preserving daily income and recovery ticks."""
+        if days < 0:
+            raise ValueError("days must be non-negative")
+        for _ in range(days):
+            self.advance_one_day(reason)
+
+    def advance_turn(self) -> None:
+        """Backward-compatible wrapper for one strategic day."""
+        self.advance_one_day("turn refresh")
 
     def add_event(self, text: str) -> None:
         """Append a compact event-log entry and retain only the latest beats."""
@@ -288,6 +314,7 @@ class GameState:
     def save(self, path: str):
         data = {
             "turn": self.turn,
+            "calendar": self.calendar.to_dict(),
             "budget_pool": self.budget_pool,
             "funds": self.funds.to_dict(),
             "corp_budget": self.corp_budget,
@@ -326,7 +353,11 @@ class GameState:
         gs.corp_budget.update(data.get("corp_budget", {}))
         gs.city_budget.update(data.get("city_budget", {}))
         gs.strategic_resources.update(data.get("strategic_resources", {}))
-        gs.turn = data.get("turn", 1)
+        gs.calendar = StrategicCalendar.from_dict(data.get("calendar"))
+        gs.turn = data.get("turn", gs.calendar.current_day)
+        if "calendar" not in data:
+            gs.calendar.current_day = max(1, int(gs.turn))
+            gs.calendar._last_week = gs.calendar.current_week
         if "funds" in data:
             gs.funds = CorporateFunds.from_dict(data["funds"])
             gs.budget_pool = gs.funds.available_funds

--- a/game/management/calendar.py
+++ b/game/management/calendar.py
@@ -1,0 +1,86 @@
+"""Strategic campaign calendar for management-phase pacing.
+
+The calendar is intentionally small: it tracks day-scale campaign time so
+mission fallout, passive funding, and agent recovery all move from one shared
+clock instead of separate UI-only turns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class StrategicCalendar:
+    """Track campaign day, week, month, and a readable date label."""
+
+    current_day: int = 1
+    days_per_week: int = 7
+    days_per_month: int = 30
+    era_label: str = "2085"
+    _last_week: int = field(default=1, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.current_day = max(1, int(self.current_day))
+        self.days_per_week = max(1, int(self.days_per_week))
+        self.days_per_month = max(self.days_per_week, int(self.days_per_month))
+        self._last_week = self.current_week
+
+    @property
+    def current_week(self) -> int:
+        """Return the one-indexed campaign week for the current day."""
+        return ((self.current_day - 1) // self.days_per_week) + 1
+
+    @property
+    def current_month(self) -> int:
+        """Return the one-indexed campaign month for the current day."""
+        return ((self.current_day - 1) // self.days_per_month) + 1
+
+    @property
+    def day_of_month(self) -> int:
+        """Return the one-indexed day inside the current campaign month."""
+        return ((self.current_day - 1) % self.days_per_month) + 1
+
+    @property
+    def campaign_date_label(self) -> str:
+        """Return a compact in-world label for dashboards and logs."""
+        return f"{self.era_label}.M{self.current_month:02d}.D{self.day_of_month:02d}"
+
+    @property
+    def is_new_week(self) -> bool:
+        """Return whether the most recent advancement crossed into a new week."""
+        return self.current_week != self._last_week
+
+    def advance_days(self, days: int) -> None:
+        """Advance the calendar by a positive number of days."""
+        if days < 0:
+            raise ValueError("days must be non-negative")
+        if days == 0:
+            self._last_week = self.current_week
+            return
+        self._last_week = self.current_week
+        self.current_day += int(days)
+
+    def advance_one_day(self) -> None:
+        """Advance the calendar exactly one campaign day."""
+        self.advance_days(1)
+
+    def to_dict(self) -> dict:
+        """Serialize the strategic calendar for save files."""
+        return {
+            "current_day": self.current_day,
+            "days_per_week": self.days_per_week,
+            "days_per_month": self.days_per_month,
+            "era_label": self.era_label,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | None) -> "StrategicCalendar":
+        """Restore a calendar from save data, tolerating older save files."""
+        data = data or {}
+        return cls(
+            current_day=int(data.get("current_day", 1)),
+            days_per_week=int(data.get("days_per_week", 7)),
+            days_per_month=int(data.get("days_per_month", 30)),
+            era_label=str(data.get("era_label", "2085")),
+        )

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -86,4 +86,5 @@ def resolve_mission_outcome(
         game_state.add_event(f"Complication triggered: {complication.trigger_text}")
 
     game_state.active_mission = None
+    game_state.advance_one_day("mission success" if victory else "mission failure")
     return complication

--- a/game/ui/command_deck.py
+++ b/game/ui/command_deck.py
@@ -114,3 +114,8 @@ def build_ops_table_header(mission: MissionTemplate | None, district_name: str) 
         f"{district_name.upper()} // {objective_label(mission.objective_type)} // "
         f"RISK {mission.risk_level} {risk_label(mission.risk_level).upper()}"
     )
+
+
+def build_calendar_status_line(date_label: str, day: int, week: int) -> str:
+    """Build a small command-deck calendar prompt for manual day advancement."""
+    return f"{date_label} // DAY {day} // WEEK {week} // D ADVANCE DAY"

--- a/game/ui/dashboard.py
+++ b/game/ui/dashboard.py
@@ -58,13 +58,15 @@ def build_command_status_line(
     resources: dict[str, int],
     district: District,
     available_funds: int | None = None,
+    campaign_date_label: str | None = None,
 ) -> str:
     """Build the top-line command HUD status for Corp and City screens."""
     funds_text = (
         f"FUNDS {available_funds} // " if available_funds is not None else ""
     )
+    date_text = f"{campaign_date_label} // " if campaign_date_label else ""
     return (
-        f"TURN {turn} // {base_name} // "
+        f"TURN {turn} // {date_text}{base_name} // "
         f"{funds_text}"
         f"{build_resource_summary_line(resources)} // "
         f"DISTRICT PRESSURE {district_pressure_severity(district)}"

--- a/game/ui/room_interaction.py
+++ b/game/ui/room_interaction.py
@@ -70,7 +70,10 @@ class RoomUIState:
 
 ROOM_ACTIONS = {
     "corp": {
-        "executive": [RoomAction("politics", "influence", "Fund politics")],
+        "executive": [
+            RoomAction("advance_day", "city", "Advance day"),
+            RoomAction("politics", "influence", "Fund politics"),
+        ],
         "research": [RoomAction("research", "research", "Fund research")],
         "security": [RoomAction("security", "shield", "Fund security")],
         "black_ops": [
@@ -88,7 +91,10 @@ ROOM_ACTIONS = {
         ],
     },
     "city": {
-        "municipal": [RoomAction("garrisons", "shield", "Fund garrisons")],
+        "municipal": [
+            RoomAction("advance_day", "city", "Advance day"),
+            RoomAction("garrisons", "shield", "Fund garrisons"),
+        ],
         "district": [RoomAction("defense_zones", "radar", "Fund zones")],
         "transit": [RoomAction("armaments", "armory", "Fund arms")],
         "factions": [RoomAction("garrisons", "shield", "Fund garrisons")],

--- a/game/views.py
+++ b/game/views.py
@@ -147,6 +147,8 @@ class CorpView(GameView):
             rpg_view = RPGView(self.game_state)
             rpg_view.setup()
             self.window.show_view(rpg_view)
+        elif key == arcade.key.D:
+            self.game_state.advance_one_day("manual command")
         elif key in self.CORP_UPGRADE_COSTS:
             budget_key, costs = self.CORP_UPGRADE_COSTS[key]
             self._buy_corp_upgrade(budget_key, costs)
@@ -187,6 +189,9 @@ class CorpView(GameView):
             city_view.setup()
             self.window.show_view(city_view)
             return
+        if action_key == "advance_day":
+            self.game_state.advance_one_day("manual command")
+            return
         if action_key == "squad":
             rpg_view = RPGView(self.game_state)
             rpg_view.setup()
@@ -212,6 +217,7 @@ class CorpView(GameView):
         resources = self.game_state.strategic_resources
         return {
             "executive": [
+                f"{self.game_state.calendar.campaign_date_label} | Day {self.game_state.calendar.current_day}",
                 f"Turn {self.game_state.turn} | Funds {self.game_state.available_funds}",
                 f"Politics allocation {self.game_state.corp_budget['politics']}",
                 f"Influence reserve {resources.get('influence', 0)}",
@@ -239,8 +245,8 @@ class CorpView(GameView):
             ],
             "logistics": [
                 f"Credits {resources.get('credits', 0)} | Salvage {resources.get('salvage', 0)}",
-                f"Budget refresh target {self.game_state.compute_budget()}",
-                "Supply stock feeds security and field readiness.",
+                f"Daily income target {self.game_state.compute_budget()}",
+                "D / Advance day ticks income, events, recovery.",
             ],
             "server": [
                 f"Intel reserve {resources.get('intel', 0)}",
@@ -306,6 +312,8 @@ class CityView(GameView):
             rpg_view = RPGView(self.game_state)
             rpg_view.setup()
             self.window.show_view(rpg_view)
+        elif key == arcade.key.D:
+            self.game_state.advance_one_day("manual command")
         elif key in self.CITY_UPGRADE_COSTS:
             budget_key, costs = self.CITY_UPGRADE_COSTS[key]
             self._buy_city_upgrade(budget_key, costs)
@@ -340,6 +348,9 @@ class CityView(GameView):
             rpg_view.setup()
             self.window.show_view(rpg_view)
             return
+        if action_key == "advance_day":
+            self.game_state.advance_one_day("manual command")
+            return
         costs = self.CITY_UPGRADE_ACTIONS.get(action_key)
         if costs:
             self._buy_city_upgrade(action_key, costs)
@@ -356,6 +367,7 @@ class CityView(GameView):
         hostility = factions[0].hostility_to_player if factions else 0
         return {
             "municipal": [
+                f"{self.game_state.calendar.campaign_date_label} | Week {self.game_state.calendar.current_week}",
                 f"District {district.name}",
                 f"Control faction {district.control_faction}",
                 f"Garrisons network {self.game_state.city_budget['garrisons']}",
@@ -387,6 +399,7 @@ class CityView(GameView):
             ],
             "records": [
                 f"Recent events {len(self.game_state.event_log)}",
+                "D / Advance day reviews pending fallout.",
                 f"District tags {len(district.tags)}",
                 "Records preserve consequences for later systems.",
             ],

--- a/tests/test_calendar_management.py
+++ b/tests/test_calendar_management.py
@@ -1,0 +1,104 @@
+"""Strategic calendar and day-advance management flow."""
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from game.character import Character
+from game.gamestate import GameState
+from game.management.calendar import StrategicCalendar
+from game.mission_system import resolve_mission_outcome
+from game.mission_templates import MissionTemplate
+from game.ui.command_deck import build_calendar_status_line
+from game.ui.room_interaction import ROOM_ACTIONS
+
+
+def _mission() -> MissionTemplate:
+    return MissionTemplate(
+        id="calendar_test",
+        title="Calendar Test",
+        objective_text="Prove time moves after the operation.",
+        target_faction="Clockwork Saints",
+        district="Chrome Warrens",
+        district_pressure={},
+        starting_enemy_count=1,
+        risk_level=1,
+    )
+
+
+class CalendarManagementTest(unittest.TestCase):
+    def test_strategic_calendar_tracks_day_week_month_and_label(self):
+        calendar = StrategicCalendar()
+
+        calendar.advance_days(7)
+
+        self.assertEqual(calendar.current_day, 8)
+        self.assertEqual(calendar.current_week, 2)
+        self.assertEqual(calendar.current_month, 1)
+        self.assertEqual(calendar.campaign_date_label, "2085.M01.D08")
+        self.assertTrue(calendar.is_new_week)
+
+    def test_game_state_manual_day_advance_triggers_income_events_and_recovery(self):
+        agent = Character("Stitch", recovery_turns=1)
+        game_state = GameState(characters=[agent])
+        starting_funds = game_state.available_funds
+
+        game_state.advance_one_day("manual command")
+
+        self.assertEqual(game_state.calendar.current_day, 2)
+        self.assertEqual(game_state.turn, 2)
+        self.assertGreater(game_state.available_funds, starting_funds)
+        self.assertEqual(agent.recovery_turns, 0)
+        self.assertTrue(
+            any("passive income" in event for event in game_state.event_log)
+        )
+        self.assertTrue(
+            any("Pending fallout reviewed" in event for event in game_state.event_log)
+        )
+        self.assertTrue(
+            any("Stitch is deployable after recovery" in event for event in game_state.event_log)
+        )
+
+    def test_mission_resolution_advances_calendar_on_success_and_failure(self):
+        success_state = GameState()
+        failure_state = GameState()
+
+        resolve_mission_outcome(success_state, _mission(), True)
+        resolve_mission_outcome(failure_state, _mission(), False)
+
+        self.assertEqual(success_state.calendar.current_day, 2)
+        self.assertEqual(failure_state.calendar.current_day, 2)
+        self.assertTrue(
+            any("mission success" in event for event in success_state.event_log)
+        )
+        self.assertTrue(
+            any("mission failure" in event for event in failure_state.event_log)
+        )
+
+    def test_calendar_serializes_through_game_state_save(self):
+        game_state = GameState()
+        game_state.advance_days(3, "test")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_path = Path(temp_dir) / "savegame.json"
+            game_state.save(str(save_path))
+            loaded = GameState.load(str(save_path))
+
+        self.assertEqual(loaded.calendar.current_day, 4)
+        self.assertEqual(loaded.calendar.campaign_date_label, "2085.M01.D04")
+        self.assertEqual(loaded.turn, 4)
+
+    def test_command_deck_exposes_manual_advance_day_action(self):
+        corp_actions = [action.key for action in ROOM_ACTIONS["corp"]["executive"]]
+        city_actions = [action.key for action in ROOM_ACTIONS["city"]["municipal"]]
+        status_line = build_calendar_status_line("2085.M01.D02", 2, 1)
+
+        self.assertIn("advance_day", corp_actions)
+        self.assertIn("advance_day", city_actions)
+        self.assertIn("D ADVANCE DAY", status_line)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Introduce a small, shared campaign clock so mission resolution and manual corporate actions drive a single strategic cadence for passive income, fallout review, and recovery.  
- Expose a manual “advance day” control in the corporate/city command UI so operators can step the strategic clock without leaving the management flow.

### Description

- Add `StrategicCalendar` dataclass (`game/management/calendar.py`) providing `current_day`, `current_week`, `current_month`, `campaign_date_label`, `advance_days`, `advance_one_day`, `is_new_week`, and save/load support.  
- Integrate calendar into `GameState` (`game/gamestate.py`) with `calendar: StrategicCalendar`, `advance_one_day(reason: str)`, `advance_days(days, reason)`, and a backwards-compatible `advance_turn()` wrapper; daily advancement now ticks recovery, awards passive income, records pending-fallout/events, and emits weekly planning events.  
- Advance the calendar automatically when missions resolve by one day on both success and failure (`game/mission_system.py`).  
- Expose manual day-advance in UI: add `advance_day` room action to corp/city room actions (`game/ui/room_interaction.py`), keyboard shortcut `D` and room-action handling to `CorpView`/`CityView` (`game/views.py`), and a small calendar status helper for the command deck (`game/ui/command_deck.py`).  
- Surface campaign date on HUD lines via `build_command_status_line` signature change (`game/ui/dashboard.py`).  
- Add tests covering calendar math, manual day-advance side effects, mission-driven advancement, save/load roundtrip, and the UI action exposure (`tests/test_calendar_management.py`).  
- Update `docs/backlog.md` and `docs/roadmap.md` to reflect the new strategic calendar work.

### Testing

- Ran the new calendar unit tests: `pytest -q tests/test_calendar_management.py` and they passed.  
- Ran a broader suite to ensure integration with existing systems: `python -m pytest -q` and all tests passed (92 passed).  
- Basic static checks/compilation performed via `python -m py_compile` during development and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078f464a70832bba0d0e4081996a5e)