### PR TITLE
Add strategic event system

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ python main.py
 - Each day grants passive operating funds; crossing into a new strategic week
   also deposits projected corporate funding based on stipend, city support,
   political pressure, and upkeep
+- Advancing the calendar can roll unresolved strategic events from city pressure,
+  faction hostility, or weighted threat odds, including enemy corporation
+  attacks, mutant invasions, Starvers outbreaks, social unrest, corporate
+  politics, and city politics
 - Corporate rooms show the next weekly income date and projected payment
 - `1-4` add funds to research, security, politics and black ops
 - Budget is refreshed automatically when all funds are spent
@@ -40,8 +44,10 @@ python main.py
 
 ### City View
 - City control tower presents budget networks, district pressure meters, faction
-  pressure and operations feed over the same image-backed corporate base
+  pressure, active strategic events, and operations feed over the same
+  image-backed corporate base
 - Click city rooms to expand them and use icon buttons for investment actions
+  or the first active event response choices shown in the records room
 - `7-9` allocate city budget
 
 ### RPG View

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -18,6 +18,7 @@ TODO:
 [x] Add mission fund rewards with default post-mission allocation
 [x] Add weekly recurring corporate funding tied to the strategic calendar
 [x] Add mission duration days to mission templates, board UI, and calendar resolution
+[x] Add small strategic event deck for corporate, mutant, Starvers, social, and political threats
 [x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -74,3 +75,8 @@ Done:
 - Mission duration pacing: mission resolution advances the strategic calendar by
   the mission's `duration_days`, so existing generated missions consume one
   campaign day while later templates can opt into longer operations.
+- Strategic events: calendar pressure can now surface unresolved command events
+  across enemy corporation attacks, mutant invasions, Starvers outbreaks, social
+  unrest, corporate politics, and city politics. Events expire if ignored, and
+  response choices can touch funds, agent stress, faction hostility, city
+  stability/unrest, and temporary mission availability.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,10 @@
     agent has loadout slots for primary weapon, sidearm, armor, utility item,
     psi focus/implant, and special gear, and combat unit creation applies those
     bonuses without hard-coding combat behavior into Character.
+  - Progress: Strategic event management now rolls a compact pressure-based
+    threat deck when the calendar advances, stores active unresolved events in
+    GameState, and exposes command choices that trade funds, agent stress,
+    faction pressure, city stability, and mission availability.
 - District system
 - Mission generation
 - Black ops
@@ -61,5 +65,7 @@
 
 # Phase 3
 - Corporate politics
+  - Progress: Board and municipal pressure now appears through the first small
+    strategic event deck rather than a large separate politics simulation.
 - Dynamic factions
 - Consequences

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -8,6 +8,12 @@ from .consequences import Consequence, create_opening_consequence
 from .factions import Faction, create_vertical_slice_factions
 from .management.calendar import StrategicCalendar
 from .management.corporation import CorporationFinance
+from .management.events import (
+    ActiveEvent,
+    apply_event_choice,
+    expire_events,
+    roll_random_event,
+)
 from .management.funds import (
     MISSION_FUND_CATEGORIES,
     CorporateFunds,
@@ -85,6 +91,9 @@ class GameState:
             "Turn 1: Forward Base Kilo establishes overwatch in the Chrome Warrens."
         ]
     )
+    active_events: list[ActiveEvent] = field(default_factory=list)
+    next_event_id: int = 1
+    unavailable_mission_ids: list[str] = field(default_factory=list)
 
     # Experience points gained through battles
     x: int = 0
@@ -93,9 +102,7 @@ class GameState:
     turn: int = 1
     calendar: StrategicCalendar = field(default_factory=StrategicCalendar)
     funds: CorporateFunds = field(default_factory=CorporateFunds)
-    corporation_finance: CorporationFinance = field(
-        default_factory=CorporationFinance
-    )
+    corporation_finance: CorporationFinance = field(default_factory=CorporationFinance)
     budget_pool: int = 0
 
     def __post_init__(self) -> None:
@@ -160,9 +167,7 @@ class GameState:
 
     def collect_weekly_corporate_funding(self) -> int:
         """Apply the corporation finance model to the funds ledger."""
-        amount = self.corporation_finance.apply_weekly_income(
-            self.funds, self.calendar
-        )
+        amount = self.corporation_finance.apply_weekly_income(self.funds, self.calendar)
         if amount > 0:
             self.budget_pool = self.funds.available_funds
             self.add_event(
@@ -303,6 +308,8 @@ class GameState:
                 f"Week {self.calendar.current_week}: Strategic planning cycle opens "
                 f"with corporate funding +{weekly_income}."
             )
