### PR TITLE
Add mission fund rewards and post-mission allocation

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -15,6 +15,7 @@ TODO:
 [x] Create dedicated corporate funds ledger and show available funds in command UI
 [x] Add strategic calendar with daily income, pending fallout, and recovery ticks
 [x] Add compact agent equipment loadouts with primary, sidearm, armor, utility, psi focus, and special gear slots
+[x] Add mission fund rewards with default post-mission allocation
 [x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -48,7 +49,9 @@ Done:
   remaining upgrade points, and use 24 generated portrait assets.
 - Corporate funds ledger: the global game state now owns a small funds module
   tracking available cash, income, expenses, and transaction history for
-  management decisions.
+  management decisions. Mission successes now add fund rewards through that
+  ledger and automatically split payouts into agent morale, research,
+  equipment, maintenance, and reserves.
 - Strategic calendar: GameState now owns a small campaign calendar that advances
   after mission success/failure or manual command-deck orders, then ticks passive
   income, pending fallout review, weekly planning beats, and agent recovery.
@@ -59,4 +62,5 @@ Done:
 - City/corporate tactical command deck: RPG View has separate agent barracks,
   operations table, intel lab, and medbay/fallout panels over the tower base.
 - Mission UI: RPG view mission board has selectable rows plus a selected-mission
-  detail panel for launch pressure, complications, tags, and outcome stakes.
+  detail panel for launch pressure, fund rewards, complications, tags, and
+  outcome stakes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,8 @@
 # Phase 1
 - Cool and smart UI
   - Progress: Mission Board now shows selectable missions, objective type, risk,
-    pressure, complications, and success/failure stakes before launch.
+    fund rewards, pressure, complications, and success/failure stakes before
+    launch.
   - Progress: RPG View now uses a focused city/corporate command tower: agent
     barracks, operations table, intel lab, and medbay/fallout floors for a more
     tactical XCOM-like planning mood without changing combat systems.
@@ -31,6 +32,9 @@
     badges/buttons for leveling.
   - Progress: Corporate management now has a dedicated funds ledger owned by
     GameState, with available funds shown in command HUD and room info.
+    Successful missions now pay a small `fund_reward` through the ledger and
+    auto-allocate it across agent morale/pay, research, equipment,
+    robot/power-armor maintenance, and corporate reserves.
   - Progress: Strategic time now has a small calendar owned by GameState;
     resolved missions and manual command-deck day advances trigger daily income,
     pending fallout review, weekly planning beats, and recovery timers.

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -7,7 +7,12 @@ from typing import List, TYPE_CHECKING
 from .consequences import Consequence, create_opening_consequence
 from .factions import Faction, create_vertical_slice_factions
 from .management.calendar import StrategicCalendar
-from .management.funds import CorporateFunds
+from .management.funds import (
+    MISSION_FUND_CATEGORIES,
+    CorporateFunds,
+    calculate_mission_fund_reward,
+    default_mission_fund_distribution,
+)
 from .mission_templates import MissionTemplate, create_mission_templates
 from .operations import Operation, create_operation_templates
 from .world import District, create_vertical_slice_district
@@ -38,6 +43,11 @@ class GameState:
             "salvage": 0,
             "influence": 0,
         }
+    )
+
+    # Post-mission cash allocations reserved for named command categories.
+    mission_fund_allocations: dict = field(
+        default_factory=lambda: {key: 0 for key in MISSION_FUND_CATEGORIES}
     )
 
     # Management data for the city phase
@@ -171,6 +181,44 @@ class GameState:
         else:
             self.add_event("Extraction failed: no strategic resources recovered.")
         return rewards
+
+    def award_mission_funds(
+        self, mission: MissionTemplate | None, victory: bool
+    ) -> dict[str, int]:
+        """Add mission cash to the ledger, then apply a small default split."""
+        reward = calculate_mission_fund_reward(mission, victory)
+        if reward <= 0:
+            return {}
+
+        mission_title = getattr(mission, "title", "mission")
+        if not self.add_funds(
+            reward,
+            "mission_reward",
+            f"{mission_title} success payout.",
+        ):
+            return {}
+
+        distribution = default_mission_fund_distribution(reward)
+        for category, amount in distribution.items():
+            if amount <= 0:
+                continue
+            self.mission_fund_allocations[category] = (
+                self.mission_fund_allocations.get(category, 0) + amount
+            )
+            if category != "corporate_reserves":
+                self.spend_funds(
+                    amount,
+                    f"mission_{category}",
+                    f"Post-mission allocation from {mission_title}.",
+                )
+
+        summary = ", ".join(
+            f"{category.replace('_', ' ')} +{amount}"
+            for category, amount in distribution.items()
+            if amount > 0
+        )
+        self.add_event(f"Mission funds secured: +{reward}; allocation {summary}.")
+        return {key: value for key, value in distribution.items() if value > 0}
 
     def spend_resource(self, resource_key: str, amount: int) -> bool:
         """Spend one strategic resource safely when enough stock is available."""
