### PR TITLE
Add mission duration calendar pacing

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -17,6 +17,7 @@ TODO:
 [x] Add compact agent equipment loadouts with primary, sidearm, armor, utility, psi focus, and special gear slots
 [x] Add mission fund rewards with default post-mission allocation
 [x] Add weekly recurring corporate funding tied to the strategic calendar
+[x] Add mission duration days to mission templates, board UI, and calendar resolution
 [x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -68,4 +69,8 @@ Done:
   operations table, intel lab, and medbay/fallout panels over the tower base.
 - Mission UI: RPG view mission board has selectable rows plus a selected-mission
   detail panel for launch pressure, fund rewards, complications, tags, and
-  outcome stakes.
+  outcome stakes. Mission templates now carry `duration_days` (defaulting to
+  one day), and the board shows that operation duration before launch.
+- Mission duration pacing: mission resolution advances the strategic calendar by
+  the mission's `duration_days`, so existing generated missions consume one
+  campaign day while later templates can opt into longer operations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Phase 1
 - Cool and smart UI
   - Progress: Mission Board now shows selectable missions, objective type, risk,
-    fund rewards, pressure, complications, and success/failure stakes before
-    launch.
+    fund rewards, duration, pressure, complications, and success/failure stakes
+    before launch.
   - Progress: RPG View now uses a focused city/corporate command tower: agent
     barracks, operations table, intel lab, and medbay/fallout floors for a more
     tactical XCOM-like planning mood without changing combat systems.
@@ -36,8 +36,10 @@
     auto-allocate it across agent morale/pay, research, equipment,
     robot/power-armor maintenance, and corporate reserves.
   - Progress: Strategic time now has a small calendar owned by GameState;
-    resolved missions and manual command-deck day advances trigger daily income,
-    pending fallout review, weekly planning beats, and recovery timers.
+    resolved missions advance by each mission's `duration_days` (one day for
+    existing generated missions), while manual command-deck day advances trigger
+    daily income, pending fallout review, weekly planning beats, and recovery
+    timers.
   - Progress: Corporate finance now has a weekly recurring funding model: the
     calendar pays the funds ledger whenever a new week opens, after stipend,
     city-support, political-pressure, and upkeep calculations.

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -88,5 +88,8 @@ def resolve_mission_outcome(
         game_state.add_event(f"Complication triggered: {complication.trigger_text}")
 
     game_state.active_mission = None
-    game_state.advance_one_day("mission success" if victory else "mission failure")
+    duration_days = max(1, int(getattr(mission, "duration_days", 1)))
+    game_state.advance_days(
+        duration_days, "mission success" if victory else "mission failure"
+    )
     return complication

--- a/game/mission_templates.py
+++ b/game/mission_templates.py
@@ -58,6 +58,7 @@ class MissionTemplate:
     failure_consequences: list[Consequence] = field(default_factory=list)
     risk_level: int = 1
     fund_reward: int = 0
+    duration_days: int = 1
     tags: list[SavageTag] = field(default_factory=list)
 
     def to_dict(self) -> dict:
@@ -81,6 +82,7 @@ class MissionTemplate:
             ],
             "risk_level": self.risk_level,
             "fund_reward": self.fund_reward,
+            "duration_days": max(1, int(self.duration_days)),
             "tags": [tag.to_dict() for tag in self.tags],
         }
 
@@ -113,6 +115,7 @@ class MissionTemplate:
             ],
             risk_level=data.get("risk_level", 1),
             fund_reward=int(data.get("fund_reward", 0)),
+            duration_days=max(1, int(data.get("duration_days", 1))),
             tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
         )
 

--- a/game/ui/mission_board.py
+++ b/game/ui/mission_board.py
@@ -95,6 +95,7 @@ def build_mission_board_lines(
             f"{objective_label(mission.objective_type)} | "
             f"Risk {mission.risk_level} ({risk_label(mission.risk_level)}) | "
             f"Reward {mission.fund_reward} funds | "
+            f"Duration: {mission.duration_days} day{'s' if mission.duration_days != 1 else ''} | "
             f"{mission.target_faction} | Enemies {mission.starting_enemy_count}"
         )
     return lines
@@ -109,6 +110,7 @@ def build_selected_mission_lines(mission: MissionTemplate | None) -> list[str]:
         f"Objective: {mission.objective_text}",
         f"District: {mission.district} | Pressure: {_pressure_summary(mission.district_pressure)}",
         f"Fund Reward: {mission.fund_reward} corporate funds",
+        f"Duration: {mission.duration_days} day{'s' if mission.duration_days != 1 else ''}",
         f"Tags: {_tag_names(mission.tags)}",
         f"Complications: {_complication_names(mission.possible_complications)}",
         _outcome_line("Success", mission.success_consequences),

--- a/tests/test_mission_board_ui.py
+++ b/tests/test_mission_board_ui.py
@@ -28,6 +28,7 @@ class MissionBoardUITest(unittest.TestCase):
         self.assertIn("SABOTAGE", lines[1])
         self.assertIn("Risk 4 (severe)", lines[1])
         self.assertIn("Reward 70 funds", lines[1])
+        self.assertIn("Duration: 1 day", lines[1])
         self.assertTrue(lines[0].startswith(" 1. Extraction: Neon Witness"))
 
     def test_selected_mission_lines_show_pressure_complications_and_stakes(self):
@@ -38,11 +39,12 @@ class MissionBoardUITest(unittest.TestCase):
         self.assertIn("Objective: Extract a clinic witness", lines[0])
         self.assertIn("Pressure: Unrest +3, Media Heat +2", lines[1])
         self.assertEqual(lines[2], "Fund Reward: 40 corporate funds")