+        expire_events(self)
+        roll_random_event(self)
         for name in recovered_agents:
             self.add_event(
                 f"{self.calendar.campaign_date_label}: {name} is deployable after recovery."
@@ -318,6 +325,14 @@ class GameState:
     def advance_turn(self) -> None:
         """Backward-compatible wrapper for one strategic day."""
         self.advance_one_day("turn refresh")
+
+    def roll_strategic_event(self, rng=None) -> ActiveEvent | None:
+        """Roll the management event deck for the current calendar day."""
+        return roll_random_event(self, rng)
+
+    def respond_to_event(self, event_id: str, choice_key: str) -> bool:
+        """Resolve an active event with a command choice."""
+        return apply_event_choice(self, event_id, choice_key)
 
     def add_event(self, text: str) -> None:
         """Append a compact event-log entry and retain only the latest beats."""
@@ -420,6 +435,9 @@ class GameState:
             ],
             "latest_agent_aftermath": list(self.latest_agent_aftermath),
             "event_log": list(self.event_log),
+            "active_events": [event.to_dict() for event in self.active_events],
+            "next_event_id": self.next_event_id,
+            "unavailable_mission_ids": list(self.unavailable_mission_ids),
         }
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
@@ -432,9 +450,7 @@ class GameState:
         gs.corp_budget.update(data.get("corp_budget", {}))
         gs.city_budget.update(data.get("city_budget", {}))
         gs.strategic_resources.update(data.get("strategic_resources", {}))
-        gs.mission_fund_allocations.update(
-            data.get("mission_fund_allocations", {})
-        )
+        gs.mission_fund_allocations.update(data.get("mission_fund_allocations", {}))
         gs.calendar = StrategicCalendar.from_dict(data.get("calendar"))
         gs.turn = data.get("turn", gs.calendar.current_day)
         if "calendar" not in data:
@@ -477,6 +493,11 @@ class GameState:
         ] or [create_opening_consequence(gs.district.name)]
         gs.latest_agent_aftermath = list(data.get("latest_agent_aftermath", []))
         gs.event_log = list(data.get("event_log", gs.event_log))
+        gs.active_events = [
+            ActiveEvent.from_dict(event) for event in data.get("active_events", [])
+        ]
+        gs.next_event_id = int(data.get("next_event_id", len(gs.active_events) + 1))
+        gs.unavailable_mission_ids = list(data.get("unavailable_mission_ids", []))
         from .character import Character
 
         gs.characters = [Character.from_dict(c) for c in data.get("characters", [])]

