### PR TITLE
Add deterministic daily mission board generation

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -24,7 +24,7 @@ TODO:
 [x] Add contextual battle action bar for selected unit combat choices
 [x] Create Agent data model
 [x] Create district data model
-[ ] Create mission generation system
+[x] Create mission generation system
 [x] Create stress system
 
 Done:
@@ -75,6 +75,7 @@ Done:
   detail panel for launch pressure, fund rewards, complications, tags, and
   outcome stakes. Mission templates now carry `duration_days` (defaulting to
   one day), and the board shows that operation duration before launch.
+- Mission generation system: mission board entries now regenerate once per strategic day from district pressure, with deterministic day seeds for readable planning and small risk/reward variations.
 - Mission duration pacing: mission resolution advances the strategic calendar by
   the mission's `duration_days`, so existing generated missions consume one
   campaign day while later templates can opt into longer operations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,6 +63,8 @@
     them beside agents; combat setup turns them into distinct Units; and the
     funds ledger pays upkeep/repair while agent cards remain first in the squad
     UI.
+  - Progress: Mission generation now rebuilds a small daily board from district pressure with deterministic day seeds, keeping ops readable while varying risk, enemy count, and payout each campaign day.
+
   - Progress: Battle UI now has a reusable contextual action deck for the
     selected unit. Pure combat action rules decide when fire, melee, psi,
     first aid, missiles, defend, and end-turn controls appear so rendering stays

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -93,6 +93,7 @@ class GameState:
     )
     active_mission: MissionTemplate | None = None
     selected_mission_index: int = 0
+    mission_board_generated_day: int = 0
     recent_consequences: list[Consequence] = field(
         default_factory=lambda: [create_opening_consequence()]
     )

--- a/game/mission_generation.py
+++ b/game/mission_generation.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import random
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .gamestate import GameState
+from .mission_templates import MissionTemplate, create_mission_templates
+
+
+def _mission_seed(game_state: "GameState") -> int:
+    """Build a deterministic seed from campaign state for stable daily boards."""
+    return (
+        game_state.calendar.current_day * 97
+        + game_state.district.unrest * 11
+        + game_state.district.media_heat * 7
+        + (100 - game_state.district.stability) * 5
+    )
+
+
+def generate_mission_board(game_state: "GameState", board_size: int = 3) -> list[MissionTemplate]:
+    """Generate a small daily mission board based on district pressure."""
+    templates = create_mission_templates(game_state.district.name)
+    if not templates:
+        return []
+
+    rng = random.Random(_mission_seed(game_state))
+    pressure_score = game_state.district.unrest + game_state.district.media_heat
+    pressure_mod = max(0, pressure_score - game_state.district.stability) // 20
+
+    generated: list[MissionTemplate] = []
+    slots = max(1, board_size)
+    for slot in range(slots):
+        base = templates[slot % len(templates)]
+        mission = MissionTemplate.from_dict(base.to_dict())
+        risk_delta = rng.choice([-1, 0, 1]) + pressure_mod
+        mission.risk_level = max(1, mission.risk_level + risk_delta)
+        mission.fund_reward = max(20, mission.fund_reward + mission.risk_level * 5)
+        mission.starting_enemy_count = max(1, mission.starting_enemy_count + max(0, risk_delta))
+        mission.id = f"{mission.id}_d{game_state.calendar.current_day}_s{slot}"
+        mission.title = f"{mission.title} [Day {game_state.calendar.current_day}]"
+        generated.append(mission)
+
+    rng.shuffle(generated)
+    return generated
+

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -3,19 +3,22 @@
 import random
 
 from .gamestate import GameState
+from .mission_generation import generate_mission_board
 from .mission_templates import (
     MissionComplication,
     MissionTemplate,
-    create_mission_templates,
 )
 
 
 def ensure_mission_templates(game_state: GameState) -> None:
     """Ensure there is a selectable mission board and clamp the selected index."""
-    if not game_state.mission_templates:
-        game_state.mission_templates = create_mission_templates(
-            game_state.district.name
-        )
+    if (
+        not game_state.mission_templates
+        or game_state.mission_board_generated_day != game_state.calendar.current_day
+    ):
+        game_state.mission_templates = generate_mission_board(game_state)
+        game_state.mission_board_generated_day = game_state.calendar.current_day
+        game_state.selected_mission_index = 0
     game_state.selected_mission_index %= len(game_state.mission_templates)
 
 

--- a/tests/test_mission_generation.py
+++ b/tests/test_mission_generation.py
@@ -1,0 +1,43 @@
+"""Mission board generation keeps daily flavor while staying deterministic."""
+
+import unittest
+
+from game.gamestate import GameState
+from game.mission_system import ensure_mission_templates
+
+
+class MissionGenerationTest(unittest.TestCase):
+    def test_daily_generation_creates_day_tagged_board(self):
+        game_state = GameState(mission_templates=[])
+
+        ensure_mission_templates(game_state)
+
+        self.assertEqual(game_state.mission_board_generated_day, game_state.calendar.current_day)
+        self.assertTrue(game_state.mission_templates)
+        self.assertTrue(all(f"Day {game_state.calendar.current_day}" in m.title for m in game_state.mission_templates))
+
+    def test_same_day_generation_is_stable(self):
+        game_state = GameState(mission_templates=[])
+
+        ensure_mission_templates(game_state)
+        first_ids = [m.id for m in game_state.mission_templates]
+        ensure_mission_templates(game_state)
+        second_ids = [m.id for m in game_state.mission_templates]
+
+        self.assertEqual(first_ids, second_ids)
+
+    def test_next_day_regenerates_board(self):
+        game_state = GameState(mission_templates=[])
+
+        ensure_mission_templates(game_state)
+        day_one_ids = [m.id for m in game_state.mission_templates]
+
+        game_state.advance_one_day("test")
+        ensure_mission_templates(game_state)
+        day_two_ids = [m.id for m in game_state.mission_templates]
+
+        self.assertNotEqual(day_one_ids, day_two_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small, readable mission-board slice that regenerates each strategic day so players can plan with consistent daily options while still seeing day-to-day variation. 
- Use district pressure and a deterministic seed so boards are stable within a day and vary predictably across days for reproducible play and testing.

### Description
- Add a new module `game/mission_generation.py` that builds a day-tagged mission board from `create_mission_templates` using a deterministic seed and small risk/reward/enemy-count adjustments. 
- Update mission selection flow in `game/mission_system.py` to regenerate the board once per strategic day and reset `selected_mission_index` safely. 
- Extend `GameState` with `mission_board_generated_day` in `game/gamestate.py` to track the last-generated day. 
- Add `tests/test_mission_generation.py` and update `docs/backlog.md` and `docs/roadmap.md` to mark the mission-generation slice and document behavior.

### Testing
- Ran unit tests with `python -m unittest tests/test_mission_generation.py tests/test_mission_duration.py` and all tests passed. 
- The test suite execution ran 8 tests and completed with `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0feb2a11b4832bab826558c01c07cd)