### PR TITLE
Add contextual battle action bar

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -21,6 +21,7 @@ TODO:
 [x] Add small strategic event deck for corporate, mutant, Starvers, social, and political threats
 [x] Add starter research management with timed funded projects and lab UI
 [x] Add spec-ops robot and power-armor assets with deployment, combat conversion, and maintenance costs
+[x] Add contextual battle action bar for selected unit combat choices
 [x] Create Agent data model
 [ ] Create district data model
 [ ] Create mission generation system
@@ -91,3 +92,6 @@ Done:
   Deployment can include selected support assets beside selected agents, combat
   setup converts them into distinct Units, and the funds ledger can pay their
   upkeep/repair costs without making them the emotional center of the squad.
+- Contextual battle action bar: the battle map now has a reusable selected-unit
+  action deck that shows only sensible move, fire, melee, psi, first-aid,
+  missile, defend, and end-turn options from pure combat action rules.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,6 +63,10 @@
     them beside agents; combat setup turns them into distinct Units; and the
     funds ledger pays upkeep/repair while agent cards remain first in the squad
     UI.
+  - Progress: Battle UI now has a reusable contextual action deck for the
+    selected unit. Pure combat action rules decide when fire, melee, psi,
+    first aid, missiles, defend, and end-turn controls appear so rendering stays
+    small and testable.
 - District system
 - Mission generation
 - Black ops