--- a/game/management/events.py
+++ b/game/management/events.py
@@ -1,0 +1,460 @@
+"""Small strategic event system for management-phase threats.
+
+Events are deliberately compact: templates describe the narrative pressure,
+active events track calendar expiry, and choices apply a few mechanical levers
+already owned by ``GameState``.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Any
+
+ENEMY_CORPORATION_ATTACK = "enemy corporation attack"
+MUTANT_INVASION = "mutant invasion"
+STARVERS_OUTBREAK = "Starvers outbreak"
+SOCIAL_UNREST = "social unrest"
+CORPORATE_POLITICS = "corporate politics"
+CITY_POLITICS = "city politics"
+
+EVENT_CATEGORIES = (
+    ENEMY_CORPORATION_ATTACK,
+    MUTANT_INVASION,
+    STARVERS_OUTBREAK,
+    SOCIAL_UNREST,
+    CORPORATE_POLITICS,
+    CITY_POLITICS,
+)
+
+
+@dataclass(frozen=True)
+class EventChoice:
+    """One player response option and its compact mechanical effects."""
+
+    key: str
+    label: str
+    effects: dict[str, Any] = field(default_factory=dict)
+    summary: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "key": self.key,
+            "label": self.label,
+            "effects": dict(self.effects),
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "EventChoice") -> "EventChoice":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            key=str(data.get("key", "respond")),
+            label=str(data.get("label", "Respond")),
+            effects=dict(data.get("effects", {})),
+            summary=str(data.get("summary", "")),
+        )
+
+
+@dataclass(frozen=True)
+class EventTemplate:
+    """Reusable event seed that can become an active command-deck crisis."""
+
+    title: str
+    category: str
+    description: str
+    severity: int
+    choices: list[EventChoice]
+    consequences: dict[str, Any] = field(default_factory=dict)
+    expiration_days: int = 3
+    weight: int = 1
+
+    def to_dict(self) -> dict:
+        return {
+            "title": self.title,
+            "category": self.category,
+            "description": self.description,
+            "severity": max(1, int(self.severity)),
+            "choices": [choice.to_dict() for choice in self.choices],
+            "consequences": dict(self.consequences),
+            "expiration_days": max(1, int(self.expiration_days)),
+            "weight": max(1, int(self.weight)),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "EventTemplate") -> "EventTemplate":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            title=str(data.get("title", "Unmarked Event")),
+            category=str(data.get("category", SOCIAL_UNREST)),
+            description=str(
+                data.get("description", "A pressure spike reaches command.")
+            ),
+            severity=max(1, int(data.get("severity", 1))),
+            choices=[
+                EventChoice.from_dict(choice) for choice in data.get("choices", [])
+            ],
+            consequences=dict(data.get("consequences", {})),
+            expiration_days=max(1, int(data.get("expiration_days", 3))),
+            weight=max(1, int(data.get("weight", 1))),
+        )
+
+
+@dataclass
+class ActiveEvent:
+    """Calendar-bound unresolved event visible to the command deck."""
+
+    id: str
+    template: EventTemplate
+    created_day: int
+    expires_day: int
+
+    @property
+    def title(self) -> str:
+        return self.template.title
+
+    @property
+    def category(self) -> str:
+        return self.template.category
+
+    @property
+    def severity(self) -> int:
+        return self.template.severity
+
+    @property
+    def choices(self) -> list[EventChoice]:
+        return self.template.choices
+
+    def days_remaining(self, current_day: int) -> int:
+        return max(0, self.expires_day - int(current_day) + 1)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "template": self.template.to_dict(),
+            "created_day": int(self.created_day),
+            "expires_day": int(self.expires_day),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | "ActiveEvent") -> "ActiveEvent":
+        if isinstance(data, cls):
+            return data
+        return cls(
+            id=str(data.get("id", "event-0")),
+            template=EventTemplate.from_dict(data.get("template", {})),
+            created_day=int(data.get("created_day", 1)),
+            expires_day=int(data.get("expires_day", 1)),
+        )
+
+
+def create_event_templates() -> list[EventTemplate]:
+    """Return the first small threat deck for CyberCity 2085."""
+    return [
+        EventTemplate(
+            title="Aegis Shadow Buyout",
+            category=ENEMY_CORPORATION_ATTACK,
+            description="A rival board cell starts buying informants around Forward Base Kilo.",
+            severity=3,
+            expiration_days=3,
+            weight=3,
+            choices=[
+                EventChoice(
+                    "pay",
+                    "Pay counter-intel",
+                    {"funds": -30, "faction_pressure": -8},
+                    "Spend funds to cool the hostile corporate net.",
+                ),
+                EventChoice(
+                    "burn",
+                    "Burn their cutouts",
+                    {
+                        "agent_stress": 5,
+                        "faction_pressure": 6,
+                        "mission_availability": -1,
+                    },
+                    "Agents move fast, but one operation route goes dark.",
+                ),
+            ],
+            consequences={"faction_pressure": 5, "city_stability": -2},
+        ),
+        EventTemplate(
+            title="Mutant Tunnel Surge",
+            category=MUTANT_INVASION,
+            description="Heat blooms under the transit grid as mutant packs breach service tunnels.",
+            severity=4,
+            expiration_days=2,
+            weight=2,
+            choices=[
+                EventChoice(
+                    "deploy",
+                    "Deploy garrisons",
+                    {"funds": -20, "city_stability": 5, "agent_stress": 3},
+                    "Hold the line with tired patrol teams.",
+                ),
+                EventChoice(
+                    "seal",
+                    "Seal the lower decks",
+                    {"city_unrest": 6, "city_stability": 2},
+                    "Containment saves lives but strands residents.",
+                ),
+            ],
+            consequences={"city_unrest": 8, "city_stability": -5},
+        ),
+        EventTemplate(
+            title="Starvers Fever Line",
+            category=STARVERS_OUTBREAK,
+            description="Clinic relays report hunger-cult fever spreading through stacked shelters.",
+            severity=4,
+            expiration_days=3,
+            weight=2,
+            choices=[
+                EventChoice(
+                    "relief",
+                    "Fund relief drones",
+                    {"funds": -25, "city_unrest": -7, "city_stability": 3},
+                    "Visible aid wins a fragile calm.",
+                ),
+                EventChoice(
+                    "quarantine",
+                    "Hard quarantine",
+                    {"agent_stress": 4, "city_unrest": 4, "mission_availability": -1},
+                    "Security saves the perimeter and closes a mission window.",
+                ),
+            ],
+            consequences={"city_unrest": 7, "faction_pressure": 3},
+        ),
+        EventTemplate(
+            title="Neon Market Riot",
+            category=SOCIAL_UNREST,
+            description="Rent strikes and pirate broadcasts turn a market deck into a flashpoint.",
+            severity=2,
+            expiration_days=2,
+            weight=4,
+            choices=[
+                EventChoice(
+                    "listen",
+                    "Send negotiators",
+                    {"funds": -10, "city_unrest": -5, "city_stability": 2},
+                    "A cheap concession buys trust.",
+                ),
+                EventChoice(
+                    "sweep",
+                    "Authorize sweep",
+                    {"city_unrest": 5, "faction_pressure": -4},
+                    "Order returns with cameras watching.",
+                ),
+            ],
+            consequences={"city_unrest": 5, "city_stability": -3},
+        ),
+        EventTemplate(
+            title="Board Knife Vote",
+            category=CORPORATE_POLITICS,
+            description="Aegis directors demand proof the Warrens project deserves more funding.",
+            severity=3,
+            expiration_days=4,
+            weight=3,
+            choices=[
+                EventChoice(
+                    "lobby",
+                    "Lobby the board",
+                    {"funds": -20, "faction_pressure": -5},
+                    "Political cover dampens the attack.",
+                ),
+                EventChoice(
+                    "profit",
+                    "Promise faster returns",
+                    {"funds": 15, "agent_stress": 4, "city_stability": -2},
+                    "The budget improves and the floor feels colder.",
+                ),
+            ],
+            consequences={"funds": -15, "faction_pressure": 5},
+        ),
+        EventTemplate(
+            title="Council Leverage Demand",
+            category=CITY_POLITICS,
+            description="Municipal brokers ask Aegis to back their ward boss before permits freeze.",
+            severity=2,
+            expiration_days=3,
+            weight=3,
+            choices=[
+                EventChoice(
+                    "back",
+                    "Back the ward boss",
+                    {"funds": -15, "city_stability": 3, "faction_pressure": 3},
+                    "Permits stay open, but factions notice.",
+                ),
+                EventChoice(
+                    "refuse",
+                    "Refuse the demand",
+                    {"city_stability": -4, "mission_availability": -1},
+                    "Command stays clean while one city route closes.",
+                ),
+            ],
+            consequences={"city_stability": -4, "city_unrest": 3},
+        ),
+    ]
+
+
+def city_pressure_score(game_state) -> int:
+    """Score district pressure from stability, unrest, and media heat."""
+    district = game_state.district
+    return max(0, (100 - district.stability) + district.unrest + district.media_heat)
+
+
+def faction_pressure_score(game_state) -> int:
+    """Score the loudest faction threat against the player."""
+    if not game_state.factions:
+        return 0
+    return max(
+        faction.hostility_to_player + faction.influence // 2
+        for faction in game_state.factions
+    )
+
+
+def strategic_event_chance(game_state) -> float:
+    """Return daily event chance from pressure spikes above normal slice tension."""
+    city_overload = max(0, city_pressure_score(game_state) - 130) / 300
+    faction_overload = max(0, faction_pressure_score(game_state) - 95) / 400
+    if city_overload <= 0 and faction_overload <= 0:
+        return 0.0
+    return min(0.65, 0.05 + city_overload + faction_overload)
+
+
+def weighted_event_templates(game_state) -> list[tuple[EventTemplate, int]]:
+    """Build pressure-aware template weights without duplicating active categories."""
+    active_categories = {event.category for event in game_state.active_events}
+    city_pressure = city_pressure_score(game_state)
+    faction_pressure = faction_pressure_score(game_state)
+    weighted: list[tuple[EventTemplate, int]] = []
+    for template in create_event_templates():
+        if template.category in active_categories:
+            continue
+        weight = template.weight
+        if template.category in {
+            SOCIAL_UNREST,
+            MUTANT_INVASION,
+            STARVERS_OUTBREAK,
+            CITY_POLITICS,
+        }:
+            weight += city_pressure // 35
+        if template.category in {
+            ENEMY_CORPORATION_ATTACK,
+            CORPORATE_POLITICS,
+            CITY_POLITICS,
+        }:
+            weight += faction_pressure // 35
+        weighted.append((template, max(1, weight)))
+    return weighted
+
+
+def roll_random_event(
+    game_state, rng: random.Random | None = None
+) -> ActiveEvent | None:
+    """Possibly create one unresolved event for the current campaign day."""
+    rng = rng or random
+    if rng.random() > strategic_event_chance(game_state):
+        return None
+    weighted = weighted_event_templates(game_state)
+    if not weighted:
+        return None
+    templates, weights = zip(*weighted)
+    template = rng.choices(templates, weights=weights, k=1)[0]
+    event_number = getattr(game_state, "next_event_id", 1)
+    game_state.next_event_id = event_number + 1
+    active_event = ActiveEvent(
+        id=f"event-{event_number}",
+        template=template,
+        created_day=game_state.calendar.current_day,
+        expires_day=game_state.calendar.current_day + template.expiration_days - 1,
+    )
+    game_state.active_events.append(active_event)
+    game_state.add_event(
+        f"Strategic event: {template.title} ({template.category}, severity {template.severity})."
+    )
+    return active_event
+
+
+def expire_events(game_state) -> list[ActiveEvent]:
+    """Expire unresolved events and apply their unattended consequences."""
+    expired: list[ActiveEvent] = []
+    remaining: list[ActiveEvent] = []
+    for active_event in game_state.active_events:
+        if game_state.calendar.current_day > active_event.expires_day:
+            expired.append(active_event)
+            apply_event_effects(game_state, active_event.template.consequences)
+            game_state.add_event(
+                f"Expired event: {active_event.title} fallout hits command."
+            )
+        else:
+            remaining.append(active_event)
+    game_state.active_events = remaining
+    return expired
+
+
+def apply_event_choice(game_state, event_id: str, choice_key: str) -> bool:
+    """Resolve an active event by applying a selected response choice."""
+    for active_event in list(game_state.active_events):
+        if active_event.id != event_id:
+            continue
+        for choice in active_event.choices:
+            if choice.key != choice_key:
+                continue
+            apply_event_effects(game_state, choice.effects)
+            game_state.active_events.remove(active_event)
+            game_state.add_event(
+                f"Event response: {active_event.title} -> {choice.label}."
+            )
+            return True
+    return False
+
+
+def apply_event_effects(game_state, effects: dict[str, Any]) -> None:
+    """Apply the small set of strategic levers events are allowed to touch."""
+    funds = int(effects.get("funds", 0))
+    if funds > 0:
+        game_state.add_funds(funds, "event_choice", "Strategic event windfall.")
+    elif funds < 0:
+        game_state.spend_funds(abs(funds), "event_choice", "Strategic event response.")
+
+    agent_stress = int(effects.get("agent_stress", 0))
+    if agent_stress:
+        for character in game_state.characters:
+            character.stress = max(0, min(100, character.stress + agent_stress))
+
+    district = game_state.district
+    if "city_stability" in effects:
+        district.stability += int(effects["city_stability"])
+    if "city_unrest" in effects:
+        district.unrest += int(effects["city_unrest"])
+    if "media_heat" in effects:
+        district.media_heat += int(effects["media_heat"])
+    district.clamp_pressure()
+
+    faction_pressure = int(effects.get("faction_pressure", 0))
+    if faction_pressure and game_state.factions:
+        faction_name = effects.get("faction")
+        faction = game_state.get_faction(faction_name) if faction_name else None
+        if faction is None:
+            faction = max(
+                game_state.factions, key=lambda item: item.hostility_to_player
+            )
+        faction.hostility_to_player += faction_pressure
+        faction.clamp_pressure()
+
+    mission_delta = int(effects.get("mission_availability", 0))
+    if mission_delta < 0:
+        _lock_first_available_mission(game_state)
+    elif mission_delta > 0:
+        del game_state.unavailable_mission_ids[:mission_delta]
+
+
+def _lock_first_available_mission(game_state) -> None:
+    """Mark one mission unavailable without removing the template from saves."""
+    unavailable = set(game_state.unavailable_mission_ids)
+    for mission in game_state.mission_templates:
+        if mission.id not in unavailable:
+            game_state.unavailable_mission_ids.append(mission.id)
+            return

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -32,7 +32,13 @@ def clone_selected_mission(game_state: GameState) -> MissionTemplate:
 
 def launch_selected_mission(game_state: GameState) -> MissionTemplate:
     """Set the active mission and apply launch pressure."""
-    mission = clone_selected_mission(game_state)
+    selected = selected_mission(game_state)
+    if selected.id in game_state.unavailable_mission_ids:
+        game_state.add_event(
+            f"Mission unavailable: {selected.title} route is disrupted."
+        )
+        raise ValueError(f"Mission unavailable: {selected.title}")
+    mission = MissionTemplate.from_dict(selected.to_dict())
     game_state.active_mission = mission
     game_state.apply_active_mission_pressure()
     return mission

--- a/game/ui/command_deck.py
+++ b/game/ui/command_deck.py
@@ -129,3 +129,23 @@ def build_corporate_finance_lines(
         f"Next weekly income {next_income_date}",
         f"Projected income +{max(0, int(projected_income))} funds",
     ]
+
+
+def build_event_panel_lines(active_events, current_day: int) -> list[str]:
+    """Build command-deck copy for unresolved strategic events and choices."""
+    if not active_events:
+        return [
+            "No unresolved strategic events.",
+            "Advance the calendar to scan pressure feeds.",
+        ]
+
+    lines: list[str] = []
+    for index, event in enumerate(active_events[:3], start=1):
+        days_left = event.days_remaining(current_day)
+        lines.append(
+            f"{index}. {event.title} [{event.category}] severity {event.severity} ({days_left}d)"
+        )
+        for choice_index, choice in enumerate(event.choices[:2], start=1):
+            summary = f" - {choice.summary}" if choice.summary else ""
+            lines.append(f"   {index}.{choice_index} {choice.label}{summary}")
+    return lines

--- a/game/ui/room_interaction.py
+++ b/game/ui/room_interaction.py
@@ -73,6 +73,8 @@ ROOM_ACTIONS = {
         "executive": [
             RoomAction("advance_day", "city", "Advance day"),
             RoomAction("politics", "influence", "Fund politics"),
+            RoomAction("event_0", "shield", "Event choice A"),
+            RoomAction("event_1", "radar", "Event choice B"),
         ],
         "research": [RoomAction("research", "research", "Fund research")],
         "security": [RoomAction("security", "shield", "Fund security")],
@@ -100,7 +102,11 @@ ROOM_ACTIONS = {
         "factions": [RoomAction("garrisons", "shield", "Fund garrisons")],
         "public": [RoomAction("defense_zones", "radar", "Fund zones")],
         "relief": [RoomAction("armaments", "armory", "Fund arms")],
-        "records": [RoomAction("defense_zones", "radar", "Fund zones")],
+        "records": [
+            RoomAction("defense_zones", "radar", "Fund zones"),
+            RoomAction("event_0", "shield", "Event choice A"),
+            RoomAction("event_1", "influence", "Event choice B"),
+        ],
         "skybridge": [RoomAction("squad", "squad", "Squad tower")],
     },
     "squad": {
@@ -258,7 +264,9 @@ def roster_card_at_point(
     rect: UIRect, buttons: list[ActionButton], card_count: int, x: int, y: int
 ) -> int | None:
     """Return the roster-card index under a pointer, if any."""
-    for index, card_rect in enumerate(layout_roster_card_rects(rect, buttons, card_count)):
+    for index, card_rect in enumerate(
+        layout_roster_card_rects(rect, buttons, card_count)
+    ):
         if card_rect.contains(x, y):
             return index
     return None

--- a/game/views.py
+++ b/game/views.py
@@ -45,7 +45,7 @@ from .mission_system import (
 from .mission_templates import MissionTemplate
 from .recruitment import recruit_agent
 from .ui import GameView
-from .ui.command_deck import build_corporate_finance_lines
+from .ui.command_deck import build_corporate_finance_lines, build_event_panel_lines
 from .unit import Unit
 
 
@@ -210,9 +210,20 @@ class CorpView(GameView):
             else:
                 self.game_state.add_event("Recruitment denied: budget pool below 5.")
             return
+        if action_key.startswith("event_"):
+            self._respond_to_first_event(action_key)
+            return
         costs = self.CORP_UPGRADE_ACTIONS.get(action_key)
         if costs:
             self._buy_corp_upgrade(action_key, costs)
+
+    def _respond_to_first_event(self, action_key: str) -> None:
+        if not self.game_state.active_events:
+            return
+        choice_index = int(action_key.rsplit("_", 1)[-1])
+        event = self.game_state.active_events[0]
+        if 0 <= choice_index < len(event.choices):
+            self.game_state.respond_to_event(event.id, event.choices[choice_index].key)
 
     def _room_info_lines(self) -> dict[str, list[str]]:
         resources = self.game_state.strategic_resources
@@ -223,6 +234,9 @@ class CorpView(GameView):
         return {
             "executive": [
                 f"{self.game_state.calendar.campaign_date_label} | Day {self.game_state.calendar.current_day}",
+                *build_event_panel_lines(
+                    self.game_state.active_events, self.game_state.calendar.current_day
+                )[:3],
                 f"Turn {self.game_state.turn} | Funds {self.game_state.available_funds}",
                 *finance_lines,
                 f"Politics allocation {self.game_state.corp_budget['politics']}",
@@ -358,9 +372,20 @@ class CityView(GameView):
         if action_key == "advance_day":
             self.game_state.advance_one_day("manual command")
             return
+        if action_key.startswith("event_"):
+            self._respond_to_first_event(action_key)
+            return
         costs = self.CITY_UPGRADE_ACTIONS.get(action_key)
         if costs:
             self._buy_city_upgrade(action_key, costs)
+
+    def _respond_to_first_event(self, action_key: str) -> None:
+        if not self.game_state.active_events:
+            return
+        choice_index = int(action_key.rsplit("_", 1)[-1])
+        event = self.game_state.active_events[0]
+        if 0 <= choice_index < len(event.choices):
+            self.game_state.respond_to_event(event.id, event.choices[choice_index].key)
 
     def _room_info_lines(self) -> dict[str, list[str]]:
         resources = self.game_state.strategic_resources
@@ -406,6 +431,9 @@ class CityView(GameView):
             ],
             "records": [
                 f"Recent events {len(self.game_state.event_log)}",
+                *build_event_panel_lines(
+                    self.game_state.active_events, self.game_state.calendar.current_day
+                )[:4],
                 "D / Advance day reviews pending fallout.",
                 f"District tags {len(district.tags)}",
                 "Records preserve consequences for later systems.",
@@ -468,6 +496,11 @@ class RPGView(GameView):
             return
 
         selected_mission = self.selected_mission()
+        if selected_mission.id in self.game_state.unavailable_mission_ids:
+            self.message = f"{selected_mission.title} is temporarily unavailable."
+            self.pending_breakdown_confirmation = False
+            self.pending_breakdown_mission_id = None
+            return
         agents_at_risk = agents_at_breaking_risk(selected_squad, selected_mission)
         confirmation_matches = (
             self.pending_breakdown_confirmation
@@ -675,15 +708,15 @@ class RPGView(GameView):
             self._refresh_squad_room_actions()
             return
         if action_key == "agent_prev" and self.game_state.characters:
-            self.deployment_cursor_index = (
-                self.deployment_cursor_index - 1
-            ) % len(self.game_state.characters)
+            self.deployment_cursor_index = (self.deployment_cursor_index - 1) % len(
+                self.game_state.characters
+            )
             self._refresh_squad_room_actions()
             return
         if action_key == "agent_next" and self.game_state.characters:
-            self.deployment_cursor_index = (
-                self.deployment_cursor_index + 1
-            ) % len(self.game_state.characters)
+            self.deployment_cursor_index = (self.deployment_cursor_index + 1) % len(
+                self.game_state.characters
+            )
             self._refresh_squad_room_actions()
             return
         if action_key == "select_agent" and self.game_state.characters:

--- a/tests/test_strategic_events.py
+++ b/tests/test_strategic_events.py
@@ -1,0 +1,134 @@
+"""Strategic event generation, expiry, and command choices."""
+
+import unittest
+
+from game.character import Character
+from game.gamestate import GameState
+from game.mission_system import launch_selected_mission
+from game.management.events import (
+    ActiveEvent,
+    EventChoice,
+    EventTemplate,
+    EVENT_CATEGORIES,
+    apply_event_choice,
+    expire_events,
+)
+from game.ui.command_deck import build_event_panel_lines
+
+
+class FixedRoller:
+    """Deterministic RNG that always allows and selects the first weighted event."""
+
+    def random(self):
+        return 0.0
+
+    def choices(self, population, weights=None, k=1):
+        return [population[0]]
+
+
+class StrategicEventsTest(unittest.TestCase):
+    def test_event_generation_uses_requested_threat_categories(self):
+        game_state = GameState()
+        game_state.district.stability = 12
+        game_state.district.unrest = 90
+        game_state.district.media_heat = 80
+
+        event = game_state.roll_strategic_event(FixedRoller())
+
+        self.assertIsNotNone(event)
+        self.assertIn(event.category, EVENT_CATEGORIES)
+        self.assertEqual(len(game_state.active_events), 1)
+        self.assertEqual(
+            game_state.active_events[0].expires_day,
+            game_state.calendar.current_day + event.template.expiration_days - 1,
+        )
+        panel_lines = build_event_panel_lines(
+            game_state.active_events, game_state.calendar.current_day
+        )
+        self.assertIn(event.title, panel_lines[0])
+        self.assertIn("1.1", panel_lines[1])
+
+    def test_event_expiration_applies_unattended_consequences(self):
+        game_state = GameState()
+        starting_unrest = game_state.district.unrest
+        template = EventTemplate(
+            title="Ignored Riot",
+            category="social unrest",
+            description="A riot is left to burn.",
+            severity=2,
+            choices=[],
+            consequences={"city_unrest": 9, "city_stability": -4},
+            expiration_days=1,
+        )
+        game_state.active_events.append(
+            ActiveEvent(
+                id="event-test",
+                template=template,
+                created_day=game_state.calendar.current_day,
+                expires_day=game_state.calendar.current_day,
+            )
+        )
+        game_state.calendar.advance_one_day()
+
+        expired = expire_events(game_state)
+
+        self.assertEqual([event.id for event in expired], ["event-test"])
+        self.assertEqual(game_state.active_events, [])
+        self.assertEqual(game_state.district.unrest, starting_unrest + 9)
+        self.assertTrue(any("Expired event" in entry for entry in game_state.event_log))
+
+    def test_event_choice_changes_funds_agents_factions_city_and_missions(self):
+        game_state = GameState()
+        game_state.characters = [Character(name="Vega", stress=10)]
+        starting_funds = game_state.available_funds
+        starting_stability = game_state.district.stability
+        hostile_faction = max(
+            game_state.factions, key=lambda faction: faction.hostility_to_player
+        )
+        starting_hostility = hostile_faction.hostility_to_player
+        first_mission_id = game_state.mission_templates[0].id
+        template = EventTemplate(
+            title="Council Knife",
+            category="city politics",
+            description="Council pressure demands an answer.",
+            severity=3,
+            choices=[
+                EventChoice(
+                    key="refuse",
+                    label="Refuse leverage",
+                    effects={
+                        "funds": -12,
+                        "agent_stress": 7,
+                        "faction_pressure": 5,
+                        "city_stability": -6,
+                        "mission_availability": -1,
+                    },
+                )
+            ],
+            consequences={},
+            expiration_days=2,
+        )
+        game_state.active_events.append(
+            ActiveEvent(
+                id="event-choice",
+                template=template,
+                created_day=game_state.calendar.current_day,
+                expires_day=game_state.calendar.current_day + 1,
+            )
+        )
+
+        applied = apply_event_choice(game_state, "event-choice", "refuse")
+
+        self.assertTrue(applied)
+        self.assertEqual(game_state.active_events, [])
+        self.assertEqual(game_state.available_funds, starting_funds - 12)
+        self.assertEqual(game_state.characters[0].stress, 17)
+        self.assertEqual(hostile_faction.hostility_to_player, starting_hostility + 5)
+        self.assertEqual(game_state.district.stability, starting_stability - 6)
+        self.assertIn(first_mission_id, game_state.unavailable_mission_ids)
+        with self.assertRaises(ValueError):
+            launch_selected_mission(game_state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Surface compact management-phase threats (enemy corporations, mutants, Starvers, social unrest, corporate politics, city politics) so the command deck can present emergent narrative beats and demand player choices.
- Keep the system small and modular by reusing existing GameState levers (funds, agent stress, faction pressure, district stability/unrest, and mission availability) instead of adding a large new simulation.
- Expose unresolved events to the UI so players can respond from the command deck and see consequences applied over the strategic calendar.

### Description

- Add `game/management/events.py` implementing `EventTemplate`, `EventChoice`, `ActiveEvent`, a small template deck, pressure scoring, weighted rolls, expiration handling, and application of choice effects to the game state.
- Extend `GameState` to store `active_events`, `next_event_id`, and `unavailable_mission_ids`, to run `expire_events`/`roll_random_event` during day advancement, and to expose `roll_strategic_event` and `respond_to_event` helpers for the UI.
- Surface events in the command deck via `build_event_panel_lines`, add simple event action buttons in the corp/city records rooms, implement response handlers in views to resolve the first active event, and prevent launching missions marked unavailable by events.
- Add `tests/test_strategic_events.py` covering event generation, expiration fallout, UI lines, and choice consequences, and update `README.md`, `docs/backlog.md`, and `docs/roadmap.md` to document the new system and backlog status.

### Testing

- Ran the focused strategic event tests with `python -m pytest tests/test_strategic_events.py -q`, which passed (new tests exercise generation, expiry, and choice effects).
- Ran the full test suite with `python -m pytest -q`, and all tests passed (`107 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07958af0ec832b80eea7527137be55)