### PR TITLE
Add spec-ops support assets (robots & power armor) with deployment, combat units, and maintenance costs

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -20,6 +20,7 @@ TODO:
 [x] Add mission duration days to mission templates, board UI, and calendar resolution
 [x] Add small strategic event deck for corporate, mutant, Starvers, social, and political threats
 [x] Add starter research management with timed funded projects and lab UI
+[x] Add spec-ops robot and power-armor assets with deployment, combat conversion, and maintenance costs
 [x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -85,3 +86,8 @@ Done:
   vehicle, weapon, armor, psy, equipment, robot, and power-armor category.
   Projects spend corporate funds up front, tick down with the strategic
   calendar, then apply small unlock flags and stat modifiers to GameState.
+- Spec-ops assets: combat robots and power armor now have small data models for
+  armor, hardpoints, missile capacity, pilot requirements, and maintenance.
+  Deployment can include selected support assets beside selected agents, combat
+  setup converts them into distinct Units, and the funds ledger can pay their
+  upkeep/repair costs without making them the emotional center of the squad.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,6 +57,12 @@
     power-armor category. Projects spend corporate funds, progress as days
     advance on the strategic calendar, and complete into GameState unlock flags
     or small stat modifiers for later systems to consume.
+  - Progress: Spec-ops support assets now have a contained vertical slice:
+    combat robots and power armor define maintenance, weapon hardpoints, armor,
+    missile capacity, and pilot requirements; deployment manifests can include
+    them beside agents; combat setup turns them into distinct Units; and the
+    funds ledger pays upkeep/repair while agent cards remain first in the squad
+    UI.
 - District system
 - Mission generation
 - Black ops

--- a/game/combat_system.py
+++ b/game/combat_system.py
@@ -5,9 +5,14 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 
 from .character import Character
-from .deployment import deployable_agents, selected_deployable_agents
+from .deployment import (
+    deployable_agents,
+    selected_deployable_agents,
+    selected_deployment_manifest,
+)
 from .mission_templates import MissionTemplate
 from .management.equipment import Weapon
+from .management.spec_ops_assets import SpecOpsAsset
 from .stats import EnemyStats, PlayerStats
 from .unit import Unit
 
@@ -65,19 +70,48 @@ def primary_attack_range(character: Character) -> int:
     return max(weapon.range_cells for weapon in weapons)
 
 
-def create_player_units(
-    characters: list[Character], selected_agent_names: list[str] | None = None
-) -> list[Unit]:
-    """Create battle units from selected deployable agents.
-
-    Passing ``None`` preserves the legacy all-deployable roster path for tests and
-    direct combat setup. Passing an empty list intentionally creates no units.
-    """
-    deployable_characters = (
-        deployable_agents(characters)
-        if selected_agent_names is None
-        else selected_deployable_agents(characters, selected_agent_names)
+def create_asset_unit(asset: SpecOpsAsset, index: int) -> Unit:
+    """Convert one robot or power armor asset into a tactical combat unit."""
+    stats = asset.combat_stats()
+    return Unit(
+        position=(64 + index * 64, 64),
+        stats=stats,
+        health=stats.hp,
+        spec_ops_asset=asset,
+        unit_type=asset.asset_type,
+        attack_range=asset.primary_range,
+        action_points=asset.action_points,
+        available_actions=asset.combat_actions,
+        equipment_summary=[
+            *(hardpoint.name for hardpoint in asset.hardpoints),
+            f"Missiles x{asset.missile_capacity}",
+            f"Armor {asset.armor.defense_bonus}",
+        ],
     )
+
+
+def create_player_units(
+    characters: list[Character],
+    selected_agent_names: list[str] | None = None,
+    assets: list[SpecOpsAsset] | None = None,
+    selected_asset_ids: list[str] | None = None,
+) -> list[Unit]:
+    """Create battle units from selected deployable agents and support assets.
+
+    Passing ``None`` for ``selected_agent_names`` preserves the legacy all-agent
+    roster path for tests and direct combat setup. Passing an empty agent list
+    intentionally creates no agent units; selected assets may still be supplied.
+    """
+    if selected_agent_names is None:
+        deployable_characters = deployable_agents(characters)
+        deployable_assets = []
+    else:
+        manifest = selected_deployment_manifest(
+            characters, selected_agent_names, assets, selected_asset_ids
+        )
+        deployable_characters = manifest.agents
+        deployable_assets = manifest.assets
+
     player_units: list[Unit] = []
     for i, char in enumerate(deployable_characters):
         stats = equipped_player_stats(char)
@@ -87,10 +121,14 @@ def create_player_units(
                 stats=stats,
                 health=stats.hp,
                 character=char,
+                unit_type="agent",
                 attack_range=primary_attack_range(char),
                 available_actions=char.loadout.combat_actions(),
+                equipment_summary=char.loadout.summary_lines(),
             )
         )
+    for asset in deployable_assets:
+        player_units.append(create_asset_unit(asset, len(player_units)))
     return player_units
 
 

--- a/game/deployment.py
+++ b/game/deployment.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from .character import Character, is_deployable
+from .management.spec_ops_assets import SpecOpsAsset
 
 
 def deployable_agents(characters: list[Character]) -> list[Character]:
@@ -55,3 +58,101 @@ def toggle_agent_selection(
 
     sanitized.append(character.name)
     return sanitized, f"{character.name} added to the squad."
+
+
+@dataclass(frozen=True)
+class DeploymentManifest:
+    """Selected deployable agents plus support assets for one operation."""
+
+    agents: list[Character]
+    assets: list[SpecOpsAsset]
+
+    @property
+    def has_units(self) -> bool:
+        return bool(self.agents or self.assets)
+
+    @property
+    def pilot_count(self) -> int:
+        return len(self.agents)
+
+
+def deployable_assets(
+    assets: list[SpecOpsAsset], selected_agents: list[Character] | None = None
+) -> list[SpecOpsAsset]:
+    """Return robots/suits ready for deployment without replacing agent checks."""
+    pilot_count = len(selected_agents or [])
+    deployable: list[SpecOpsAsset] = []
+    pilots_reserved = 0
+    for asset in assets:
+        if not asset.is_deployable:
+            continue
+        if asset.pilot_required:
+            if pilot_count <= pilots_reserved:
+                continue
+            pilots_reserved += 1
+        deployable.append(asset)
+    return deployable
+
+
+def selected_deployable_assets(
+    assets: list[SpecOpsAsset],
+    selected_asset_ids: list[str],
+    selected_agents: list[Character] | None = None,
+) -> list[SpecOpsAsset]:
+    """Return selected deployable assets, preserving hangar order."""
+    selected_ids = set(selected_asset_ids)
+    return [
+        asset
+        for asset in deployable_assets(assets, selected_agents)
+        if asset.id in selected_ids
+    ]
+
+
+def sanitize_selected_asset_ids(
+    assets: list[SpecOpsAsset],
+    selected_asset_ids: list[str],
+    selected_agents: list[Character] | None = None,
+) -> list[str]:
+    """Drop damaged, missing, duplicate, or unpiloted assets from selection."""
+    deployable_ids = {asset.id for asset in deployable_assets(assets, selected_agents)}
+    sanitized: list[str] = []
+    for asset_id in selected_asset_ids:
+        if asset_id in deployable_ids and asset_id not in sanitized:
+            sanitized.append(asset_id)
+    return sanitized
+
+
+def selected_deployment_manifest(
+    characters: list[Character],
+    selected_agent_names: list[str],
+    assets: list[SpecOpsAsset] | None = None,
+    selected_asset_ids: list[str] | None = None,
+) -> DeploymentManifest:
+    """Build the mixed team currently eligible to enter tactical combat."""
+    agents = selected_deployable_agents(characters, selected_agent_names)
+    selected_assets = selected_deployable_assets(
+        assets or [], selected_asset_ids or [], agents
+    )
+    return DeploymentManifest(agents=agents, assets=selected_assets)
+
+
+def toggle_asset_selection(
+    assets: list[SpecOpsAsset],
+    selected_asset_ids: list[str],
+    selected_agents: list[Character] | None = None,
+) -> tuple[list[str], str]:
+    """Toggle one ready support asset while keeping agents as the squad focus."""
+    deployable = deployable_assets(assets, selected_agents)
+    sanitized = sanitize_selected_asset_ids(assets, selected_asset_ids, selected_agents)
+    if not deployable:
+        return sanitized, "No ready support assets in the hangar."
+
+    for asset in deployable:
+        if asset.id not in sanitized:
+            sanitized.append(asset.id)
+            return sanitized, f"{asset.name} added as support asset."
+
+    removed_id = sanitized.pop(0)
+    removed = next((asset for asset in assets if asset.id == removed_id), None)
+    name = removed.name if removed else removed_id
+    return sanitized, f"{name} removed from support assets."

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -27,6 +27,10 @@ from .management.funds import (
     calculate_mission_fund_reward,
     default_mission_fund_distribution,
 )
+from .management.spec_ops_assets import (
+    SpecOpsAsset,
+    pay_asset_maintenance,
+)
 from .mission_templates import MissionTemplate, create_mission_templates
 from .operations import Operation, create_operation_templates
 from .world import District, create_vertical_slice_district
@@ -93,6 +97,8 @@ class GameState:
     )
     latest_agent_aftermath: list[str] = field(default_factory=list)
     selected_agent_names: list[str] = field(default_factory=list)
+    spec_ops_assets: list[SpecOpsAsset] = field(default_factory=list)
+    selected_asset_ids: list[str] = field(default_factory=list)
     event_log: list[str] = field(
         default_factory=lambda: [
             "Turn 1: Forward Base Kilo establishes overwatch in the Chrome Warrens."
@@ -127,6 +133,14 @@ class GameState:
                 "Initial corporate operating funds.",
             )
         self.budget_pool = self.funds.available_funds
+
+    def service_spec_ops_assets(self) -> int:
+        """Pay upkeep/repair for robots and power armor from corporate funds."""
+        paid = pay_asset_maintenance(self.funds, self.spec_ops_assets)
+        if paid:
+            self.budget_pool = self.funds.available_funds
+            self.add_event(f"Hangar service cycle completed for {paid} funds.")
+        return paid
 
     # ------------------------------------------------------------------
     # Turn and budget management
@@ -451,6 +465,8 @@ class GameState:
             ),
             "selected_mission_index": self.selected_mission_index,
             "selected_agent_names": list(self.selected_agent_names),
+            "spec_ops_assets": [asset.to_dict() for asset in self.spec_ops_assets],
+            "selected_asset_ids": list(self.selected_asset_ids),
             "recent_consequences": [
                 consequence.to_dict() for consequence in self.recent_consequences
             ],
@@ -514,6 +530,10 @@ class GameState:
         )
         gs.selected_mission_index = data.get("selected_mission_index", 0)
         gs.selected_agent_names = list(data.get("selected_agent_names", []))
