### PR TITLE
Add starter research management with lab UI and calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ python main.py
   attacks, mutant invasions, Starvers outbreaks, social unrest, corporate
   politics, and city politics
 - Corporate rooms show the next weekly income date and projected payment
+- The Research Lab lists starter vehicle, weapon, armor, psy, equipment, robot,
+  and power-armor projects; each project spends funds, advances with campaign
+  days, and completes into unlock flags or small stat modifiers
 - `1-4` add funds to research, security, politics and black ops
 - Budget is refreshed automatically when all funds are spent
 - `S` save game / `L` load game

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -19,6 +19,7 @@ TODO:
 [x] Add weekly recurring corporate funding tied to the strategic calendar
 [x] Add mission duration days to mission templates, board UI, and calendar resolution
 [x] Add small strategic event deck for corporate, mutant, Starvers, social, and political threats
+[x] Add starter research management with timed funded projects and lab UI
 [x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -80,3 +81,7 @@ Done:
   unrest, corporate politics, and city politics. Events expire if ignored, and
   response choices can touch funds, agent stress, faction hostility, city
   stability/unrest, and temporary mission availability.
+- Research management: the Research Lab now offers one starter project per
+  vehicle, weapon, armor, psy, equipment, robot, and power-armor category.
+  Projects spend corporate funds up front, tick down with the strategic
+  calendar, then apply small unlock flags and stat modifiers to GameState.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,6 +51,12 @@
     threat deck when the calendar advances, stores active unresolved events in
     GameState, and exposes command choices that trade funds, agent stress,
     faction pressure, city stability, and mission availability.
+
+  - Progress: Research management now has a first small lab slice: one starter
+    project per vehicles, weapons, armor, psy, equipment, robots, and
+    power-armor category. Projects spend corporate funds, progress as days
+    advance on the strategic calendar, and complete into GameState unlock flags
+    or small stat modifiers for later systems to consume.
 - District system
 - Mission generation
 - Black ops

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -14,6 +14,13 @@ from .management.events import (
     expire_events,
     roll_random_event,
 )
+from .management.research import (
+    ActiveResearch,
+    ResearchTree,
+    advance_research_days,
+    create_starter_research_tree,
+    start_research,
+)
 from .management.funds import (
     MISSION_FUND_CATEGORIES,
     CorporateFunds,
@@ -104,6 +111,11 @@ class GameState:
     funds: CorporateFunds = field(default_factory=CorporateFunds)
     corporation_finance: CorporationFinance = field(default_factory=CorporationFinance)
     budget_pool: int = 0
+    research_tree: ResearchTree = field(default_factory=create_starter_research_tree)
+    active_research: list[ActiveResearch] = field(default_factory=list)
+    completed_research: list[str] = field(default_factory=list)
+    research_unlock_flags: list[str] = field(default_factory=list)
+    research_stat_modifiers: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.budget_pool:
@@ -308,12 +320,21 @@ class GameState:
                 f"Week {self.calendar.current_week}: Strategic planning cycle opens "
                 f"with corporate funding +{weekly_income}."
             )
+        advance_research_days(self, 1, self.research_tree)
         expire_events(self)
         roll_random_event(self)
         for name in recovered_agents:
             self.add_event(
                 f"{self.calendar.campaign_date_label}: {name} is deployable after recovery."
             )
+
+    def start_research(self, project_id: str) -> bool:
+        """Start a research project from the current research tree."""
+        return start_research(self, project_id, self.research_tree)
+
+    def advance_research(self, days: int = 1):
+        """Advance active research outside normal calendar flow for tests/tools."""
+        return advance_research_days(self, days, self.research_tree)
 
     def advance_days(self, days: int, reason: str = "manual") -> None:
         """Advance multiple days while preserving daily income and recovery ticks."""
@@ -438,6 +459,12 @@ class GameState:
             "active_events": [event.to_dict() for event in self.active_events],
             "next_event_id": self.next_event_id,
             "unavailable_mission_ids": list(self.unavailable_mission_ids),
+            "active_research": [
+                research.to_dict() for research in self.active_research
+            ],
+            "completed_research": list(self.completed_research),
+            "research_unlock_flags": list(self.research_unlock_flags),
+            "research_stat_modifiers": dict(self.research_stat_modifiers),
         }
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
@@ -498,6 +525,14 @@ class GameState:
         ]
         gs.next_event_id = int(data.get("next_event_id", len(gs.active_events) + 1))
         gs.unavailable_mission_ids = list(data.get("unavailable_mission_ids", []))