--- a/game/combat_actions.py
+++ b/game/combat_actions.py
@@ -1,0 +1,135 @@
+"""Pure combat action availability rules for tactical UI.
+
+The battle renderer consumes this module so action visibility stays testable
+without importing Arcade or binding rules to draw code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .management.equipment import EquipmentItem, Weapon
+from .unit import Unit
+
+
+@dataclass(frozen=True)
+class CombatAction:
+    """One contextual action exposed by the battle command bar."""
+
+    key: str
+    label: str
+    icon: str
+    hotkey: str = ""
+
+
+def _item_tags(item: EquipmentItem | None) -> set[str]:
+    return {tag.lower() for tag in item.tags} if item else set()
+
+
+def _is_medical_item(item: EquipmentItem | None) -> bool:
+    if item is None:
+        return False
+    text = f"{item.id} {item.name}".lower()
+    return "medical" in _item_tags(item) or "medkit" in text or "trauma" in text
+
+
+def _weapon_supports_fire(weapon: Weapon | None) -> bool:
+    return bool(weapon and (weapon.range_cells > 1 or weapon.attack_stat == "agi"))
+
+
+def _weapon_supports_melee(weapon: Weapon | None) -> bool:
+    return bool(weapon and (weapon.range_cells <= 1 or weapon.attack_stat == "str"))
+
+
+def unit_can_fire(unit: Unit) -> bool:
+    """Return whether the unit has an equipped ranged weapon or hardpoint."""
+    if unit.spec_ops_asset:
+        return any(
+            hardpoint.range_cells > 1 or hardpoint.attack_stat == "agi"
+            for hardpoint in unit.spec_ops_asset.hardpoints
+        )
+    loadout = unit.character.loadout if unit.character else None
+    return bool(
+        loadout
+        and (
+            _weapon_supports_fire(loadout.primary_weapon)
+            or _weapon_supports_fire(loadout.sidearm)
+        )
+    )
+
+
+def unit_can_melee(unit: Unit) -> bool:
+    """Return whether the unit has a close-quarters weapon or hardpoint."""
+    if unit.spec_ops_asset:
+        return any(
+            hardpoint.range_cells <= 1 or hardpoint.attack_stat == "str"
+            for hardpoint in unit.spec_ops_asset.hardpoints
+        )
+    loadout = unit.character.loadout if unit.character else None
+    return bool(
+        loadout
+        and (
+            _weapon_supports_melee(loadout.primary_weapon)
+            or _weapon_supports_melee(loadout.sidearm)
+        )
+    )
+
+
+def unit_can_use_psi(unit: Unit) -> bool:
+    """Return whether an agent has psi training or a psi focus equipped."""
+    if not unit.character:
+        return False
+    loadout = unit.character.loadout
+    return (
+        unit.character.role == "psi"
+        or bool(loadout.psi_focus)
+        or "psi" in {trait.lower() for trait in unit.character.traits}
+    )
+
+
+def unit_can_first_aid(unit: Unit) -> bool:
+    """Return whether an agent carries medical gear or has medic training."""
+    if not unit.character:
+        return False
+    character = unit.character
+    loadout = character.loadout
+    skill_markers = {
+        character.role.lower(),
+        *(trait.lower() for trait in character.traits),
+    }
+    return (
+        "medic" in skill_markers
+        or "first aid" in skill_markers
+        or _is_medical_item(loadout.utility_item)
+        or any("medical" in _item_tags(item) for item in loadout.equipped_items())
+    )
+
+
+def unit_can_use_missiles(unit: Unit) -> bool:
+    """Return whether a support asset has missile capacity."""
+    return bool(unit.spec_ops_asset and unit.spec_ops_asset.missile_capacity > 0)
+
+
+def available_combat_actions(unit: Unit | None) -> list[CombatAction]:
+    """Build ordered, contextual combat actions for the selected unit."""
+    if unit is None or unit.health <= 0:
+        return []
+
+    actions = [CombatAction("move", "Move", "radar", "Arrows")]
+    if unit_can_fire(unit):
+        actions.append(CombatAction("fire", "Fire", "armory", "F"))
+    if unit_can_melee(unit):
+        actions.append(CombatAction("melee", "Melee", "black_ops", "Space"))
+    if unit_can_use_psi(unit):
+        actions.append(CombatAction("psi", "Psi", "research", "P"))
+    if unit_can_first_aid(unit):
+        actions.append(CombatAction("first_aid", "First Aid", "medbay", "A"))
+    if unit_can_use_missiles(unit):
+        actions.append(CombatAction("missiles", "Missiles", "launch", "M"))
+    actions.extend(
+        [
+            CombatAction("defend", "Defend", "shield", "D"),
+            CombatAction("end_turn", "End Turn", "right", "Enter"),
+        ]
+    )
+    return actions

--- a/game/ui/combat_action_bar.py
+++ b/game/ui/combat_action_bar.py
@@ -1,0 +1,112 @@
+"""Reusable tactical combat action bar drawing and hit-testing."""
+
+from __future__ import annotations
+
+import arcade
+
+from ..combat_actions import CombatAction
+from . import palette
+from .panels import _draw_icon, draw_panel
+from .room_interaction import UIRect
+
+
+BAR_HEIGHT = 112
+BUTTON_WIDTH = 96
+BUTTON_HEIGHT = 58
+BUTTON_GAP = 10
+
+
+def combat_action_bar_rect(width: int) -> UIRect:
+    """Return the bottom-center action bar rectangle."""
+    bar_width = min(width - 28, 880)
+    return UIRect((width - bar_width) // 2, 18, bar_width, BAR_HEIGHT)
+
+
+def layout_combat_action_buttons(
+    width: int, actions: list[CombatAction]
+) -> list[tuple[CombatAction, UIRect]]:
+    """Lay out action buttons in a centered command strip."""
+    if not actions:
+        return []
+    bar = combat_action_bar_rect(width)
+    button_width = min(BUTTON_WIDTH, max(66, (bar.width - 48) // max(1, len(actions))))
+    total_width = len(actions) * button_width + (len(actions) - 1) * BUTTON_GAP
+    left = bar.left + max(20, (bar.width - total_width) // 2)
+    bottom = bar.bottom + 24
+    return [
+        (
+            action,
+            UIRect(
+                left + index * (button_width + BUTTON_GAP),
+                bottom,
+                button_width,
+                BUTTON_HEIGHT,
+            ),
+        )
+        for index, action in enumerate(actions)
+    ]
+
+
+def combat_action_at_point(
+    buttons: list[tuple[CombatAction, UIRect]], x: int, y: int
+) -> CombatAction | None:
+    """Return the clicked combat action, if the point hits a button."""
+    for action, rect in buttons:
+        if rect.contains(x, y):
+            return action
+    return None
+
+
+def draw_combat_action_bar(
+    width: int,
+    height: int,
+    actions: list[CombatAction],
+    unit_name: str,
+    action_points: int,
+    message: str = "",
+) -> list[tuple[CombatAction, UIRect]]:
+    """Draw the tactical action bar and return its clickable button rects."""
+    bar = combat_action_bar_rect(width)
+    draw_panel(bar.left, bar.bottom, bar.width, bar.height, "Action Deck")
+    arcade.draw_text(
+        f"{unit_name.upper()} // AP {max(0, action_points)}",
+        bar.left + 18,
+        bar.top - 51,
+        palette.RESOURCE,
+        11,
+    )
+    if message:
+        arcade.draw_text(
+            message[:72], bar.left + 220, bar.top - 51, palette.MUTED_TEXT, 10
+        )
+
+    buttons = layout_combat_action_buttons(width, actions)
+    for action, rect in buttons:
+        arcade.draw_lrbt_rectangle_filled(
+            rect.left, rect.right, rect.bottom, rect.top, palette.ACTION_BUTTON_FILL
+        )
+        arcade.draw_line(
+            rect.left, rect.top, rect.right, rect.top, palette.PANEL_BORDER, 2
+        )
+        arcade.draw_line(
+            rect.left, rect.bottom, rect.right, rect.bottom, palette.GRID_LINE, 1
+        )
+        _draw_icon(action.icon, rect.center_x, rect.bottom + 37, 20, palette.ACCENT)
+        arcade.draw_text(
+            action.label.upper(),
+            rect.center_x,
+            rect.bottom + 18,
+            palette.TEXT,
+            9,
+            anchor_x="center",
+        )
+        if action.hotkey:
+            arcade.draw_text(
+                action.hotkey,
+                rect.center_x,
+                rect.bottom + 12,
+                palette.WARNING,
+                8,
+                anchor_x="center",
+            )
+    return buttons

--- a/game/views.py
+++ b/game/views.py
@@ -6,6 +6,7 @@ from .agent_readiness import agents_at_breaking_risk, build_agent_readiness_line
 from .battle_outcomes import resolve_defeated_agent_outcome
 from .character import Character, is_deployable
 from .management.equipment import EQUIPMENT_SLOTS, default_equipment_catalog
+from .combat_actions import available_combat_actions
 from .combat_system import (
     create_enemy_units,
     create_player_units,
@@ -20,6 +21,11 @@ from .deployment import (
     toggle_asset_selection,
 )
 from .ui import palette
+from .ui.combat_action_bar import (
+    combat_action_at_point,
+    draw_combat_action_bar,
+    layout_combat_action_buttons,
+)
 from .ui.panels import draw_graphical_command_surface
 from .ui.room_interaction import (
     RoomAction,
@@ -1062,6 +1068,7 @@ class BattleView(GameView):
         self.target_candidates = []
         self.selected_target_idx = 0
         self.pending_attack = None
+        self.combat_action_buttons = []
         self.start_player_turn()
 
     def is_occupied(self, x: int, y: int, *, exclude: Unit | None = None) -> bool:
@@ -1309,9 +1316,89 @@ class BattleView(GameView):
                 self.window.height - 38,
                 palette.ACCENT if self.turn == "player" else palette.WARNING,
             )
+        if self.turn == "player" and self.player_units:
+            active_unit = self.player_units[self.active_index]
+            unit_name = (
+                active_unit.character.name
+                if active_unit.character
+                else active_unit.spec_ops_asset.name
+                if active_unit.spec_ops_asset
+                else active_unit.unit_type
+            )
+            self.combat_action_buttons = draw_combat_action_bar(
+                self.window.width,
+                self.window.height,
+                available_combat_actions(active_unit),
+                unit_name,
+                active_unit.action_points,
+                self.message,
+            )
+        else:
+            self.combat_action_buttons = []
         if self.turn == "ended":
             color = palette.TACTICAL_GREEN if not self.enemy_units else palette.DANGER
             arcade.draw_lrbt_rectangle_filled(0, self.window.width, 0, 18, color)
+
+    def _begin_target_action(self, player: Unit, attack_key: str) -> None:
+        """Enter target selection for an available combat-bar attack."""
+        if attack_key == "melee":
+            range_cells = 1
+            pending = "melee"
+        elif attack_key == "fire":
+            range_cells = max(1, player.attack_range)
+            pending = "shoot"
+        else:
+            range_cells = 10
+            pending = "psi"
+        self.target_candidates = [
+            enemy
+            for enemy in self.enemy_units
+            if player.distance_to(enemy) <= range_cells * 32
+        ]
+        if self.target_candidates:
+            self.selecting_target = True
+            self.selected_target_idx = 0
+            self.pending_attack = pending
+        else:
+            self.message = "No enemy in range"
+
+    def _perform_combat_action(self, action_key: str) -> bool:
+        """Perform a clicked or keyed combat action for the active player unit."""
+        if self.turn != "player" or not self.player_units:
+            return False
+        player = self.player_units[self.active_index]
+        available = {action.key for action in available_combat_actions(player)}
+        if action_key not in available:
+            return False
+        if action_key == "move":
+            self.message = "Move with arrow keys."
+            return True
+        if action_key in {"fire", "melee", "psi"}:
+            self._begin_target_action(player, action_key)
+            return True
+        if action_key == "first_aid":
+            if player.action_points <= 0 or not player.stats:
+                return True
+            before = player.health
+            player.health = min(player.stats.max_hp, player.health + 2)
+            player.stats.hp = player.health
+            player.action_points -= 1
+            self.message = f"First aid restores {player.health - before} HP."
+            self.check_active_player()
+            return True
+        if action_key == "missiles":
+            self._begin_target_action(player, "fire")
+            self.message = "Missile target lock acquired."
+            return True
+        if action_key == "defend":
+            player.defend()
+            self.check_active_player()
+            return True
+        if action_key == "end_turn":
+            player.action_points = 0
+            self.check_active_player()
+            return True
+        return False
 
     def on_key_press(self, key, modifiers):
         if self.map_index is None:
@@ -1365,7 +1452,14 @@ class BattleView(GameView):
                         "shoot": "shoots",
                         "psi": "psy hits",
                     }[self.pending_attack]
-                    self.message = f"{player.character.name} {atk_name} for {damage}"
+                    attacker_name = (
+                        player.character.name
+                        if player.character
+                        else player.spec_ops_asset.name
+                        if player.spec_ops_asset
+                        else player.unit_type
+                    )
+                    self.message = f"{attacker_name} {atk_name} for {damage}"
                     self.start_attack_animation(player, target)
                     if target.health <= 0:
                         if target.sprite:
@@ -1417,37 +1511,19 @@ class BattleView(GameView):
             if not self.is_occupied(new_x, new_y, exclude=player):
                 player.move(32, 0)
         elif key == arcade.key.SPACE:
-            self.target_candidates = [
-                e for e in self.enemy_units if player.distance_to(e) <= 32
-            ]
-            if self.target_candidates:
-                self.selecting_target = True
-                self.selected_target_idx = 0
-                self.pending_attack = "melee"
-            else:
-                self.message = "No enemy in range"
+            self._perform_combat_action("melee")
         elif key == arcade.key.F:
-            self.target_candidates = [
-                e for e in self.enemy_units if player.distance_to(e) <= 10 * 32
-            ]
-            if self.target_candidates:
-                self.selecting_target = True
-                self.selected_target_idx = 0
-                self.pending_attack = "shoot"
-            else:
-                self.message = "No enemy in range"
+            self._perform_combat_action("fire")
         elif key == arcade.key.P:
-            self.target_candidates = [
-                e for e in self.enemy_units if player.distance_to(e) <= 10 * 32
-            ]
-            if self.target_candidates:
-                self.selecting_target = True
-                self.selected_target_idx = 0
-                self.pending_attack = "psi"
-            else:
-                self.message = "No enemy in range"
+            self._perform_combat_action("psi")
+        elif key == arcade.key.A:
+            self._perform_combat_action("first_aid")
+        elif key == arcade.key.M:
+            self._perform_combat_action("missiles")
+        elif key == arcade.key.ENTER or key == arcade.key.RETURN:
+            self._perform_combat_action("end_turn")
         elif key == arcade.key.D:
-            player.defend()
+            self._perform_combat_action("defend")
         elif key == arcade.key.V:
             player.psi_defend()
         elif key == arcade.key.ESCAPE:
@@ -1462,6 +1538,14 @@ class BattleView(GameView):
             if self._handle_map_room_click(x, y):
                 return
             return
+        if self.turn == "player" and self.player_units:
+            active_unit = self.player_units[self.active_index]
+            buttons = self.combat_action_buttons or layout_combat_action_buttons(
+                self.window.width, available_combat_actions(active_unit)
+            )
+            action = combat_action_at_point(buttons, x, y)
+            if action is not None:
+                self._perform_combat_action(action.key)
 
     def _handle_map_room_click(self, x: int, y: int) -> bool:
         if self.room_ui.is_open:

--- a/tests/test_combat_actions.py
+++ b/tests/test_combat_actions.py
@@ -1,0 +1,84 @@
+"""Pure combat action availability rules."""
+
+import unittest
+
+from game.character import Character
+from game.combat_actions import available_combat_actions
+from game.combat_system import create_asset_unit, create_player_units
+from game.management.equipment import Weapon, default_equipment_catalog
+from game.management.spec_ops_assets import ArmorRating, CombatRobot, WeaponHardpoint
+
+
+def action_keys(unit):
+    return [action.key for action in available_combat_actions(unit)]
+
+
+class CombatActionsTest(unittest.TestCase):
+    def test_ranged_agent_gets_fire_without_psi_or_missiles(self):
+        catalog = default_equipment_catalog()
+        agent = Character("Vega", role="sniper")
+        agent.loadout.equip("primary_weapon", catalog["primary_weapon"][0])
+
+        keys = action_keys(create_player_units([agent])[0])
+
+        self.assertIn("move", keys)
+        self.assertIn("fire", keys)
+        self.assertIn("defend", keys)
+        self.assertIn("end_turn", keys)
+        self.assertNotIn("psi", keys)
+        self.assertNotIn("missiles", keys)
+
+    def test_psi_and_first_aid_are_contextual_agent_actions(self):
+        catalog = default_equipment_catalog()
+        agent = Character("Echo", role="psi")
+        agent.loadout.equip("utility_item", catalog["utility_item"][0])
+        agent.loadout.equip("psi_focus", catalog["psi_focus"][0])
+
+        keys = action_keys(create_player_units([agent])[0])
+
+        self.assertIn("psi", keys)
+        self.assertIn("first_aid", keys)
+
+    def test_melee_depends_on_close_weapon(self):
+        blade = Weapon(
+            "test_blade",
+            "Test Blade",
+            "primary_weapon",
+            allowed_slots=("primary_weapon",),
+            attack_stat="str",
+            range_cells=1,
+        )
+        agent = Character("Knox")
+        agent.loadout.equip("primary_weapon", blade)
+
+        keys = action_keys(create_player_units([agent])[0])
+
+        self.assertIn("melee", keys)
+        self.assertNotIn("fire", keys)
+
+    def test_medic_trait_unlocks_first_aid_without_item(self):
+        agent = Character("Patch", traits=["first aid"])
+
+        self.assertIn("first_aid", action_keys(create_player_units([agent])[0]))
+
+    def test_robot_missiles_require_capacity(self):
+        robot = CombatRobot(
+            id="r1",
+            name="Bulwark",
+            armor=ArmorRating(plating=2),
+            hardpoints=[WeaponHardpoint("Rail", range_cells=8)],
+            missile_capacity=2,
+        )
+        keys = action_keys(create_asset_unit(robot, 0))
+        robot.missile_capacity = 0
+        no_missile_keys = action_keys(create_asset_unit(robot, 0))
+
+        self.assertIn("fire", keys)
+        self.assertIn("missiles", keys)
+        self.assertNotIn("missiles", no_missile_keys)
+        self.assertNotIn("psi", keys)
+        self.assertNotIn("first_aid", keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small, reusable tactical action deck for the battle UI so selected-unit controls are consistent with the corporate UI style and remain decoupled from rendering code. 
- Keep action-visibility logic pure and testable so rules like psi-only, medic-only, and missile-capacity gating can be validated without Arcade. 
- Wire keyboard and mouse handling through the same helper so the BattleView remains small and the UI remains modular and maintainable.

### Description
- Add `game/combat_actions.py`: a pure logic helper that builds ordered contextual actions (move, fire, melee, psi, first aid, missiles, defend, end turn) based on unit loadout, traits, and asset hardpoints. 
- Add `game/ui/combat_action_bar.py`: a corporate-styled, bottom-centered action bar with layout, drawing, icon support, and hit-testing using existing `palette` and `panels` helpers. 
- Wire BattleView (`game/views.py`) to render the action bar for the active unit and route key/mouse actions through `_perform_combat_action` and `_begin_target_action` to reuse the availability rules. 
- Add unit tests `tests/test_combat_actions.py` covering ranged/melee/psi/first-aid/missile availability and update `docs/backlog.md` and `docs/roadmap.md` to record the change.

### Testing
- Ran `python -m pytest tests/test_combat_actions.py` and the new tests passed (5 passed). 
- Ran the full test suite with `python -m pytest` and all tests passed (124 passed), confirming no regressions in existing code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082d6cbbf4832b97efddfd39d20f89)