+        gs.spec_ops_assets = [
+            SpecOpsAsset.from_dict(asset) for asset in data.get("spec_ops_assets", [])
+        ]
+        gs.selected_asset_ids = list(data.get("selected_asset_ids", []))
         gs.recent_consequences = [
             Consequence.from_dict(consequence)
             for consequence in data.get("recent_consequences", [])
@@ -536,9 +556,17 @@ class GameState:
         from .character import Character
 
         gs.characters = [Character.from_dict(c) for c in data.get("characters", [])]
-        from .deployment import sanitize_selected_agent_names
+        from .deployment import sanitize_selected_agent_names, sanitize_selected_asset_ids
 
         gs.selected_agent_names = sanitize_selected_agent_names(
             gs.characters, gs.selected_agent_names
+        )
+        selected_agents = [
+            character
+            for character in gs.characters
+            if character.name in set(gs.selected_agent_names)
+        ]
+        gs.selected_asset_ids = sanitize_selected_asset_ids(
+            gs.spec_ops_assets, gs.selected_asset_ids, selected_agents
         )
         return gs

--- a/game/management/spec_ops_assets.py
+++ b/game/management/spec_ops_assets.py
@@ -1,0 +1,267 @@
+"""Compact spec-ops asset models for robots and power armor.
+
+These assets support agents without taking over the emotional center of the
+squad: they are deployable tools with repair bills, not replacement heroes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..stats import PlayerStats
+from .funds import CorporateFunds
+
+
+@dataclass(frozen=True)
+class WeaponHardpoint:
+    """A mounted weapon slot on a combat asset."""
+
+    name: str
+    attack_stat: str = "agi"
+    damage_bonus: int = 0
+    range_cells: int = 1
+    action_name: str = "Fire"
+
+    def __post_init__(self) -> None:
+        if self.attack_stat not in {"str", "agi", "psi"}:
+            raise ValueError(f"Unsupported hardpoint attack stat: {self.attack_stat}")
+        if self.range_cells < 1:
+            raise ValueError("Hardpoint range must be at least 1 cell")
+        if self.damage_bonus < 0:
+            raise ValueError("Hardpoint damage bonus cannot be negative")
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "attack_stat": self.attack_stat,
+            "damage_bonus": self.damage_bonus,
+            "range_cells": self.range_cells,
+            "action_name": self.action_name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "WeaponHardpoint":
+        return cls(
+            name=str(data.get("name", "Hardpoint")),
+            attack_stat=str(data.get("attack_stat", "agi")),
+            damage_bonus=int(data.get("damage_bonus", 0)),
+            range_cells=int(data.get("range_cells", 1)),
+            action_name=str(data.get("action_name", "Fire")),
+        )
+
+
+@dataclass(frozen=True)
+class ArmorRating:
+    """Protection profile for a robotic or armored support asset."""
+
+    plating: int = 1
+    sealed_systems: int = 0
+
+    def __post_init__(self) -> None:
+        if self.plating < 0 or self.sealed_systems < 0:
+            raise ValueError("Armor ratings cannot be negative")
+
+    @property
+    def defense_bonus(self) -> int:
+        return self.plating + self.sealed_systems
+
+    def to_dict(self) -> dict:
+        return {"plating": self.plating, "sealed_systems": self.sealed_systems}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ArmorRating":
+        return cls(
+            plating=int(data.get("plating", 1)),
+            sealed_systems=int(data.get("sealed_systems", 0)),
+        )
+
+
+@dataclass
+class MaintenanceState:
+    """Readiness and repair cost state for a spec-ops asset."""
+
+    integrity: int = 100
+    repair_cost_per_damage: int = 1
+    base_upkeep: int = 1
+
+    def __post_init__(self) -> None:
+        self.integrity = max(0, min(int(self.integrity), 100))
+        self.repair_cost_per_damage = max(0, int(self.repair_cost_per_damage))
+        self.base_upkeep = max(0, int(self.base_upkeep))
+
+    @property
+    def can_deploy(self) -> bool:
+        return self.integrity >= 50
+
+    @property
+    def damage(self) -> int:
+        return max(0, 100 - self.integrity)
+
+    @property
+    def repair_cost(self) -> int:
+        return self.damage * self.repair_cost_per_damage
+
+    @property
+    def maintenance_cost(self) -> int:
+        return self.base_upkeep + self.repair_cost
+
+    def mark_repaired(self) -> None:
+        self.integrity = 100
+
+    def to_dict(self) -> dict:
+        return {
+            "integrity": self.integrity,
+            "repair_cost_per_damage": self.repair_cost_per_damage,
+            "base_upkeep": self.base_upkeep,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MaintenanceState":
+        return cls(
+            integrity=int(data.get("integrity", 100)),
+            repair_cost_per_damage=int(data.get("repair_cost_per_damage", 1)),
+            base_upkeep=int(data.get("base_upkeep", 1)),
+        )
+
+
+@dataclass
+class SpecOpsAsset:
+    """Base model shared by robots and power armor suits."""
+
+    id: str
+    name: str
+    asset_type: str
+    armor: ArmorRating = field(default_factory=ArmorRating)
+    hardpoints: list[WeaponHardpoint] = field(default_factory=list)
+    missile_capacity: int = 0
+    maintenance: MaintenanceState = field(default_factory=MaintenanceState)
+    pilot_required: bool = False
+    action_points: int = 2
+
+    @property
+    def display_role(self) -> str:
+        return self.asset_type.replace("_", " ")
+
+    @property
+    def is_deployable(self) -> bool:
+        return self.maintenance.can_deploy
+
+    @property
+    def primary_range(self) -> int:
+        if not self.hardpoints:
+            return 1
+        return max(hardpoint.range_cells for hardpoint in self.hardpoints)
+
+    @property
+    def combat_actions(self) -> list[str]:
+        actions = ["Move", "Defend"]
+        actions.extend(hardpoint.action_name for hardpoint in self.hardpoints)
+        if self.missile_capacity > 0:
+            actions.append("Missile Salvo")
+        return actions
+
+    def combat_stats(self) -> PlayerStats:
+        level = 1 + self.armor.defense_bonus // 3
+        strongest = max((hardpoint.damage_bonus for hardpoint in self.hardpoints), default=0)
+        stats = PlayerStats(
+            level=max(1, level),
+            defense=max(1, self.armor.defense_bonus),
+            psi=0,
+            str=max(1, 2 + strongest),
+            agi=max(1, 2 + len(self.hardpoints)),
+            con=max(1, 2 + self.armor.plating),
+        )
+        stats.hp = max(1, int(stats.max_hp * self.maintenance.integrity / 100))
+        return stats
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "asset_type": self.asset_type,
+            "armor": self.armor.to_dict(),
+            "hardpoints": [hardpoint.to_dict() for hardpoint in self.hardpoints],
+            "missile_capacity": self.missile_capacity,
+            "maintenance": self.maintenance.to_dict(),
+            "pilot_required": self.pilot_required,
+            "action_points": self.action_points,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SpecOpsAsset":
+        asset_type = str(data.get("asset_type", "combat_robot"))
+        asset_cls: type[SpecOpsAsset]
+        if asset_type == "power_armor":
+            asset_cls = PowerArmorSuit
+        elif asset_type == "combat_robot":
+            asset_cls = CombatRobot
+        else:
+            asset_cls = cls
+        return asset_cls(
+            id=str(data.get("id", "asset")),
+            name=str(data.get("name", "Spec-Ops Asset")),
+            armor=ArmorRating.from_dict(data.get("armor", {})),
+            hardpoints=[
+                WeaponHardpoint.from_dict(hardpoint)
+                for hardpoint in data.get("hardpoints", [])
+            ],
+            missile_capacity=int(data.get("missile_capacity", 0)),
+            maintenance=MaintenanceState.from_dict(data.get("maintenance", {})),
+            pilot_required=bool(data.get("pilot_required", False)),
+            action_points=int(data.get("action_points", 2)),
+        )
+
+
+@dataclass
+class CombatRobot(SpecOpsAsset):
+    """Autonomous combat robot that can deploy beside agents."""
+
+    asset_type: str = "combat_robot"
+    pilot_required: bool = False
+
+
+@dataclass
+class PowerArmorSuit(SpecOpsAsset):
+    """Power armor suit that needs an agent pilot in the selected team."""
+
+    asset_type: str = "power_armor"
+    pilot_required: bool = True
+
+
+def default_spec_ops_assets() -> list[SpecOpsAsset]:
+    """Return a tiny starting pool for tests and future campaign hooks."""
+    return [
+        CombatRobot(
+            id="robot_k9_01",
+            name="K-9 Breacher Drone",
+            armor=ArmorRating(plating=2, sealed_systems=1),
+            hardpoints=[WeaponHardpoint("Shock Carbine", damage_bonus=1, range_cells=4, action_name="Shock Carbine")],
+            missile_capacity=1,
+            maintenance=MaintenanceState(base_upkeep=2),
+        ),
+        PowerArmorSuit(
+            id="armor_aegis_01",
+            name="Aegis Mantis Suit",
+            armor=ArmorRating(plating=4, sealed_systems=1),
+            hardpoints=[WeaponHardpoint("Servo Fist", attack_stat="str", damage_bonus=2, range_cells=1, action_name="Servo Strike")],
+            missile_capacity=2,
+            maintenance=MaintenanceState(base_upkeep=3),
+        ),
+    ]
+
+
+def maintenance_cost_for_assets(assets: list[SpecOpsAsset]) -> int:
+    """Total upkeep and repair cost for the supplied assets."""
+    return sum(asset.maintenance.maintenance_cost for asset in assets)
+
+
+def pay_asset_maintenance(funds: CorporateFunds, assets: list[SpecOpsAsset]) -> int:
+    """Charge the funds ledger and restore asset integrity when affordable."""
+    cost = maintenance_cost_for_assets(assets)
+    if cost <= 0:
+        return 0
+    if not funds.spend_funds(cost, "spec_ops_maintenance", "Robot and power armor repair cycle."):
+        return 0
+    for asset in assets:
+        asset.maintenance.mark_repaired()
+    return cost

--- a/game/ui/room_interaction.py
+++ b/game/ui/room_interaction.py
@@ -136,6 +136,7 @@ ROOM_ACTIONS = {
         "armory": [
             RoomAction("select_agent", "select", "Toggle squad"),
             RoomAction("launch", "launch", "Launch mission"),
+            RoomAction("toggle_asset", "armory", "Toggle support"),
         ],
         "briefing": [
             RoomAction("agent_prev", "left", "Prev agent"),
@@ -146,7 +147,10 @@ ROOM_ACTIONS = {
             RoomAction("agent_prev", "left", "Prev agent"),
             RoomAction("agent_next", "right", "Next agent"),
         ],
-        "insertion": [RoomAction("launch", "launch", "Launch mission")],
+        "insertion": [
+            RoomAction("launch", "launch", "Launch mission"),
+            RoomAction("toggle_asset", "armory", "Toggle support"),
+        ],
     },
 }
 

--- a/game/unit.py
+++ b/game/unit.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple
 
 from .character import Character
+from .management.spec_ops_assets import SpecOpsAsset
 from .stats import PlayerStats, EnemyStats, perform_attack
 
 if TYPE_CHECKING:
@@ -15,6 +16,9 @@ class Unit:
     position: Tuple[int, int]
     stats: PlayerStats | EnemyStats | None = None
     character: Character | None = None
+    spec_ops_asset: SpecOpsAsset | None = None
+    unit_type: str = "agent"
+    equipment_summary: list[str] | None = None
     attack_range: int = 1
     health: int = 3
     action_points: int = 2

--- a/game/views.py
+++ b/game/views.py
@@ -14,8 +14,10 @@ from .combat_system import (
 )
 from .deployment import (
     sanitize_selected_agent_names,
+    sanitize_selected_asset_ids,
     selected_deployable_agents,
     toggle_agent_selection,
+    toggle_asset_selection,
 )
 from .ui import palette
 from .ui.panels import draw_graphical_command_surface
@@ -51,9 +53,13 @@ from .unit import Unit
 
 
 def build_roster_cards(
-    characters: list[Character], selected_names: list[str], cursor_index: int = 0
+    characters: list[Character],
+    selected_names: list[str],
+    cursor_index: int = 0,
+    assets: list | None = None,
+    selected_asset_ids: list[str] | None = None,
 ) -> list[dict]:
-    """Build graphical roster-card data for expanded team rooms."""
+    """Build graphical agent-first roster cards plus compact asset support cards."""
     selected = set(selected_names)
     cards = []
     for index, character in enumerate(characters):
@@ -81,6 +87,26 @@ def build_roster_cards(
                     if character.loadout.armor
                     else "No armor"
                 ),
+            }
+        )
+    selected_assets = set(selected_asset_ids or [])
+    for asset in assets or []:
+        integrity = max(0, min(asset.maintenance.integrity / 100, 1))
+        cards.append(
+            {
+                "name": asset.name,
+                "role": asset.display_role,
+                "active": False,
+                "selected": asset.id in selected_assets,
+                "portrait_path": None,
+                "hp_ratio": integrity,
+                "stress_ratio": 0,
+                "pending_points": 0,
+                "recovery_turns": 0 if asset.is_deployable else 1,
+                "level": 1,
+                "primary_weapon": asset.hardpoints[0].name if asset.hardpoints else "Unarmed rig",
+                "armor": f"Armor {asset.armor.defense_bonus} | Missiles {asset.missile_capacity}",
+                "is_asset": True,
             }
         )
     return cards
@@ -119,7 +145,10 @@ class CorpView(GameView):
             self.game_state.strategic_resources,
             self._room_info_lines(),
             roster_cards=build_roster_cards(
-                self.game_state.characters, self.game_state.selected_agent_names
+                self.game_state.characters,
+                self.game_state.selected_agent_names,
+                assets=self.game_state.spec_ops_assets,
+                selected_asset_ids=self.game_state.selected_asset_ids,
             ),
             available_funds=self.game_state.available_funds,
         )
@@ -320,7 +349,10 @@ class CityView(GameView):
             self.game_state.strategic_resources,
             self._room_info_lines(),
             roster_cards=build_roster_cards(
-                self.game_state.characters, self.game_state.selected_agent_names
+                self.game_state.characters,
+                self.game_state.selected_agent_names,
+                assets=self.game_state.spec_ops_assets,
+                selected_asset_ids=self.game_state.selected_asset_ids,
             ),
             available_funds=self.game_state.available_funds,
         )
@@ -474,6 +506,12 @@ class RPGView(GameView):
         self.game_state.selected_agent_names = sanitize_selected_agent_names(
             self.game_state.characters, self.game_state.selected_agent_names
         )
+        selected_agents = selected_deployable_agents(
+            self.game_state.characters, self.game_state.selected_agent_names
+        )
+        self.game_state.selected_asset_ids = sanitize_selected_asset_ids(
+            self.game_state.spec_ops_assets, self.game_state.selected_asset_ids, selected_agents
+        )
         ensure_mission_templates(self.game_state)
 
     def selected_mission(self) -> MissionTemplate:
@@ -486,9 +524,13 @@ class RPGView(GameView):
         self.game_state.selected_agent_names = sanitize_selected_agent_names(
             self.game_state.characters, self.game_state.selected_agent_names
         )
-        return selected_deployable_agents(
+        selected_agents = selected_deployable_agents(
             self.game_state.characters, self.game_state.selected_agent_names
         )
+        self.game_state.selected_asset_ids = sanitize_selected_asset_ids(
+            self.game_state.spec_ops_assets, self.game_state.selected_asset_ids, selected_agents
+        )
+        return selected_agents
 
     def launch_selected_mission(self) -> None:
         if not self.has_deployable_agent():
@@ -555,6 +597,8 @@ class RPGView(GameView):
                 self.game_state.characters,
                 self.game_state.selected_agent_names,
                 self.deployment_cursor_index,
+                self.game_state.spec_ops_assets,
+                self.game_state.selected_asset_ids,
             ),
             available_funds=self.game_state.available_funds,
         )
@@ -581,6 +625,18 @@ class RPGView(GameView):
                 self.game_state.characters,
                 self.game_state.selected_agent_names,
                 self.deployment_cursor_index,
+            )
+            self.pending_breakdown_confirmation = False
+            self.pending_breakdown_mission_id = None
+        elif key == arcade.key.V:
+            selected_agents = self.selected_deployment()
+            (
+                self.game_state.selected_asset_ids,
+                self.message,
+            ) = toggle_asset_selection(
+                self.game_state.spec_ops_assets,
+                self.game_state.selected_asset_ids,
+                selected_agents,
             )
             self.pending_breakdown_confirmation = False
             self.pending_breakdown_mission_id = None
@@ -745,6 +801,20 @@ class RPGView(GameView):
             self.pending_breakdown_mission_id = None
             self._refresh_squad_room_actions()
             return
+        if action_key == "toggle_asset":
+            selected_agents = self.selected_deployment()
+            (
+                self.game_state.selected_asset_ids,
+                self.message,
+            ) = toggle_asset_selection(
+                self.game_state.spec_ops_assets,
+                self.game_state.selected_asset_ids,
+                selected_agents,
+            )
+            self.pending_breakdown_confirmation = False
+            self.pending_breakdown_mission_id = None
+            self._refresh_squad_room_actions()
+            return
         if action_key.startswith("equip_"):
             self._equip_active_agent(action_key.removeprefix("equip_"))
             self._refresh_squad_room_actions()
@@ -799,7 +869,12 @@ class RPGView(GameView):
                     ]
                 )
         elif room_key == "insertion":
-            actions.append(RoomAction("launch", "launch", "Launch mission"))
+            actions.extend(
+                [
+                    RoomAction("launch", "launch", "Launch mission"),
+                    RoomAction("toggle_asset", "armory", "Toggle support"),
+                ]
+            )
         elif room_key == "ops":
             actions.extend(
                 [
@@ -857,6 +932,10 @@ class RPGView(GameView):
             else None
         )
         risk_count = len(agents_at_breaking_risk(selected, mission)) if selected else 0
+        selected_asset_count = len(self.game_state.selected_asset_ids)
+        ready_asset_count = sum(
+            1 for asset in self.game_state.spec_ops_assets if asset.is_deployable
+        )
         agent_line = (
             f"{active_agent.name} | Stress {active_agent.stress} | Loyalty {active_agent.loyalty}"
             if active_agent
@@ -881,12 +960,13 @@ class RPGView(GameView):
             "medbay": [
                 f"Recovering agents {len(recovering)}",
                 agent_line,
-                f"Selected squad {len(selected)}",
+                f"Selected squad {len(selected)} + {selected_asset_count} support",
             ],
             "armory": (
                 [
-                    f"Selected squad {len(selected)}",
+                    f"Selected squad {len(selected)} + {selected_asset_count} support",
                     f"Deployable agents {sum(1 for char in self.game_state.characters if is_deployable(char))}",
+                    f"Ready support assets {ready_asset_count}",
                     f"Upgrade points {getattr(active_agent, 'pending_points', 0) if active_agent else 0}",
                 ]
                 + (active_agent.loadout.summary_lines() if active_agent else [])
@@ -894,7 +974,7 @@ class RPGView(GameView):
             "briefing": [
                 mission.title,
                 f"Breakdown risk agents {risk_count}",
-                f"Selected squad {len(selected)}",
+                f"Selected squad {len(selected)} + {selected_asset_count} support",
             ],
             "dossier": (
                 [
@@ -906,8 +986,8 @@ class RPGView(GameView):
             ),
             "insertion": [
                 mission.title,
-                f"Selected squad {len(selected)}",
-                "Launch moves the squad to tactical combat.",
+                f"Selected squad {len(selected)} + {selected_asset_count} support",
+                "Launch moves agents and support assets to combat.",
             ],
         }
 
@@ -935,8 +1015,14 @@ class BattleView(GameView):
         selected_squad = selected_deployable_agents(
             self.game_state.characters, self.game_state.selected_agent_names
         )
+        self.game_state.selected_asset_ids = sanitize_selected_asset_ids(
+            self.game_state.spec_ops_assets, self.game_state.selected_asset_ids, selected_squad
+        )
         self.player_units = create_player_units(
-            self.game_state.characters, self.game_state.selected_agent_names
+            self.game_state.characters,
+            self.game_state.selected_agent_names,
+            self.game_state.spec_ops_assets,
+            self.game_state.selected_asset_ids,
         )
         self.defeated_player_units = []
         self.enemy_units, self.initial_enemy_count = create_enemy_units(

--- a/tests/test_spec_ops_assets.py
+++ b/tests/test_spec_ops_assets.py
@@ -1,0 +1,120 @@
+"""Spec-ops robot and power armor support assets."""
+
+import unittest
+
+from game.character import Character
+from game.combat_system import create_player_units
+from game.deployment import (
+    deployable_assets,
+    sanitize_selected_asset_ids,
+    selected_deployment_manifest,
+    toggle_asset_selection,
+)
+from game.gamestate import GameState
+from game.management.spec_ops_assets import (
+    ArmorRating,
+    CombatRobot,
+    MaintenanceState,
+    PowerArmorSuit,
+    WeaponHardpoint,
+)
+
+
+class SpecOpsAssetsTest(unittest.TestCase):
+    def test_create_combat_robot_and_power_armor_models(self):
+        robot = CombatRobot(
+            id="drone_01",
+            name="K-9 Breacher",
+            armor=ArmorRating(plating=2, sealed_systems=1),
+            hardpoints=[WeaponHardpoint("Shock Carbine", damage_bonus=1, range_cells=4)],
+            missile_capacity=2,
+        )
+        suit = PowerArmorSuit(id="suit_01", name="Mantis Suit")
+
+        self.assertEqual(robot.asset_type, "combat_robot")
+        self.assertFalse(robot.pilot_required)
+        self.assertEqual(robot.armor.defense_bonus, 3)
+        self.assertEqual(robot.primary_range, 4)
+        self.assertIn("Missile Salvo", robot.combat_actions)
+        self.assertTrue(suit.pilot_required)
+
+
+    def test_toggle_asset_selection_adds_ready_support_without_agent_selection(self):
+        robot = CombatRobot(id="drone", name="Drone")
+
+        selected_ids, message = toggle_asset_selection([robot], [])
+
+        self.assertEqual(selected_ids, ["drone"])
+        self.assertEqual(message, "Drone added as support asset.")
+
+    def test_deployment_eligibility_requires_readiness_and_pilot_when_needed(self):
+        agent = Character("Vega")
+        robot = CombatRobot(id="drone", name="Drone")
+        damaged = CombatRobot(
+            id="wreck", name="Wreck", maintenance=MaintenanceState(integrity=40)
+        )
+        suit = PowerArmorSuit(id="armor", name="Armor")
+
+        self.assertEqual(deployable_assets([robot, damaged, suit], []), [robot])
+        self.assertEqual(deployable_assets([robot, damaged, suit], [agent]), [robot, suit])
+        self.assertEqual(
+            sanitize_selected_asset_ids([robot, damaged, suit], ["wreck", "armor", "armor"], [agent]),
+            ["armor"],
+        )
+
+    def test_selected_deployment_manifest_includes_agents_robots_and_power_armor(self):
+        agent = Character("Vega")
+        robot = CombatRobot(id="drone", name="Drone")
+        suit = PowerArmorSuit(id="armor", name="Armor")
+
+        manifest = selected_deployment_manifest(
+            [agent], ["Vega"], [robot, suit], ["drone", "armor"]
+        )
+
+        self.assertEqual(manifest.agents, [agent])
+        self.assertEqual(manifest.assets, [robot, suit])
+        self.assertTrue(manifest.has_units)
+
+    def test_combat_unit_conversion_uses_distinct_asset_stats_actions_and_equipment(self):
+        agent = Character("Vega")
+        robot = CombatRobot(
+            id="drone",
+            name="Drone",
+            armor=ArmorRating(plating=3, sealed_systems=1),
+            hardpoints=[WeaponHardpoint("Rail Stubber", damage_bonus=2, range_cells=5, action_name="Rail Burst")],
+            missile_capacity=1,
+        )
+
+        units = create_player_units([agent], ["Vega"], [robot], ["drone"])
+
+        self.assertEqual(len(units), 2)
+        self.assertEqual(units[0].unit_type, "agent")
+        self.assertIs(units[1].spec_ops_asset, robot)
+        self.assertEqual(units[1].unit_type, "combat_robot")
+        self.assertEqual(units[1].attack_range, 5)
+        self.assertIn("Rail Burst", units[1].available_actions)
+        self.assertIn("Missile Salvo", units[1].available_actions)
+        self.assertIn("Rail Stubber", units[1].equipment_summary)
+        self.assertGreater(units[1].stats.defense, units[0].stats.defense)
+
+    def test_maintenance_costs_spend_funds_and_restore_integrity(self):
+        robot = CombatRobot(
+            id="drone",
+            name="Drone",
+            maintenance=MaintenanceState(
+                integrity=80, repair_cost_per_damage=2, base_upkeep=3
+            ),
+        )
+        state = GameState(spec_ops_assets=[robot])
+        starting_funds = state.available_funds
+
+        paid = state.service_spec_ops_assets()
+
+        self.assertEqual(paid, 43)
+        self.assertEqual(state.available_funds, starting_funds - 43)
+        self.assertEqual(robot.maintenance.integrity, 100)
+        self.assertEqual(state.funds.transaction_history[-1].source, "spec_ops_maintenance")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small, contained vertical slice for spec-ops support assets so teams can field robots and power-armor alongside agents without replacing the emotional focus on agents. 
- Represent weapon hardpoints, armor ratings, missile capacity, pilot requirement, and maintenance/repair costs as first-class data so funds and combat systems can treat assets consistently. 
- Keep scope small and modular: add asset models, deployment selection, combat conversion, upkeep, UI display, docs, and tests as a compact feature set.

### Description
- Add `game/management/spec_ops_assets.py` defining `SpecOpsAsset`, `CombatRobot`, `PowerArmorSuit`, `WeaponHardpoint`, `ArmorRating`, `MaintenanceState`, serialization, `combat_stats`/`combat_actions`, and funds-backed `pay_asset_maintenance` helpers. 
- Extend deployment helpers in `game/deployment.py` with `DeploymentManifest`, `deployable_assets`, `selected_deployable_assets`, `sanitize_selected_asset_ids`, and `toggle_asset_selection` so selected teams may include assets (pilot checks preserved). 
- Update combat setup in `game/combat_system.py` and `game/unit.py` so assets convert to `Unit` instances with `spec_ops_asset`, `unit_type`, `equipment_summary`, distinct stats/actions/range, and are appended beside agent units. 
- Add GameState fields and logic in `game/gamestate.py` to store `spec_ops_assets` and `selected_asset_ids`, sanitize selections on load, and pay/record maintenance via `service_spec_ops_assets`. 
- Surface assets in the squad UI (`game/views.py`, `game/ui/room_interaction.py`) by adding compact support cards, toggle actions/keys, insertion/armory actions, and ensure BattleView passes selected assets into combat unit creation. 
- Update docs (`docs/backlog.md`, `docs/roadmap.md`) and add unit tests `tests/test_spec_ops_assets.py` covering creation, eligibility, manifest selection, combat unit conversion, support toggling, and maintenance charges.

### Testing
- Type-check/compile: `python -m py_compile game/management/spec_ops_assets.py game/deployment.py game/combat_system.py game/gamestate.py game/views.py game/unit.py game/ui/room_interaction.py tests/test_spec_ops_assets.py` (succeeded). 
- Unit tests: `python -m unittest discover -s tests` (all tests passed; full test run OK). 
- New spec-ops tests: `python -m unittest tests/test_spec_ops_assets.py` (success: new tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0798efaf14832b8d3b1baea0d1e1fe)