@@ -320,6 +368,7 @@ class GameState:
             "corp_budget": self.corp_budget,
             "city_budget": self.city_budget,
             "strategic_resources": self.strategic_resources,
+            "mission_fund_allocations": self.mission_fund_allocations,
             "characters": [c.to_dict() for c in self.characters],
             "x": self.x,
             "base_name": self.base_name,
@@ -353,6 +402,9 @@ class GameState:
         gs.corp_budget.update(data.get("corp_budget", {}))
         gs.city_budget.update(data.get("city_budget", {}))
         gs.strategic_resources.update(data.get("strategic_resources", {}))
+        gs.mission_fund_allocations.update(
+            data.get("mission_fund_allocations", {})
+        )
         gs.calendar = StrategicCalendar.from_dict(data.get("calendar"))
         gs.turn = data.get("turn", gs.calendar.current_day)
         if "calendar" not in data:

--- a/game/management/__init__.py
+++ b/game/management/__init__.py
@@ -1,7 +1,13 @@
 """Management-phase domain modules."""
 
 from .equipment import AgentLoadout, Armor, EquipmentItem, Weapon
-from .funds import CorporateFunds, FundsLedger, FundsTransaction
+from .funds import (
+    CorporateFunds,
+    FundsLedger,
+    FundsTransaction,
+    calculate_mission_fund_reward,
+    default_mission_fund_distribution,
+)
 
 __all__ = [
     "AgentLoadout",
@@ -11,4 +17,6 @@ __all__ = [
     "CorporateFunds",
     "FundsLedger",
     "FundsTransaction",
+    "calculate_mission_fund_reward",
+    "default_mission_fund_distribution",
 ]

--- a/game/management/funds.py
+++ b/game/management/funds.py
@@ -9,6 +9,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+MISSION_FUND_CATEGORIES = (
+    "agent_pay_morale",
+    "research",
+    "equipment",
+    "robot_power_armor_maintenance",
+    "corporate_reserves",
+)
+
+DEFAULT_MISSION_FUND_SPLIT = {
+    "agent_pay_morale": 25,
+    "research": 25,
+    "equipment": 20,
+    "robot_power_armor_maintenance": 15,
+    "corporate_reserves": 15,
+}
+
 
 @dataclass(frozen=True)
 class FundsTransaction:
@@ -105,6 +121,31 @@ class CorporateFunds:
                 for transaction in data.get("transaction_history", [])
             ],
         )
+
+
+def calculate_mission_fund_reward(mission: object | None, victory: bool) -> int:
+    """Return the cash payout for a resolved mission."""
+    if not victory or mission is None:
+        return 0
+    return max(0, int(getattr(mission, "fund_reward", 0)))
+
+
+def default_mission_fund_distribution(amount: int) -> dict[str, int]:
+    """Split a payout across small post-mission allocation categories."""
+    amount = max(0, int(amount))
+    distribution = {key: 0 for key in MISSION_FUND_CATEGORIES}
+    if amount <= 0:
+        return distribution
+
+    allocated = 0
+    for key in MISSION_FUND_CATEGORIES:
+        if key == "corporate_reserves":
+            continue
+        share = amount * DEFAULT_MISSION_FUND_SPLIT[key] // 100
+        distribution[key] = share
+        allocated += share
+    distribution["corporate_reserves"] = amount - allocated
+    return distribution
 
 
 FundsLedger = CorporateFunds

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -77,6 +77,8 @@ def resolve_mission_outcome(
     for consequence in consequences:
         game_state.apply_consequence(consequence)
 
+    game_state.award_mission_funds(mission, victory)
+
     complication = pick_complication(mission, triggered_complication)
     if complication:
         consequence = complication.consequence

--- a/game/mission_templates.py
+++ b/game/mission_templates.py
@@ -57,6 +57,7 @@ class MissionTemplate:
     success_consequences: list[Consequence] = field(default_factory=list)
     failure_consequences: list[Consequence] = field(default_factory=list)
     risk_level: int = 1
+    fund_reward: int = 0
     tags: list[SavageTag] = field(default_factory=list)
 
     def to_dict(self) -> dict:
@@ -79,6 +80,7 @@ class MissionTemplate:
                 consequence.to_dict() for consequence in self.failure_consequences
             ],
             "risk_level": self.risk_level,
+            "fund_reward": self.fund_reward,
             "tags": [tag.to_dict() for tag in self.tags],
         }
 
