### PR TITLE
Add mission debrief narrative module and integrate into post‑mission flow

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -27,8 +27,10 @@ TODO:
 [x] Create district data model
 [x] Create mission generation system
 [x] Create stress system
+[x] Add mission debrief narrative module with GameState persistence and tests
 
 Done:
+- Mission narrative debrief API: added `game/narrative/debrief.py` with pure `DebriefLine`/`DebriefReport` data structures, deterministic emotional template mapping from stress/injury/recovery/outcome, post-mission integration in battle resolution, and persisted `latest_mission_debrief` on `GameState` for later UI consumption without view coupling.
 - Corporate tower base UI: Corp, City, RPG, and Battle screens now share a
   stacked room cross-section, resource HUD slots, pressure meters, and bottom
   action bars inspired by XCOM2 command-room readability.

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -98,6 +98,7 @@ class GameState:
         default_factory=lambda: [create_opening_consequence()]
     )
     latest_agent_aftermath: list[str] = field(default_factory=list)
+    latest_mission_debrief: dict = field(default_factory=dict)
     selected_agent_names: list[str] = field(default_factory=list)
     spec_ops_assets: list[SpecOpsAsset] = field(default_factory=list)
     selected_asset_ids: list[str] = field(default_factory=list)
@@ -481,6 +482,7 @@ class GameState:
                 consequence.to_dict() for consequence in self.recent_consequences
             ],
             "latest_agent_aftermath": list(self.latest_agent_aftermath),
+            "latest_mission_debrief": dict(self.latest_mission_debrief),
             "event_log": list(self.event_log),
             "active_events": [event.to_dict() for event in self.active_events],
             "next_event_id": self.next_event_id,
@@ -549,6 +551,7 @@ class GameState:
             for consequence in data.get("recent_consequences", [])
         ] or [create_opening_consequence(gs.district.name)]
         gs.latest_agent_aftermath = list(data.get("latest_agent_aftermath", []))
