### PR TITLE
Add daily strategic stress recovery loop

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -23,9 +23,9 @@ TODO:
 [x] Add spec-ops robot and power-armor assets with deployment, combat conversion, and maintenance costs
 [x] Add contextual battle action bar for selected unit combat choices
 [x] Create Agent data model
-[ ] Create district data model
+[x] Create district data model
 [ ] Create mission generation system
-[ ] Create stress system
+[x] Create stress system
 
 Done:
 - Corporate tower base UI: Corp, City, RPG, and Battle screens now share a
@@ -95,3 +95,7 @@ Done:
 - Contextual battle action bar: the battle map now has a reusable selected-unit
   action deck that shows only sensible move, fire, melee, psi, first-aid,
   missile, defend, and end-turn options from pure combat action rules.
+
+- Daily stress recovery now ticks from the strategic calendar: every day lowers
+  agent stress by 1, while agents in medical recovery decompress by 2 and log
+  visible command-room updates to keep emotional consequences readable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,6 +73,9 @@
 
 # Phase 2
 - Agent system
+  - Progress: Strategic calendar now applies a compact stress-recovery loop:
+    active agents decompress by 1 stress/day, medbay recovery agents by 2/day,
+    and command logs surface those emotional beats without adding a giant sim.
   - Progress: Loadouts are now a first small agent-system slice, giving agents
     memorable gear choices while preserving scope and modularity.
 - Media system

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -27,6 +27,7 @@ from .management.funds import (
     calculate_mission_fund_reward,
     default_mission_fund_distribution,
 )
+from .management.stress import daily_stress_recovery
 from .management.spec_ops_assets import (
     SpecOpsAsset,
     pay_asset_maintenance,
@@ -305,7 +306,11 @@ class GameState:
     def advance_one_day(self, reason: str = "manual") -> None:
         """Move the shared strategic clock one day and process daily systems."""
         recovered_agents = []
+        stress_recovery_log = []
         for character in self.characters:
+            stress_result = daily_stress_recovery(character)
+            if stress_result.changed:
+                stress_recovery_log.append((character.name, stress_result.amount, character.stress))
             if character.recovery_turns > 0:
                 character.recovery_turns -= 1
                 if character.recovery_turns == 0:
@@ -337,6 +342,10 @@ class GameState:
         advance_research_days(self, 1, self.research_tree)
         expire_events(self)
         roll_random_event(self)
+        for name, amount, remaining in stress_recovery_log:
+            self.add_event(
+                f"{self.calendar.campaign_date_label}: {name} decompresses ({amount} stress relief, {remaining}/100)."
+            )
         for name in recovered_agents:
             self.add_event(
                 f"{self.calendar.campaign_date_label}: {name} is deployable after recovery."

--- a/game/management/stress.py
+++ b/game/management/stress.py
@@ -1,0 +1,36 @@
+"""Small strategic stress recovery rules for the management calendar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..character import Character
+
+
+@dataclass(frozen=True)
+class StressRecoveryResult:
+    """Result of one daily strategic stress recovery tick."""
+
+    changed: bool
+    amount: int
+
+
+def daily_stress_recovery(character: Character) -> StressRecoveryResult:
+    """Apply one day of stress relief based on current agent condition.
+
+    Recovery is intentionally conservative so mission-level stress remains meaningful:
+    - Agents in medical recovery decompress faster from mandatory downtime.
+    - Active agents recover slowly to avoid erasing emotional consequences.
+    """
+    current = max(0, min(100, int(character.stress)))
+    if current <= 0:
+        return StressRecoveryResult(changed=False, amount=0)
+
+    recovery_amount = 2 if character.recovery_turns > 0 else 1
+    next_value = max(0, current - recovery_amount)
+    amount = current - next_value
+    if amount <= 0:
+        return StressRecoveryResult(changed=False, amount=0)
+
+    character.stress = next_value
+    return StressRecoveryResult(changed=True, amount=amount)

--- a/tests/test_stress_management.py
+++ b/tests/test_stress_management.py
@@ -1,0 +1,48 @@
+import unittest
+
+from game.character import Character
+from game.gamestate import GameState
+from game.management.stress import daily_stress_recovery
+
+
+class StressManagementTests(unittest.TestCase):
+    def test_daily_stress_recovery_relieves_active_agents_slowly(self):
+        agent = Character(name="Echo", stress=12)
+
+        result = daily_stress_recovery(agent)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(result.amount, 1)
+        self.assertEqual(agent.stress, 11)
+
+    def test_daily_stress_recovery_relieves_recovering_agents_faster(self):
+        agent = Character(name="Mender", stress=12, recovery_turns=2)
+
+        result = daily_stress_recovery(agent)
+
+        self.assertTrue(result.changed)
+        self.assertEqual(result.amount, 2)
+        self.assertEqual(agent.stress, 10)
+
+    def test_advance_day_applies_stress_recovery_and_logs_event(self):
+        game_state = GameState(
+            characters=[
+                Character(name="Ghost", stress=8),
+                Character(name="Stitch", stress=9, recovery_turns=1),
+            ]
+        )
+
+        game_state.advance_one_day("stress recovery test")
+
+        self.assertEqual(game_state.characters[0].stress, 7)
+        self.assertEqual(game_state.characters[1].stress, 7)
+        self.assertTrue(
+            any("Ghost decompresses (1 stress relief, 7/100)." in entry for entry in game_state.event_log)
+        )
+        self.assertTrue(
+            any("Stitch decompresses (2 stress relief, 7/100)." in entry for entry in game_state.event_log)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a compact, modular stress-recovery rule so agent emotional state passively heals on the strategic calendar without adding a large new simulation.
- Surface small, readable emotional beats in the command log to reinforce emergent storytelling and player attachment to agents.
- Keep scope and architecture clean by placing rules in a dedicated subdirectory/file and avoiding sprawling changes to existing systems.

### Description
- Add a new module `game/management/stress.py` containing `StressRecoveryResult` and `daily_stress_recovery(character: Character)`, which reduces stress by `1` per day (or `2` when `recovery_turns > 0`).
- Wire `daily_stress_recovery` into `GameState.advance_one_day` by importing `daily_stress_recovery` and applying it for each character, collecting decompression events and logging visible `decompresses` entries to the event feed.
- Add focused unit tests in `tests/test_stress_management.py` that validate active vs. recovering agent recovery and day-advance integration with event log assertions.
- Update documentation: mark backlog items as complete and add roadmap/backlog notes describing the new stress-recovery behavior.

### Testing
- Ran the new and existing tests with `PYTHONPATH=. pytest -q tests/test_stress_management.py tests/test_calendar_management.py` and observed all tests pass (`8 passed`).
- Initial `pytest` run without `PYTHONPATH` failed during collection due to import path, which was resolved by running with `PYTHONPATH=.` and re-running the same test set successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe952535c832b83adfec7feeb8417)