@@ -110,6 +112,7 @@ class MissionTemplate:
                 for consequence in data.get("failure_consequences", [])
             ],
             risk_level=data.get("risk_level", 1),
+            fund_reward=int(data.get("fund_reward", 0)),
             tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
         )
 
@@ -199,6 +202,7 @@ def create_mission_templates(
                 )
             ],
             risk_level=2,
+            fund_reward=40,
             tags=[tag_from_library("neon_blackout")],
         ),
         MissionTemplate(
@@ -232,6 +236,7 @@ def create_mission_templates(
                 )
             ],
             risk_level=4,
+            fund_reward=70,
             tags=[tag_from_library("gang_pressure")],
         ),
         MissionTemplate(
@@ -265,6 +270,7 @@ def create_mission_templates(
                 )
             ],
             risk_level=3,
+            fund_reward=60,
             tags=[tag_from_library("ghost_signal"), tag_from_library("media_swarm")],
         ),
     ]

--- a/game/ui/mission_board.py
+++ b/game/ui/mission_board.py
@@ -94,6 +94,7 @@ def build_mission_board_lines(
             f"{prefix}{index + 1}. {mission.title} | "
             f"{objective_label(mission.objective_type)} | "
             f"Risk {mission.risk_level} ({risk_label(mission.risk_level)}) | "
+            f"Reward {mission.fund_reward} funds | "
             f"{mission.target_faction} | Enemies {mission.starting_enemy_count}"
         )
     return lines
