### PR TITLE
Add multi-view save/load persistence service with slot-path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ python main.py
   days, and completes into unlock flags or small stat modifiers
 - `1-4` add funds to research, security, politics and black ops
 - Budget is refreshed automatically when all funds are spent
-- `S` save game / `L` load game
+- `S` save game / `L` load game (available from Corp, City, RPG, and Battle views)
+- Save files now support nested slot paths (for example `saves/slot_a/campaign.json`)
 
 ### City View
 - City control tower presents budget networks, district pressure meters, faction

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,4 +1,5 @@
 TODO:
+- [x] Add full multi-view save/load system with slot-path support and user-facing status log messages
 [x] Create mission UI
 [x] Add city/corporate tactical command deck to RPG UI
 [x] Redesign management and tactical UI shell for city/corporate XCOM2 mood

--- a/game/persistence/__init__.py
+++ b/game/persistence/__init__.py
@@ -1,0 +1,5 @@
+"""Save/load helpers for campaign persistence."""
+
+from .save_system import DEFAULT_SAVE_PATH, SaveSystem, SaveSystemResult
+
+__all__ = ["DEFAULT_SAVE_PATH", "SaveSystem", "SaveSystemResult"]

--- a/game/persistence/save_system.py
+++ b/game/persistence/save_system.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from game.gamestate import GameState
+
+DEFAULT_SAVE_PATH = Path("savegame.json")
+
+
+@dataclass(frozen=True)
+class SaveSystemResult:
+    ok: bool
+    message: str
+
+
+class SaveSystem:
+    """Small save-slot service for JSON campaign persistence."""
+
+    @staticmethod
+    def save_game(game_state: GameState, path: Path | str = DEFAULT_SAVE_PATH) -> SaveSystemResult:
+        save_path = Path(path)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        game_state.save(str(save_path))
+        return SaveSystemResult(True, f"Campaign saved to {save_path}.")
+
+    @staticmethod
+    def load_game(path: Path | str = DEFAULT_SAVE_PATH) -> tuple[GameState | None, SaveSystemResult]:
+        save_path = Path(path)
+        if not save_path.exists():
+            return None, SaveSystemResult(False, f"No save file at {save_path}.")
+        game_state = GameState.load(str(save_path))
+        return game_state, SaveSystemResult(True, f"Campaign loaded from {save_path}.")

--- a/game/views.py
+++ b/game/views.py
@@ -51,6 +51,7 @@ from .mission_system import (
     selected_mission as selected_mission_system,
 )
 from .mission_templates import MissionTemplate
+from .persistence import SaveSystem
 from .recruitment import recruit_agent
 from .ui import GameView
 from .ui.command_deck import build_corporate_finance_lines, build_event_panel_lines
@@ -190,9 +191,13 @@ class CorpView(GameView):
             budget_key, costs = self.CORP_UPGRADE_COSTS[key]
             self._buy_corp_upgrade(budget_key, costs)
         elif key == arcade.key.S:
-            self.game_state.save("savegame.json")
+            result = SaveSystem.save_game(self.game_state)
+            self.game_state.add_event(result.message)
         elif key == arcade.key.L:
-            self.game_state = GameState.load("savegame.json")
+            loaded, result = SaveSystem.load_game()
+            self.game_state.add_event(result.message)
+            if loaded is not None:
+                self.game_state = loaded
         if self.game_state.available_funds <= 0:
             self.game_state.advance_turn()
 
@@ -389,6 +394,14 @@ class CityView(GameView):
         elif key in self.CITY_UPGRADE_COSTS:
             budget_key, costs = self.CITY_UPGRADE_COSTS[key]
             self._buy_city_upgrade(budget_key, costs)
+        elif key == arcade.key.S:
+            result = SaveSystem.save_game(self.game_state)
+            self.game_state.add_event(result.message)
+        elif key == arcade.key.L:
+            loaded, result = SaveSystem.load_game()
+            self.game_state.add_event(result.message)
+            if loaded is not None:
+                self.game_state = loaded
 
     def on_mouse_press(self, x, y, button, modifiers):
         if self._handle_room_click(x, y):
@@ -615,6 +628,16 @@ class RPGView(GameView):
             return
         if key == arcade.key.B:
             self.launch_selected_mission()