+        gs.research_tree = create_starter_research_tree()
+        gs.active_research = [
+            ActiveResearch.from_dict(research)
+            for research in data.get("active_research", [])
+        ]
+        gs.completed_research = list(data.get("completed_research", []))
+        gs.research_unlock_flags = list(data.get("research_unlock_flags", []))
+        gs.research_stat_modifiers = dict(data.get("research_stat_modifiers", {}))
         from .character import Character
 
         gs.characters = [Character.from_dict(c) for c in data.get("characters", [])]

--- a/game/management/research.py
+++ b/game/management/research.py
@@ -1,0 +1,294 @@
+"""Small research-management model for campaign upgrades.
+
+Research is intentionally scoped as a light management layer: projects cost
+corporate funds, take campaign days, and finish as unlock flags or small stat
+modifiers that other systems can read without coupling to a large tech system.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..gamestate import GameState
+
+
+RESEARCH_CATEGORIES = (
+    "vehicles",
+    "weapons",
+    "armor",
+    "psy",
+    "equipment",
+    "robots",
+    "power_armor",
+)
+
+
+@dataclass(frozen=True)
+class ResearchProject:
+    """A fund-and-time gated upgrade project."""
+
+    id: str
+    name: str
+    category: str
+    funds_cost: int
+    days_required: int
+    description: str = ""
+    unlock_flags: tuple[str, ...] = ()
+    stat_modifiers: dict[str, int] = field(default_factory=dict)
+    requires: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.category not in RESEARCH_CATEGORIES:
+            raise ValueError(f"Unsupported research category: {self.category}")
+        if self.funds_cost <= 0:
+            raise ValueError("Research projects must require positive funds")
+        if self.days_required <= 0:
+            raise ValueError("Research projects must require at least one day")
+
+    def to_dict(self) -> dict:
+        """Serialize project data for tools or future save migration."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "category": self.category,
+            "funds_cost": self.funds_cost,
+            "days_required": self.days_required,
+            "description": self.description,
+            "unlock_flags": list(self.unlock_flags),
+            "stat_modifiers": dict(self.stat_modifiers),
+            "requires": list(self.requires),
+        }
+
+
+@dataclass
+class ActiveResearch:
+    """Progress record for a started research project."""
+
+    project_id: str
+    days_remaining: int
+    days_elapsed: int = 0
+
+    def advance_day(self) -> bool:
+        """Advance one day and return whether the project is complete."""
+        if self.days_remaining <= 0:
+            return True
+        self.days_remaining -= 1
+        self.days_elapsed += 1
+        return self.days_remaining <= 0
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether no more days are required."""
+        return self.days_remaining <= 0
+
+    def to_dict(self) -> dict:
+        """Serialize active progress for save files."""
+        return {
+            "project_id": self.project_id,
+            "days_remaining": self.days_remaining,
+            "days_elapsed": self.days_elapsed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ActiveResearch":
+        """Restore active research progress from save data."""
+        return cls(
+            project_id=str(data.get("project_id", "")),
+            days_remaining=max(0, int(data.get("days_remaining", 0))),
+            days_elapsed=max(0, int(data.get("days_elapsed", 0))),
+        )
+
+
+@dataclass(frozen=True)
+class ResearchTree:
+    """A compact catalog of available research projects."""
+
+    projects: dict[str, ResearchProject]
+
+    def project(self, project_id: str) -> ResearchProject | None:
+        """Return a project by id if it exists."""
+        return self.projects.get(project_id)
+
+    def projects_for_category(self, category: str) -> list[ResearchProject]:
+        """Return projects in stable category order."""
+        return [p for p in self.projects.values() if p.category == category]
+
+    def available_projects(
+        self,
+        completed_project_ids: set[str],
+        active_project_ids: set[str] | None = None,
+    ) -> list[ResearchProject]:
+        """Return projects whose prerequisites are met and are not already active."""
+        active_project_ids = active_project_ids or set()
+        return [
+            project
+            for project in self.projects.values()
+            if project.id not in completed_project_ids
+            and project.id not in active_project_ids
+            and all(required in completed_project_ids for required in project.requires)
+        ]
+
+
+def create_starter_research_tree() -> ResearchTree:
+    """Create one memorable starter project for each requested category."""
+    starter_projects = [
+        ResearchProject(
+            id="vehicle_silent_wheels",
+            name="Silent Wheels Retrofit",
+            category="vehicles",
+            funds_cost=25,
+            days_required=2,
+            description="Muffled drive trains make extraction vehicles harder to track.",
+            unlock_flags=("vehicles.silent_wheels",),
+            stat_modifiers={"vehicle_stealth": 1},
+        ),
+        ResearchProject(
+            id="weapon_smartlink_mk1",
+            name="Smartlink Mk I",
+            category="weapons",
+            funds_cost=30,
+            days_required=2,
+            description="Cheap targeting mesh for agents who still trust a trigger.",
+            unlock_flags=("weapons.smartlink_mk1",),
+            stat_modifiers={"weapon_accuracy": 1},
+        ),
+        ResearchProject(
+            id="armor_reactive_lining",
+            name="Reactive Armor Lining",
+            category="armor",
+            funds_cost=35,
+            days_required=3,
+            description="Thin reactive plates reduce the first hit before medbay is needed.",
+            unlock_flags=("armor.reactive_lining",),
+            stat_modifiers={"armor_defense": 1},
+        ),
+        ResearchProject(
+            id="psy_echo_discipline",
+            name="Echo Discipline",
+            category="psy",
+            funds_cost=30,
+            days_required=3,
+            description="A controlled psi cadence that keeps gifted agents present.",
+            unlock_flags=("psy.echo_discipline",),
+            stat_modifiers={"psi_focus": 1},
+        ),
+        ResearchProject(
+            id="equipment_field_mender",
+            name="Field Mender Kit",
+            category="equipment",
+            funds_cost=20,
+            days_required=2,
+            description="Disposable trauma foam and a tiny diagnostic saint in a box.",
+            unlock_flags=("equipment.field_mender",),
+            stat_modifiers={"medkit_quality": 1},
+        ),
+        ResearchProject(
+            id="robot_loyalty_kernel",
+            name="Loyalty Kernel Patch",
+            category="robots",
+            funds_cost=35,
+            days_required=3,
+            description="A patched obedience kernel for drones that heard too many ghosts.",
+            unlock_flags=("robots.loyalty_kernel",),
+            stat_modifiers={"robot_reliability": 1},
+        ),
+        ResearchProject(
+            id="power_armor_servo_prayer",
+            name="Servo Prayer Loop",
+            category="power_armor",
+            funds_cost=40,
+            days_required=4,
+            description="Predictive servo chants make heavy armor feel almost human.",
+            unlock_flags=("power_armor.servo_prayer",),
+            stat_modifiers={"power_armor_mobility": 1},
+        ),
+    ]
+    return ResearchTree({project.id: project for project in starter_projects})
+
+
+def active_research_ids(game_state: "GameState") -> set[str]:
+    """Return project ids currently being researched."""
+    return {active.project_id for active in game_state.active_research}
+
+
+def completed_research_ids(game_state: "GameState") -> set[str]:
+    """Return completed project ids as a set."""
+    return set(game_state.completed_research)
+
+
+def can_start_research(
+    game_state: "GameState", project_id: str, tree: ResearchTree | None = None
+) -> bool:
+    """Return whether a project can start right now."""
+    tree = tree or create_starter_research_tree()
+    project = tree.project(project_id)
+    if project is None:
+        return False
+    completed = completed_research_ids(game_state)
+    if project_id in completed or project_id in active_research_ids(game_state):
+        return False
+    if not all(required in completed for required in project.requires):
+        return False
+    return game_state.can_afford(project.funds_cost)
+
+
+def start_research(
+    game_state: "GameState", project_id: str, tree: ResearchTree | None = None
+) -> bool:
+    """Pay for a project and add it to active research when possible."""
+    tree = tree or create_starter_research_tree()
+    project = tree.project(project_id)
+    if project is None or not can_start_research(game_state, project_id, tree):
+        return False
+    if not game_state.spend_funds(
+        project.funds_cost,
+        "research",
+        f"Started {project.name} ({project.days_required}d).",
+    ):
+        return False
+    game_state.active_research.append(
+        ActiveResearch(project.id, project.days_required, days_elapsed=0)
+    )
+    game_state.add_event(
+        f"Research started: {project.name} ({project.category.replace('_', ' ')}, "
+        f"{project.days_required}d)."
+    )
+    return True
+
+
+def apply_completed_research(game_state: "GameState", project: ResearchProject) -> None:
+    """Apply a completed project's unlock flags and stat modifiers."""
+    if project.id not in game_state.completed_research:
+        game_state.completed_research.append(project.id)
+    for flag in project.unlock_flags:
+        if flag not in game_state.research_unlock_flags:
+            game_state.research_unlock_flags.append(flag)
+    for key, value in project.stat_modifiers.items():
+        game_state.research_stat_modifiers[key] = (
+            game_state.research_stat_modifiers.get(key, 0) + value
+        )
+
+
+def advance_research_days(
+    game_state: "GameState", days: int = 1, tree: ResearchTree | None = None
+) -> list[ResearchProject]:
+    """Advance active research by campaign days and apply completions."""
+    if days < 0:
+        raise ValueError("days must be non-negative")
+    tree = tree or create_starter_research_tree()
+    completed_projects: list[ResearchProject] = []
+    for _ in range(days):
+        still_active: list[ActiveResearch] = []
+        for active in game_state.active_research:
+            if active.advance_day():
+                project = tree.project(active.project_id)
+                if project is not None:
+                    apply_completed_research(game_state, project)
+                    completed_projects.append(project)
+                    game_state.add_event(f"Research complete: {project.name}.")
+            else:
+                still_active.append(active)
+        game_state.active_research = still_active
+    return completed_projects