@@ -107,6 +108,7 @@ def build_selected_mission_lines(mission: MissionTemplate | None) -> list[str]:
     return [
         f"Objective: {mission.objective_text}",
         f"District: {mission.district} | Pressure: {_pressure_summary(mission.district_pressure)}",
+        f"Fund Reward: {mission.fund_reward} corporate funds",
         f"Tags: {_tag_names(mission.tags)}",
         f"Complications: {_complication_names(mission.possible_complications)}",
         _outcome_line("Success", mission.success_consequences),

--- a/tests/test_mission_board_ui.py
+++ b/tests/test_mission_board_ui.py
@@ -27,6 +27,7 @@ class MissionBoardUITest(unittest.TestCase):
         self.assertTrue(lines[1].startswith(">2. Sabotage: Jackal Relay Burn"))
         self.assertIn("SABOTAGE", lines[1])
         self.assertIn("Risk 4 (severe)", lines[1])
+        self.assertIn("Reward 70 funds", lines[1])
         self.assertTrue(lines[0].startswith(" 1. Extraction: Neon Witness"))
 
     def test_selected_mission_lines_show_pressure_complications_and_stakes(self):
@@ -36,11 +37,12 @@ class MissionBoardUITest(unittest.TestCase):
 
         self.assertIn("Objective: Extract a clinic witness", lines[0])
         self.assertIn("Pressure: Unrest +3, Media Heat +2", lines[1])
-        self.assertEqual(lines[2], "Tags: neon_blackout")
-        self.assertIn("Media Leak", lines[3])
-        self.assertIn("Civilian Panic", lines[3])
-        self.assertIn("Success: Warrens Free Clinic", lines[4])
-        self.assertIn("Failure: Chrome Jackals", lines[5])
+        self.assertEqual(lines[2], "Fund Reward: 40 corporate funds")
+        self.assertEqual(lines[3], "Tags: neon_blackout")
+        self.assertIn("Media Leak", lines[4])
+        self.assertIn("Civilian Panic", lines[4])
+        self.assertIn("Success: Warrens Free Clinic", lines[5])
+        self.assertIn("Failure: Chrome Jackals", lines[6])
 
     def test_empty_mission_board_has_operator_guidance(self):
         self.assertEqual(build_mission_board_lines([], 0), ["No missions available."])

--- a/tests/test_mission_funds.py
+++ b/tests/test_mission_funds.py
@@ -1,0 +1,96 @@
+"""Mission cash reward and post-mission distribution rules."""
+
+import unittest
+
+from game.gamestate import GameState
+from game.management.funds import (
+    calculate_mission_fund_reward,
+    default_mission_fund_distribution,
+)
+from game.mission_system import resolve_mission_outcome
+from game.mission_templates import MissionTemplate
+
+
+def _mission(fund_reward=80) -> MissionTemplate:
+    return MissionTemplate(
+        id="fund_test",
+        title="Fund Test",
+        objective_text="Recover a city contract cache.",
+        target_faction="Ledger Saints",
+        district="Chrome Warrens",
+        district_pressure={},
+        starting_enemy_count=1,
+        risk_level=2,
+        fund_reward=fund_reward,
+    )
+
+
+class MissionFundsTest(unittest.TestCase):
+    def test_reward_calculation_requires_victory_and_positive_reward(self):
+        mission = _mission(fund_reward=80)
+
+        self.assertEqual(calculate_mission_fund_reward(mission, True), 80)
+        self.assertEqual(calculate_mission_fund_reward(mission, False), 0)
+        self.assertEqual(
+            calculate_mission_fund_reward(_mission(fund_reward=-5), True), 0
+        )
+
+    def test_default_distribution_keeps_every_reward_dollar_allocated(self):
+        distribution = default_mission_fund_distribution(80)
+
+        self.assertEqual(sum(distribution.values()), 80)
+        self.assertEqual(distribution["agent_pay_morale"], 20)
+        self.assertEqual(distribution["research"], 20)
+        self.assertEqual(distribution["equipment"], 16)
+        self.assertEqual(distribution["robot_power_armor_maintenance"], 12)
+        self.assertEqual(distribution["corporate_reserves"], 12)
+
+    def test_successful_resolution_awards_and_distributes_through_ledger(self):
+        game_state = GameState()
+        starting_funds = game_state.available_funds
+
+        resolve_mission_outcome(game_state, _mission(fund_reward=80), True)
+
+        self.assertEqual(game_state.mission_fund_allocations["agent_pay_morale"], 20)
+        self.assertEqual(game_state.mission_fund_allocations["research"], 20)
+        self.assertEqual(game_state.mission_fund_allocations["equipment"], 16)
+        self.assertEqual(
+            game_state.mission_fund_allocations["robot_power_armor_maintenance"],
+            12,
+        )
+        self.assertEqual(game_state.mission_fund_allocations["corporate_reserves"], 12)
+        self.assertGreater(game_state.available_funds, starting_funds)
+        self.assertTrue(
+            any(
+                transaction.source == "mission_reward"
+                for transaction in game_state.funds.transaction_history
+            )
+        )
+        self.assertTrue(
+            any("Mission funds secured" in event for event in game_state.event_log)
+        )
+
+    def test_failed_resolution_does_not_pay_mission_reward(self):
+        game_state = GameState()
+        starting_income = game_state.funds.income
+
+        resolve_mission_outcome(game_state, _mission(fund_reward=80), False)
+
+        self.assertEqual(
+            game_state.mission_fund_allocations,
+            {
+                "agent_pay_morale": 0,
+                "research": 0,
+                "equipment": 0,
+                "robot_power_armor_maintenance": 0,
+                "corporate_reserves": 0,
+            },
+        )
+        self.assertEqual(
+            game_state.funds.income,
+            starting_income + game_state.compute_budget(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small, modular funds flow for mission payouts so mission resolution uses the corporate funds ledger instead of mutating raw state. 
- Allow missions to declare a `fund_reward` and enable simple post-mission allocation into meaningful categories (agent pay/morale, research, equipment, maintenance, reserves).
- Surface fund rewards in the mission board UI and persist allocations so management decisions can use them.

### Description
- Added `fund_reward: int` to `MissionTemplate` with `to_dict`/`from_dict` save/load support and seeded the three vertical-slice templates with initial `fund_reward` values (`40`, `70`, `60`).
- Extended `game/management/funds.py` with `MISSION_FUND_CATEGORIES`, `DEFAULT_MISSION_FUND_SPLIT`, `calculate_mission_fund_reward`, and `default_mission_fund_distribution` to compute payouts and split them into categories.
- Added `GameState.mission_fund_allocations` to track allocated post-mission funds and `GameState.award_mission_funds` which credits mission income to the `CorporateFunds` ledger, applies the default split, spends non-reserve shares through the ledger, records allocations, and logs a summary.
- Wired the mission resolution path to call `award_mission_funds` from `game/mission_system.py` after applying mission consequences.
- Updated `game/ui/mission_board.py` to display mission fund rewards in mission rows and the selected-mission detail panel.
- Added `tests/test_mission_funds.py` covering reward calculation, default distribution, ledger-backed distribution on success, and non-payment on failure; updated `tests/test_mission_board_ui.py` expectations to include reward display.
- Updated `docs/backlog.md` and `docs/roadmap.md` to reflect the new mission fund reward and automatic allocation feature.

### Testing
- Ran the test suite with `PYTHONPATH=. pytest -q` and verified: all tests passed (full run: `96 passed`).
- Ran the focused tests used during development: `PYTHONPATH=. pytest -q tests/test_mission_funds.py tests/test_mission_board_ui.py tests/test_calendar_management.py tests/test_strategic_resources.py` and confirmed they passed.
- Confirmed `pycompile`/lint-style checks during development; no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079164ccf0832b8745eb3817fe4fe6)