+        elif key == arcade.key.S:
+            result = SaveSystem.save_game(self.game_state)
+            self.game_state.add_event(result.message)
+        elif key == arcade.key.L:
+            loaded, result = SaveSystem.load_game()
+            self.game_state.add_event(result.message)
+            if loaded is not None:
+                self.game_state = loaded
+                self.deployment_cursor_index = 0
+                self._refresh_squad_room_actions()
         elif key in (arcade.key.A, arcade.key.D) and self.game_state.characters:
             step = -1 if key == arcade.key.A else 1
             self.deployment_cursor_index = (self.deployment_cursor_index + step) % len(
@@ -1411,10 +1434,29 @@ class BattleView(GameView):
                     self.map_index = idx
                     path = os.path.join("assets/maps", self.available_maps[idx])
                     self.background = arcade.load_texture(path)
+            elif key == arcade.key.S:
+                result = SaveSystem.save_game(self.game_state)
+                self.game_state.add_event(result.message)
+            elif key == arcade.key.L:
+                loaded, result = SaveSystem.load_game()
+                self.game_state.add_event(result.message)
+                if loaded is not None:
+                    self.game_state = loaded
             elif key == arcade.key.ESCAPE:
                 corp_view = CorpView(self.game_state)
                 corp_view.setup()
                 self.window.show_view(corp_view)
+            return
+
+        if key == arcade.key.S:
+            result = SaveSystem.save_game(self.game_state)
+            self.game_state.add_event(result.message)
+            return
+        if key == arcade.key.L:
+            loaded, result = SaveSystem.load_game()
+            self.game_state.add_event(result.message)
+            if loaded is not None:
+                self.game_state = loaded
             return
 
         if self.turn != "player" or not self.player_units:

--- a/tests/test_save_system.py
+++ b/tests/test_save_system.py
@@ -1,0 +1,45 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from game.character import Character
+from game.gamestate import GameState
+from game.persistence import SaveSystem
+
+
+class SaveSystemTests(unittest.TestCase):
+    def test_load_missing_file_returns_clear_result(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "missing.json"
+            loaded, result = SaveSystem.load_game(missing)
+
+        self.assertIsNone(loaded)
+        self.assertFalse(result.ok)
+        self.assertIn("No save file", result.message)
+
+    def test_full_campaign_roundtrip_preserves_core_progress(self):
+        game_state = GameState()
+        game_state.characters.append(Character(name="Nyx", role="samurai"))
+        game_state.advance_days(2, reason="save test")
+        game_state.selected_agent_names = ["Nyx"]
+        game_state.strategic_resources["credits"] = 55
+        game_state.city_budget["armaments"] = 20
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            save_path = Path(temp_dir) / "slot_a" / "campaign.json"
+            save_result = SaveSystem.save_game(game_state, save_path)
+            loaded, load_result = SaveSystem.load_game(save_path)
+
+        self.assertTrue(save_result.ok)
+        self.assertTrue(load_result.ok)
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        self.assertEqual(loaded.calendar.current_day, game_state.calendar.current_day)
+        self.assertEqual(loaded.selected_agent_names, ["Nyx"])
+        self.assertEqual(loaded.strategic_resources["credits"], 55)
+        self.assertEqual(loaded.city_budget["armaments"], 20)
+        self.assertEqual(len(loaded.characters), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Centralize and stabilize campaign persistence so saving/loading is not ad-hoc per-view and works consistently across management and combat phases. 
- Support nested slot paths (save slots) and surface clear, player-facing status messages into the event log. 
- Keep the change small and modular to preserve codebase readability and prevent architecture churn. 

### Description
- Add a compact persistence service in `game/persistence/save_system.py` with `SaveSystem.save_game`, `SaveSystem.load_game`, `DEFAULT_SAVE_PATH`, and `SaveSystemResult`, and expose them via `game/persistence/__init__.py`. 
- Wire `S`/`L` handling in `CorpView`, `CityView`, `RPGView`, and `BattleView` to call `SaveSystem` and append result messages to the game event log. 
- Make the save helper create parent directories automatically so nested slot paths (for example `saves/slot_a/campaign.json`) are supported. 
- Update `README.md` and `docs/backlog.md` to document the multi-view save/load behavior and mark the backlog task complete. 
- Add `tests/test_save_system.py` covering missing-file load behavior and a full campaign roundtrip that verifies calendar day, selected agents, resources, city budget, and roster are preserved. 

### Testing
- Ran `pytest -q tests/test_save_system.py tests/test_strategic_resources.py tests/test_funds_management.py`; an initial collection run without package path failed with `ModuleNotFoundError: No module named 'game'`. 
- Re-ran tests with the module path set via `PYTHONPATH=. pytest -q tests/test_save_system.py tests/test_strategic_resources.py tests/test_funds_management.py` and all targeted tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff1b4f56c832b9ffb6a8f4e4c6689)