+        gs.latest_mission_debrief = dict(data.get("latest_mission_debrief", {}))
         gs.event_log = list(data.get("event_log", gs.event_log))
         gs.active_events = [
             ActiveEvent.from_dict(event) for event in data.get("active_events", [])

--- a/game/narrative/__init__.py
+++ b/game/narrative/__init__.py
@@ -1,0 +1,1 @@
+"""Narrative systems package."""

--- a/game/narrative/debrief.py
+++ b/game/narrative/debrief.py
@@ -1,0 +1,142 @@
+"""Pure mission debrief narrative mapping for post-mission reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..character import Character
+from ..mission_templates import MissionComplication, MissionTemplate
+
+
+@dataclass(frozen=True)
+class DebriefLine:
+    """Single emotional line in a mission debrief report."""
+
+    agent_name: str
+    emotional_tone: str
+    consequence_type: str
+    text: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "agent_name": self.agent_name,
+            "emotional_tone": self.emotional_tone,
+            "consequence_type": self.consequence_type,
+            "text": self.text,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DebriefLine":
+        return cls(
+            agent_name=str(data.get("agent_name", "Unknown")),
+            emotional_tone=str(data.get("emotional_tone", "steady")),
+            consequence_type=str(data.get("consequence_type", "mission_outcome")),
+            text=str(data.get("text", "")),
+        )
+
+
+@dataclass(frozen=True)
+class DebriefReport:
+    """Collection of agent-centric debrief lines."""
+
+    mission_title: str
+    mission_outcome: str
+    lines: list[DebriefLine] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "mission_title": self.mission_title,
+            "mission_outcome": self.mission_outcome,
+            "lines": [line.to_dict() for line in self.lines],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DebriefReport":
+        return cls(
+            mission_title=str(data.get("mission_title", "Unknown Operation")),
+            mission_outcome=str(data.get("mission_outcome", "unknown")),
+            lines=[DebriefLine.from_dict(line) for line in data.get("lines", [])],
+        )
+
+
+def _stress_tone(stress: int) -> str:
+    if stress >= 85:
+        return "fractured"
+    if stress >= 65:
+        return "frayed"
+    if stress >= 35:
+        return "tense"
+    return "steady"
+
+
+def _injury_type(character: Character) -> str:
+    if character.stats.hp <= 0:
+        return "downed"
+    if character.injuries:
+        return "injured"
+    if character.recovery_turns > 0:
+        return "recovering"
+    return "operational"
+
+
+def _mission_outcome_label(victory: bool) -> str:
+    return "victory" if victory else "failure"
+
+
+def _line_text(
+    character: Character,
+    mission: MissionTemplate | None,
+    victory: bool,
+    complication: MissionComplication | None,
+) -> tuple[str, str, str]:
+    tone = _stress_tone(character.stress)
+    consequence_type = _injury_type(character)
+    mission_title = mission.title if mission else "Unknown Operation"
+
+    templates: dict[str, dict[str, str]] = {
+        "victory": {
+            "operational": "{name} garde le cap après {mission}.",
+            "recovering": "{name} tient la ligne malgré la récupération post-{mission}.",
+            "injured": "{name} revient blessé·e de {mission}, mais reste engagé·e.",
+            "downed": "{name} a payé un lourd prix pendant {mission}.",
+        },
+        "failure": {
+            "operational": "{name} encaisse l'échec de {mission} avec discipline.",
+            "recovering": "{name} est en récupération après la chute de {mission}.",
+            "injured": "{name} sort meurtri·e de {mission} et garde la mission en tête.",
+            "downed": "{name} s'effondre sous le choc de {mission}.",
+        },
+    }
+    outcome = _mission_outcome_label(victory)
+    base = templates[outcome][consequence_type].format(name=character.name, mission=mission_title)
+    if complication:
+        base += f" Complication: {complication.name.lower()}."
+    return tone, consequence_type, base
+
+
+def build_mission_debrief_report(
+    characters: list[Character],
+    mission: MissionTemplate | None,
+    victory: bool,
+    complication: MissionComplication | None = None,
+) -> DebriefReport:
+    """Build a deterministic debrief report from post-mission agent states."""
+    mission_title = mission.title if mission else "Unknown Operation"
+    lines = []
+    for character in characters:
+        tone, consequence_type, text = _line_text(
+            character, mission, victory, complication
+        )
+        lines.append(
+            DebriefLine(
+                agent_name=character.name,
+                emotional_tone=tone,
+                consequence_type=consequence_type,
+                text=text,
+            )
+        )
+    return DebriefReport(
+        mission_title=mission_title,
+        mission_outcome=_mission_outcome_label(victory),
+        lines=lines,
+    )

--- a/game/views.py
+++ b/game/views.py
@@ -4,6 +4,7 @@ import os
 from .agent_aftermath import apply_mission_aftermath
 from .agent_readiness import agents_at_breaking_risk, build_agent_readiness_lines
 from .battle_outcomes import resolve_defeated_agent_outcome
+from .narrative.debrief import build_mission_debrief_report
 from .character import Character, is_deployable
 from .management.equipment import EQUIPMENT_SLOTS, default_equipment_catalog
 from .combat_actions import available_combat_actions
@@ -1155,6 +1156,10 @@ class BattleView(GameView):
             self.triggered_complication,
         )
         self.game_state.latest_agent_aftermath = aftermath_lines[-4:]
+        debrief_report = build_mission_debrief_report(
+            surviving_participants, self.mission, victory, self.triggered_complication
+        )
+        self.game_state.latest_mission_debrief = debrief_report.to_dict()
         for line in aftermath_lines:
             self.game_state.add_event(line)
         rpg_view = RPGView(self.game_state)

--- a/tests/test_narrative_debrief.py
+++ b/tests/test_narrative_debrief.py
@@ -1,0 +1,68 @@
+"""Mission debrief narrative generation tests."""
+
+import unittest
+
+from game.character import Character
+from game.consequences import Consequence
+from game.mission_templates import MissionComplication, MissionTemplate
+from game.narrative.debrief import build_mission_debrief_report
+from game.savage_fate import tag_from_library
+
+
+def _mission(title: str = "Signal Collapse") -> MissionTemplate:
+    return MissionTemplate(
+        id="debrief-test",
+        title=title,
+        objective_text="Secure the relay",
+        target_faction="Starvers",
+        district="Chrome Warrens",
+        district_pressure={},
+        starting_enemy_count=2,
+        risk_level=3,
+    )
+
+
+def _complication() -> MissionComplication:
+    return MissionComplication(
+        key="retaliation",
+        name="Faction Retaliation",
+        trigger_text="Enemy reprisals ignite.",
+        risk_threshold=1,
+        tags=[tag_from_library("faction_retaliation")],
+        consequence=Consequence(severity=3),
+    )
+
+
+class NarrativeDebriefTest(unittest.TestCase):
+    def test_generation_is_deterministic_for_same_input(self):
+        agent = Character("Nyx", stress=44)
+        report_one = build_mission_debrief_report([agent], _mission(), True, None)
+        report_two = build_mission_debrief_report([agent], _mission(), True, None)
+
+        self.assertEqual(report_one.to_dict(), report_two.to_dict())
+
+    def test_report_contains_agent_centered_line(self):
+        report = build_mission_debrief_report([Character("Echo", stress=20)], _mission(), True)
+
+        self.assertTrue(report.lines)
+        self.assertIn("Echo", report.lines[0].text)
+        self.assertEqual(report.lines[0].agent_name, "Echo")
+
+    def test_tone_varies_with_stress_injury_and_failure(self):
+        frayed = Character("Frayed", stress=90)
+        injured = Character("Injured", stress=20, recovery_turns=2)
+        injured.injuries.append("Shrapnel")
+
+        report = build_mission_debrief_report(
+            [frayed, injured], _mission("Glass Rupture"), False, _complication()
+        )
+
+        tones = {line.agent_name: line.emotional_tone for line in report.lines}
+        types = {line.agent_name: line.consequence_type for line in report.lines}
+        self.assertEqual(tones["Frayed"], "fractured")
+        self.assertEqual(types["Injured"], "injured")
+        self.assertTrue(any("Complication" in line.text for line in report.lines))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a pure, view‑agnostic narrative layer that turns mission consequences into short emotional debrief lines for later UI consumption. 
- Make debrief generation deterministic and data‑driven from existing signals (stress, injuries, recovery, mission outcome, complications) so downstream UI can present coherent emotional beats without coupling to battle logic. 
- Persist a compact latest debrief in `GameState` so views can read the report later without invoking narrative generation inline.

### Description
- Add a new pure API module `game/narrative/debrief.py` implementing lightweight data structures `DebriefLine` and `DebriefReport` plus deterministic mapping helpers `_stress_tone`, `_injury_type`, `_mission_outcome_label`, and `build_mission_debrief_report` to produce short emotional templates. 
- Integrate debrief generation into the post‑mission flow (`BattleView.end_battle`) to build a debrief from surviving participants and store it on the game state as `GameState.latest_mission_debrief` (serialized via `to_dict`) while keeping the narrative logic separated from UI presentation. 
- Extend `GameState` to hold `latest_mission_debrief` and include it in `save`/`load` persistence so the debrief survives save/load cycles. 
- Add package init `game/narrative/__init__.py` and tests `tests/test_narrative_debrief.py` that assert deterministic generation, presence of an agent‑centered line, and tonal variation with stress/injury/failure; update `docs/backlog.md` to mark the task done.

### Testing
- Ran unit tests for the new narrative module and related aftermath behavior with `PYTHONPATH=. pytest -q tests/test_narrative_debrief.py tests/test_agent_aftermath.py`, and all tests passed (`10 passed`).
- Attempting `pytest` without `PYTHONPATH` produced an import error during collection due to module path resolution, which is resolved by running tests with `PYTHONPATH=.` as shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff40adc3c832bb0ab5609107f22dc)