-        self.assertEqual(lines[3], "Tags: neon_blackout")
-        self.assertIn("Media Leak", lines[4])
-        self.assertIn("Civilian Panic", lines[4])
-        self.assertIn("Success: Warrens Free Clinic", lines[5])
-        self.assertIn("Failure: Chrome Jackals", lines[6])
+        self.assertEqual(lines[3], "Duration: 1 day")
+        self.assertEqual(lines[4], "Tags: neon_blackout")
+        self.assertIn("Media Leak", lines[5])
+        self.assertIn("Civilian Panic", lines[5])
+        self.assertIn("Success: Warrens Free Clinic", lines[6])
+        self.assertIn("Failure: Chrome Jackals", lines[7])
 
     def test_empty_mission_board_has_operator_guidance(self):
         self.assertEqual(build_mission_board_lines([], 0), ["No missions available."])

--- a/tests/test_mission_duration.py
+++ b/tests/test_mission_duration.py
@@ -1,0 +1,83 @@
+"""Mission duration defaults and calendar advancement rules."""
+
+import unittest
+
+from game.gamestate import GameState
+from game.mission_system import launch_selected_mission, resolve_mission_outcome
+from game.mission_templates import MissionTemplate, create_mission_templates
+
+
+def _mission(duration_days: int | None = None) -> MissionTemplate:
+    kwargs = {}
+    if duration_days is not None:
+        kwargs["duration_days"] = duration_days
+    return MissionTemplate(
+        id="duration_test",
+        title="Duration Test",
+        objective_text="Validate calendar pacing.",
+        target_faction="Clockwork Saints",
+        district="Chrome Warrens",
+        district_pressure={},
+        starting_enemy_count=1,
+        risk_level=1,
+        **kwargs,
+    )
+
+
+class MissionDurationTest(unittest.TestCase):
+    def test_generated_missions_default_to_one_day(self):
+        missions = create_mission_templates("Chrome Warrens")
+
+        self.assertTrue(missions)
+        self.assertTrue(all(mission.duration_days == 1 for mission in missions))
+        self.assertTrue(
+            all(mission.to_dict()["duration_days"] == 1 for mission in missions)
+        )
+
+    def test_launching_and_resolving_selected_mission_advances_exactly_one_day(self):
+        game_state = GameState(mission_templates=[_mission()])
+        starting_day = game_state.calendar.current_day
+
+        mission = launch_selected_mission(game_state)
+        resolve_mission_outcome(game_state, mission, True)
+
+        self.assertEqual(game_state.calendar.current_day, starting_day + 1)
+        self.assertEqual(game_state.turn, starting_day + 1)
+
+    def test_direct_resolution_advances_by_default_mission_duration(self):
+        game_state = GameState()
+        starting_day = game_state.calendar.current_day
+
+        resolve_mission_outcome(game_state, _mission(duration_days=1), False)
+
+        self.assertEqual(game_state.calendar.current_day, starting_day + 1)
+        self.assertEqual(game_state.turn, starting_day + 1)
+
+    def test_resolution_respects_explicit_duration_override(self):
+        game_state = GameState()
+        starting_day = game_state.calendar.current_day
+
+        resolve_mission_outcome(game_state, _mission(duration_days=2), True)
+
+        self.assertEqual(game_state.calendar.current_day, starting_day + 2)
+        self.assertEqual(game_state.turn, starting_day + 2)
+
+    def test_duration_serialization_defaults_old_missions_to_one_day(self):
+        mission = MissionTemplate.from_dict(
+            {
+                "id": "legacy",
+                "title": "Legacy Mission",
+                "objective_text": "Restore an old save mission.",
+                "target_faction": "Chrome Jackals",
+                "district": "Chrome Warrens",
+                "district_pressure": {},
+                "starting_enemy_count": 1,
+            }
+        )
+
+        self.assertEqual(mission.duration_days, 1)
+        self.assertEqual(mission.to_dict()["duration_days"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce explicit mission durations so operations can consume multiple campaign days while preserving current one-day pacing for existing missions.
- Surface duration information in the mission board UI so operators can see how long an operation will occupy the strategic calendar.
- Ensure new field is safe across save/load and legacy data by defaulting/clamping to one day.

### Description
- Added a `duration_days: int = 1` field to `MissionTemplate` with `to_dict`/`from_dict` serialization and `max(1, int(...))` clamping for safety (`game/mission_templates.py`).
- Updated mission resolution to advance the strategic calendar by `mission.duration_days` using `GameState.advance_days(...)` instead of always advancing a single day (`game/mission_system.py`).
- Updated mission board list rows and selected-mission detail to display `Duration: X day(s)` and default generated missions show `Duration: 1 day` (`game/ui/mission_board.py`).
- Added `tests/test_mission_duration.py` to verify generated templates default to one day, launching+resolving advances the calendar by one day, explicit overrides are respected, and legacy mission dictionaries default to one day; adjusted `tests/test_mission_board_ui.py` to assert the new UI line.
- Updated documentation and backlog entries to note the `duration_days` addition and calendar-pacing behavior (`docs/backlog.md`, `docs/roadmap.md`).

### Testing
- Ran the full test suite with `python -m pytest -q` and observed a green run: all tests passed (final run: `104 passed`).
- Ran the new targeted tests `tests/test_mission_duration.py` and `tests/test_mission_board_ui.py` which passed locally as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07947a0024832b8c14643bc5dd1e6f)