--- a/game/ui/research_lab.py
+++ b/game/ui/research_lab.py
@@ -1,0 +1,43 @@
+"""Research lab panel text for the corporate command tower."""
+
+from __future__ import annotations
+
+from ..management.research import ResearchTree, create_starter_research_tree
+
+
+def build_research_lab_lines(
+    game_state: object, tree: ResearchTree | None = None
+) -> list[str]:
+    """Build compact UI copy for active, available, and completed research."""
+    tree = tree or getattr(game_state, "research_tree", create_starter_research_tree())
+    active_research = list(getattr(game_state, "active_research", []))
+    completed = set(getattr(game_state, "completed_research", []))
+    active_ids = {active.project_id for active in active_research}
+
+    resources = getattr(game_state, "strategic_resources", {})
+    lines = [
+        f"Funds {getattr(game_state, 'available_funds', 0)} | Lab queue {len(active_research)}",
+        f"Intel reserve {resources.get('intel', 0)}",
+    ]
+    if active_research:
+        for active in active_research[:2]:
+            project = tree.project(active.project_id)
+            name = project.name if project else active.project_id
+            lines.append(f"ACTIVE {name}: {active.days_remaining}d remaining")
+    else:
+        lines.append("No active project. Choose a starter study.")
+
+    available = tree.available_projects(completed, active_ids)
+    for index, project in enumerate(available[:3], start=1):
+        lines.append(
+            f"{index}. {project.name} [{project.category.replace('_', ' ')}] "
+            f"{project.funds_cost} funds / {project.days_required}d"
+        )
+
+    if completed:
+        lines.append(
+            f"Completed: {len(completed)} | Unlocks {len(getattr(game_state, 'research_unlock_flags', []))}"
+        )
+    else:
+        lines.append("Completed: none")
+    return lines[:7]

