### PR TITLE
Add weekly recurring corporate funding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ python main.py
 - Action buttons include short labels for recruit, level-up, navigation, and
   launch actions
 - `Esc` closes the open room and returns to the base map
-- Each turn grants funds to invest in the corporation
+- Each day grants passive operating funds; crossing into a new strategic week
+  also deposits projected corporate funding based on stipend, city support,
+  political pressure, and upkeep
+- Corporate rooms show the next weekly income date and projected payment
 - `1-4` add funds to research, security, politics and black ops
 - Budget is refreshed automatically when all funds are spent
 - `S` save game / `L` load game

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,6 +16,7 @@ TODO:
 [x] Add strategic calendar with daily income, pending fallout, and recovery ticks
 [x] Add compact agent equipment loadouts with primary, sidearm, armor, utility, psi focus, and special gear slots
 [x] Add mission fund rewards with default post-mission allocation
+[x] Add weekly recurring corporate funding tied to the strategic calendar
 [x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -55,6 +56,10 @@ Done:
 - Strategic calendar: GameState now owns a small campaign calendar that advances
   after mission success/failure or manual command-deck orders, then ticks passive
   income, pending fallout review, weekly planning beats, and agent recovery.
+- Weekly corporate funding: a small corporation finance model projects recurring
+  stipends after city support, political pressure, and upkeep; crossing into a
+  new strategic week deposits that funding through the funds ledger and displays
+  the next payment date in corporate management rooms.
 - Agent equipment loadouts: characters now reference modular loadouts with
   explicit weapon, armor, utility, psi focus, and special gear slots; combat
   setup reads those items for stat/action adjustments while the character model

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,9 @@
   - Progress: Strategic time now has a small calendar owned by GameState;
     resolved missions and manual command-deck day advances trigger daily income,
     pending fallout review, weekly planning beats, and recovery timers.
+  - Progress: Corporate finance now has a weekly recurring funding model: the
+    calendar pays the funds ledger whenever a new week opens, after stipend,
+    city-support, political-pressure, and upkeep calculations.
   - Progress: Agent barracks now supports a small modular equipment slice: each
     agent has loadout slots for primary weapon, sidearm, armor, utility item,
     psi focus/implant, and special gear, and combat unit creation applies those

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -7,6 +7,7 @@ from typing import List, TYPE_CHECKING
 from .consequences import Consequence, create_opening_consequence
 from .factions import Faction, create_vertical_slice_factions
 from .management.calendar import StrategicCalendar
+from .management.corporation import CorporationFinance
 from .management.funds import (
     MISSION_FUND_CATEGORIES,
     CorporateFunds,
@@ -92,6 +93,9 @@ class GameState:
     turn: int = 1
     calendar: StrategicCalendar = field(default_factory=StrategicCalendar)
     funds: CorporateFunds = field(default_factory=CorporateFunds)
+    corporation_finance: CorporationFinance = field(
+        default_factory=CorporationFinance
+    )
     budget_pool: int = 0
 
     def __post_init__(self) -> None:
@@ -143,6 +147,29 @@ class GameState:
             self.corp_budget[key] += amount
             return True
         return False
+
+    @property
+    def projected_weekly_income(self) -> int:
+        """Return the next corporate funding payment before it is collected."""
+        return self.corporation_finance.projected_weekly_income()
+
+    @property
+    def next_weekly_income_date(self) -> str:
+        """Return the campaign date label for the next weekly funding payment."""
+        return self.corporation_finance.next_income_date_label(self.calendar)
+
+    def collect_weekly_corporate_funding(self) -> int:
+        """Apply the corporation finance model to the funds ledger."""
+        amount = self.corporation_finance.apply_weekly_income(
+            self.funds, self.calendar
+        )
+        if amount > 0:
+            self.budget_pool = self.funds.available_funds
+            self.add_event(
+                f"Week {self.calendar.current_week}: corporate funding +{amount} "
+                f"(next {self.next_weekly_income_date})."
+            )
+        return amount
 
     def award_mission_resources(
         self, mission: MissionTemplate | None, victory: bool, defeated: int
@@ -271,8 +298,10 @@ class GameState:
                 f"({len(self.recent_consequences)} active beats)."
             )
         if self.calendar.is_new_week:
+            weekly_income = self.collect_weekly_corporate_funding()
             self.add_event(
-                f"Week {self.calendar.current_week}: Strategic planning cycle opens."
+                f"Week {self.calendar.current_week}: Strategic planning cycle opens "
+                f"with corporate funding +{weekly_income}."
             )
         for name in recovered_agents:
             self.add_event(
@@ -365,6 +394,7 @@ class GameState:
             "calendar": self.calendar.to_dict(),
             "budget_pool": self.budget_pool,
             "funds": self.funds.to_dict(),
+            "corporation_finance": self.corporation_finance.to_dict(),
             "corp_budget": self.corp_budget,
             "city_budget": self.city_budget,
             "strategic_resources": self.strategic_resources,
@@ -416,6 +446,9 @@ class GameState:
         else:
             gs.budget_pool = data.get("budget_pool", gs.compute_budget())
             gs.funds = CorporateFunds(current_funds=gs.budget_pool)
+        gs.corporation_finance = CorporationFinance.from_dict(
+            data.get("corporation_finance")
+        )
         gs.x = data.get("x", 0)
         gs.base_name = data.get("base_name", gs.base_name)
         gs.district = District.from_dict(data.get("district", gs.district.to_dict()))

--- a/game/management/__init__.py
+++ b/game/management/__init__.py
@@ -1,5 +1,6 @@
 """Management-phase domain modules."""
 
+from .corporation import CorporationFinance
 from .equipment import AgentLoadout, Armor, EquipmentItem, Weapon
 from .funds import (
     CorporateFunds,
@@ -10,6 +11,7 @@ from .funds import (
 )
 
 __all__ = [
+    "CorporationFinance",
     "AgentLoadout",
     "Armor",
     "EquipmentItem",

--- a/game/management/calendar.py
+++ b/game/management/calendar.py
@@ -44,7 +44,19 @@ class StrategicCalendar:
     @property
     def campaign_date_label(self) -> str:
         """Return a compact in-world label for dashboards and logs."""
-        return f"{self.era_label}.M{self.current_month:02d}.D{self.day_of_month:02d}"
+        return self.date_label_for_day(self.current_day)
+
+    @property
+    def next_week_start_day(self) -> int:
+        """Return the campaign day that opens the next weekly cycle."""
+        return self.current_week * self.days_per_week + 1
+
+    def date_label_for_day(self, day: int) -> str:
+        """Return the compact in-world label for an arbitrary campaign day."""
+        day = max(1, int(day))
+        month = ((day - 1) // self.days_per_month) + 1
+        day_of_month = ((day - 1) % self.days_per_month) + 1
+        return f"{self.era_label}.M{month:02d}.D{day_of_month:02d}"
 
     @property
     def is_new_week(self) -> bool:

--- a/game/management/corporation.py
+++ b/game/management/corporation.py
@@ -1,0 +1,75 @@
+"""Small corporation finance rules for recurring management funding.
+
+The model is intentionally narrow: the calendar decides *when* a new week
+opens, and this module decides *how much* support the corporation receives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .calendar import StrategicCalendar
+from .funds import CorporateFunds
+
+
+@dataclass
+class CorporationFinance:
+    """Recurring weekly funding profile for the player's corporation."""
+
+    weekly_stipend: int = 75
+    city_support_modifier: float = 0.10
+    political_pressure_modifier: float = -0.05
+    debt_upkeep: int = 15
+
+    def projected_weekly_income(self) -> int:
+        """Return the next net weekly payment after modifiers and upkeep."""
+        modifier = 1 + self.city_support_modifier + self.political_pressure_modifier
+        gross_income = round(self.weekly_stipend * modifier)
+        return max(0, gross_income - self.debt_upkeep)
+
+    def next_income_day(self, calendar: StrategicCalendar) -> int:
+        """Return the campaign day when the next weekly payment will arrive."""
+        return calendar.next_week_start_day
+
+    def next_income_date_label(self, calendar: StrategicCalendar) -> str:
+        """Return a readable date label for the next weekly payment."""
+        return calendar.date_label_for_day(self.next_income_day(calendar))
+
+    def apply_weekly_income(
+        self,
+        ledger: CorporateFunds,
+        calendar: StrategicCalendar,
+        source: str = "weekly_corporate_funding",
+    ) -> int:
+        """Add this week's corporation funding to the ledger and return it."""
+        amount = self.projected_weekly_income()
+        if amount <= 0:
+            return 0
+        ledger.add_funds(
+            amount,
+            source,
+            f"Week {calendar.current_week} corporate funding cycle.",
+        )
+        return amount
+
+    def to_dict(self) -> dict:
+        """Serialize recurring finance settings for save files."""
+        return {
+            "weekly_stipend": self.weekly_stipend,
+            "city_support_modifier": self.city_support_modifier,
+            "political_pressure_modifier": self.political_pressure_modifier,
+            "debt_upkeep": self.debt_upkeep,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | None) -> "CorporationFinance":
+        """Restore finance settings while tolerating older save files."""
+        data = data or {}
+        return cls(
+            weekly_stipend=int(data.get("weekly_stipend", 75)),
+            city_support_modifier=float(data.get("city_support_modifier", 0.10)),
+            political_pressure_modifier=float(
+                data.get("political_pressure_modifier", -0.05)
+            ),
+            debt_upkeep=int(data.get("debt_upkeep", 15)),
+        )

--- a/game/ui/command_deck.py
+++ b/game/ui/command_deck.py
@@ -119,3 +119,13 @@ def build_ops_table_header(mission: MissionTemplate | None, district_name: str) 
 def build_calendar_status_line(date_label: str, day: int, week: int) -> str:
     """Build a small command-deck calendar prompt for manual day advancement."""
     return f"{date_label} // DAY {day} // WEEK {week} // D ADVANCE DAY"
+
+
+def build_corporate_finance_lines(
+    next_income_date: str, projected_income: int
+) -> list[str]:
+    """Build compact recurring-funding copy for corporate management rooms."""
+    return [
+        f"Next weekly income {next_income_date}",
+        f"Projected income +{max(0, int(projected_income))} funds",
+    ]

--- a/game/views.py
+++ b/game/views.py
@@ -45,6 +45,7 @@ from .mission_system import (
 from .mission_templates import MissionTemplate
 from .recruitment import recruit_agent
 from .ui import GameView
+from .ui.command_deck import build_corporate_finance_lines
 from .unit import Unit
 
 
@@ -215,10 +216,15 @@ class CorpView(GameView):
 
     def _room_info_lines(self) -> dict[str, list[str]]:
         resources = self.game_state.strategic_resources
+        finance_lines = build_corporate_finance_lines(
+            self.game_state.next_weekly_income_date,
+            self.game_state.projected_weekly_income,
+        )
         return {
             "executive": [
                 f"{self.game_state.calendar.campaign_date_label} | Day {self.game_state.calendar.current_day}",
                 f"Turn {self.game_state.turn} | Funds {self.game_state.available_funds}",
+                *finance_lines,
                 f"Politics allocation {self.game_state.corp_budget['politics']}",
                 f"Influence reserve {resources.get('influence', 0)}",
             ],
@@ -246,6 +252,7 @@ class CorpView(GameView):
             "logistics": [
                 f"Credits {resources.get('credits', 0)} | Salvage {resources.get('salvage', 0)}",
                 f"Daily income target {self.game_state.compute_budget()}",
+                *finance_lines,
                 "D / Advance day ticks income, events, recovery.",
             ],
             "server": [

--- a/tests/test_weekly_corporate_funding.py
+++ b/tests/test_weekly_corporate_funding.py
@@ -1,0 +1,94 @@
+"""Weekly recurring corporate funding tied to the strategic calendar."""
+
+import unittest
+
+from game.gamestate import GameState
+from game.management.corporation import CorporationFinance
+from game.ui.command_deck import build_corporate_finance_lines
+
+
+class WeeklyCorporateFundingTest(unittest.TestCase):
+    def test_one_week_advance_adds_weekly_corporate_funding_once(self):
+        game_state = GameState(
+            corporation_finance=CorporationFinance(
+                weekly_stipend=100,
+                city_support_modifier=0.20,
+                political_pressure_modifier=-0.10,
+                debt_upkeep=15,
+            )
+        )
+        starting_funds = game_state.available_funds
+
+        game_state.advance_days(6, "test")
+
+        self.assertEqual(game_state.calendar.current_day, 7)
+        self.assertEqual(
+            [
+                transaction
+                for transaction in game_state.funds.transaction_history
+                if transaction.source == "weekly_corporate_funding"
+            ],
+            [],
+        )
+
+        game_state.advance_one_day("test")
+
+        weekly_transactions = [
+            transaction
+            for transaction in game_state.funds.transaction_history
+            if transaction.source == "weekly_corporate_funding"
+        ]
+        self.assertEqual(game_state.calendar.current_day, 8)
+        self.assertEqual(game_state.calendar.current_week, 2)
+        self.assertEqual(len(weekly_transactions), 1)
+        self.assertEqual(weekly_transactions[0].amount, 95)
+        self.assertEqual(
+            game_state.available_funds,
+            starting_funds + game_state.compute_budget() * 7 + 95,
+        )
+        self.assertTrue(
+            any("corporate funding +95" in event for event in game_state.event_log)
+        )
+
+    def test_multi_week_advance_collects_each_crossed_week(self):
+        game_state = GameState(
+            corporation_finance=CorporationFinance(
+                weekly_stipend=80,
+                city_support_modifier=0.25,
+                political_pressure_modifier=0.0,
+                debt_upkeep=10,
+            )
+        )
+
+        game_state.advance_days(14, "test")
+
+        weekly_transactions = [
+            transaction
+            for transaction in game_state.funds.transaction_history
+            if transaction.source == "weekly_corporate_funding"
+        ]
+        self.assertEqual(game_state.calendar.current_day, 15)
+        self.assertEqual(game_state.calendar.current_week, 3)
+        self.assertEqual(
+            [transaction.amount for transaction in weekly_transactions], [90, 90]
+        )
+        self.assertIn("Week 2", weekly_transactions[0].note)
+        self.assertIn("Week 3", weekly_transactions[1].note)
+
+    def test_corporate_management_finance_copy_exposes_next_date_and_projection(self):
+        game_state = GameState(
+            corporation_finance=CorporationFinance(weekly_stipend=50, debt_upkeep=5)
+        )
+
+        lines = build_corporate_finance_lines(
+            game_state.next_weekly_income_date,
+            game_state.projected_weekly_income,
+        )
+
+        self.assertEqual(game_state.next_weekly_income_date, "2085.M01.D08")
+        self.assertIn("Next weekly income 2085.M01.D08", lines)
+        self.assertIn("Projected income +47 funds", lines)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Introduce recurring weekly corporate income so the funds ledger receives scheduled corporate support when the strategic calendar opens a new week.  
- Keep the implementation small and modular: separate finance model, calendar helpers, GameState integration, UI copy and tests.

### Description

- Add `game/management/corporation.py` with `CorporationFinance` (fields: `weekly_stipend`, `city_support_modifier`, `political_pressure_modifier`, `debt_upkeep`), projection, `apply_weekly_income`, and save/load helpers.  
- Extend `game/management/calendar.py` with `date_label_for_day` and `next_week_start_day` to expose the next weekly income date.  
- Integrate into `GameState` (`game/gamestate.py`) by adding `corporation_finance`, `collect_weekly_corporate_funding`, and properties `projected_weekly_income` and `next_weekly_income_date`, and trigger collection when `calendar.is_new_week` is true; persist finance settings in `save`/`load`.  
- Add UI helpers and presentation: `build_corporate_finance_lines` in `game/ui/command_deck.py` and show next income date/projected income in corporate management room info (`game/views.py`).  
- Add tests `tests/test_weekly_corporate_funding.py` covering one-week and multi-week advancement and UI copy; update `game/management/__init__.py`, `README.md`, `docs/backlog.md`, and `docs/roadmap.md` to reflect the feature.

### Testing

- Ran the full test suite with `PYTHONPATH=. pytest -q`, all tests passed (`99 passed`).  
- New tests in `tests/test_weekly_corporate_funding.py` were executed and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07932039b0832bbeec742c734e4d21)