--- a/game/ui/room_interaction.py
+++ b/game/ui/room_interaction.py
@@ -76,7 +76,11 @@ ROOM_ACTIONS = {
             RoomAction("event_0", "shield", "Event choice A"),
             RoomAction("event_1", "radar", "Event choice B"),
         ],
-        "research": [RoomAction("research", "research", "Fund research")],
+        "research": [
+            RoomAction("start_research_0", "research", "Start project 1"),
+            RoomAction("start_research_1", "armory", "Start project 2"),
+            RoomAction("research", "research", "Fund research"),
+        ],
         "security": [RoomAction("security", "shield", "Fund security")],
         "black_ops": [
             RoomAction("black_ops", "black_ops", "Fund black ops"),

--- a/game/views.py
+++ b/game/views.py
@@ -46,6 +46,7 @@ from .mission_templates import MissionTemplate
 from .recruitment import recruit_agent
 from .ui import GameView
 from .ui.command_deck import build_corporate_finance_lines, build_event_panel_lines
+from .ui.research_lab import build_research_lab_lines
 from .unit import Unit
 
 
@@ -198,6 +199,22 @@ class CorpView(GameView):
             rpg_view.setup()
             self.window.show_view(rpg_view)
             return
+        if action_key.startswith("start_research_"):
+            index = int(action_key.rsplit("_", 1)[-1])
+            completed = set(self.game_state.completed_research)
+            active_ids = {
+                active.project_id for active in self.game_state.active_research
+            }
+            available = self.game_state.research_tree.available_projects(
+                completed, active_ids
+            )
+            if index < len(available):
+                self.game_state.start_research(available[index].id)
+            else:
+                self.game_state.add_event(
+                    "Research denied: no project in that lab slot."
+                )
+            return
         if action_key.startswith("recruit_"):
             role = action_key.removeprefix("recruit_")
             if self.game_state.spend_funds(
@@ -242,11 +259,7 @@ class CorpView(GameView):
                 f"Politics allocation {self.game_state.corp_budget['politics']}",
                 f"Influence reserve {resources.get('influence', 0)}",
             ],
-            "research": [
-                f"Research allocation {self.game_state.corp_budget['research']}",
-                f"Intel reserve {resources.get('intel', 0)}",
-                "Upgrade cost: 5 intel",
-            ],
+            "research": build_research_lab_lines(self.game_state),
             "security": [
                 f"Security allocation {self.game_state.corp_budget['security']}",
                 f"Credits {resources.get('credits', 0)} | Salvage {resources.get('salvage', 0)}",

--- a/tests/test_research_management.py
+++ b/tests/test_research_management.py
@@ -1,0 +1,95 @@
+"""Research management projects, calendar progress, and unlock application."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from game.gamestate import GameState
+from game.management.research import RESEARCH_CATEGORIES, create_starter_research_tree
+from game.ui.research_lab import build_research_lab_lines
+from game.ui.room_interaction import actions_for_room
+
+
+class ResearchManagementTest(unittest.TestCase):
+    def test_starter_tree_has_requested_upgrade_categories(self):
+        tree = create_starter_research_tree()
+
+        categories = {project.category for project in tree.projects.values()}
+
+        self.assertEqual(categories, set(RESEARCH_CATEGORIES))
+        for project in tree.projects.values():
+            self.assertGreater(project.funds_cost, 0)
+            self.assertGreater(project.days_required, 0)
+
+    def test_starting_research_pays_cost_and_queues_project(self):
+        game_state = GameState()
+        project = game_state.research_tree.project("weapon_smartlink_mk1")
+        starting_funds = game_state.available_funds
+
+        started = game_state.start_research(project.id)
+
+        self.assertTrue(started)
+        self.assertEqual(
+            game_state.available_funds, starting_funds - project.funds_cost
+        )
+        self.assertEqual(game_state.budget_pool, game_state.available_funds)
+        self.assertEqual(game_state.active_research[0].project_id, project.id)
+        self.assertTrue(
+            any(
+                transaction.source == "research"
+                for transaction in game_state.funds.transaction_history
+            )
+        )
+
+    def test_starting_research_requires_available_funds(self):
+        game_state = GameState()
+        game_state.spend_funds(game_state.available_funds, "test", "empty ledger")
+
+        started = game_state.start_research("power_armor_servo_prayer")
+
+        self.assertFalse(started)
+        self.assertEqual(game_state.active_research, [])
+
+    def test_calendar_advances_active_research_and_unlocks_upgrade(self):
+        game_state = GameState()
+        project = game_state.research_tree.project("equipment_field_mender")
+        self.assertTrue(game_state.start_research(project.id))
+
+        game_state.advance_days(project.days_required, "research test")
+
+        self.assertEqual(game_state.active_research, [])
+        self.assertIn(project.id, game_state.completed_research)
+        self.assertIn("equipment.field_mender", game_state.research_unlock_flags)
+        self.assertEqual(game_state.research_stat_modifiers["medkit_quality"], 1)
+        self.assertTrue(
+            any("Research complete" in event for event in game_state.event_log)
+        )
+
+    def test_completed_research_serializes_through_game_state_save(self):
+        game_state = GameState()
+        project = game_state.research_tree.project("vehicle_silent_wheels")
+        game_state.start_research(project.id)
+        game_state.advance_days(project.days_required, "save test")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_path = Path(temp_dir) / "savegame.json"
+            game_state.save(str(save_path))
+            loaded = GameState.load(str(save_path))
+
+        self.assertIn(project.id, loaded.completed_research)
+        self.assertIn("vehicles.silent_wheels", loaded.research_unlock_flags)
+        self.assertEqual(loaded.research_stat_modifiers["vehicle_stealth"], 1)
+
+    def test_research_lab_ui_lists_queue_and_start_actions(self):
+        game_state = GameState()
+        lines = build_research_lab_lines(game_state)
+        actions = [action.key for action in actions_for_room("corp", "research")]
+
+        self.assertTrue(any("Lab queue" in line for line in lines))
+        self.assertTrue(any("funds" in line.lower() and "/" in line for line in lines))
+        self.assertIn("start_research_0", actions)
+        self.assertIn("start_research_1", actions)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small, focused research system where upgrades cost corporate funds and require campaign days to complete.
- Let research progress be driven by the existing strategic calendar so projects tick while days advance.
- Surface research as a small, memorable management option in the corporate UI without growing the tech tree yet. 

### Description
- Add a compact research model in `game/management/research.py` with `ResearchProject`, `ActiveResearch`, `ResearchTree`, helper APIs (`start_research`, `advance_research_days`, apply completions) and one starter project per category in `create_starter_research_tree`.
- Integrate research into `GameState` by adding `research_tree`, `active_research`, `completed_research`, `research_unlock_flags`, and `research_stat_modifiers`, advancing research each calendar day, and persisting research state in save/load via `GameState.save`/`GameState.load`.
- Add a small Research Lab UI helper `game/ui/research_lab.py` that builds compact panel lines and expose two clickable lab actions in `game/ui/room_interaction.py` while preserving the original `Fund research` action.
- Hook room actions into `CorpView`/`RPGView` in `game/views.py` to start projects from available slots and to show the lab panel in the research room, and keep the first implementation intentionally small (two start slots in the room view).
- Add tests in `tests/test_research_management.py` for starter tree contents, starting projects (funds/payment), requiring funds, calendar-driven completion and unlock application, save/load roundtrip, and UI lab listings, and update `README.md`, `docs/backlog.md`, and `docs/roadmap.md` to reflect the new feature.

### Testing
- Ran the project test-suite with `python -m pytest -q` and all automated tests passed, `113 passed`.
- Ran the new research unit tests `tests/test_research_management.py` which passed as part of the full run.
- Compiled and ran quick static-checks/byte-compile during development; no runtime errors observed in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079752fae4832b820b40dfe277b474)