### PR TITLE
Add compact recovery-room support dialogue system

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -30,6 +30,7 @@ TODO:
 [x] Add mission debrief narrative module with GameState persistence and tests
 
 Done:
+- Recovery-room support dialogues: added `game/narrative/recovery_dialogues.py` with a small deterministic generator driven by stress threshold, affinity priority (same squad then complementary roles), and one-day anti-repetition memory persisted in `GameState.recovery_narrative_memory`; output remains render-neutral (`line` + metadata) to keep narrative modular and memorable without UI coupling.
 - Mission narrative debrief API: added `game/narrative/debrief.py` with pure `DebriefLine`/`DebriefReport` data structures, deterministic emotional template mapping from stress/injury/recovery/outcome, post-mission integration in battle resolution, and persisted `latest_mission_debrief` on `GameState` for later UI consumption without view coupling.
 - Corporate tower base UI: Corp, City, RPG, and Battle screens now share a
   stacked room cross-section, resource HUD slots, pressure meters, and bottom

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 ## Next 20 Coding Steps
 
 1. [agent] AGENT-01 — Créer des scènes de débrief narratif post-mission basées sur les conséquences.
-2. [agent] AGENT-02 — Ajouter des dialogues de soutien entre agents stressés dans la salle de récupération.
+2. [agent] AGENT-02 — [done] Ajouter des dialogues de soutien entre agents stressés dans la salle de récupération (small memorable systems: règles compactes stress/affinité/mémoire anti-répétition, sortie neutre pour UI future).
 3. [agent] AGENT-03 — Ajouter un historique de liens mentor/protégé entre agents recrutés.
 4. [agent] AGENT-04 — Relier les blessures graves à des séquelles narratives temporaires.
 5. [agent] AGENT-05 — Ajouter des traits de personnalité qui modulent les logs de mission.

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -99,6 +99,7 @@ class GameState:
     )
     latest_agent_aftermath: list[str] = field(default_factory=list)
     latest_mission_debrief: dict = field(default_factory=dict)
+    recovery_narrative_memory: dict = field(default_factory=dict)
     selected_agent_names: list[str] = field(default_factory=list)
     spec_ops_assets: list[SpecOpsAsset] = field(default_factory=list)
     selected_asset_ids: list[str] = field(default_factory=list)
@@ -483,6 +484,7 @@ class GameState:
             ],
             "latest_agent_aftermath": list(self.latest_agent_aftermath),
             "latest_mission_debrief": dict(self.latest_mission_debrief),
+            "recovery_narrative_memory": dict(self.recovery_narrative_memory),
             "event_log": list(self.event_log),
             "active_events": [event.to_dict() for event in self.active_events],
             "next_event_id": self.next_event_id,
@@ -552,6 +554,7 @@ class GameState:
         ] or [create_opening_consequence(gs.district.name)]
         gs.latest_agent_aftermath = list(data.get("latest_agent_aftermath", []))
         gs.latest_mission_debrief = dict(data.get("latest_mission_debrief", {}))
+        gs.recovery_narrative_memory = dict(data.get("recovery_narrative_memory", {}))
         gs.event_log = list(data.get("event_log", gs.event_log))
         gs.active_events = [
             ActiveEvent.from_dict(event) for event in data.get("active_events", [])

--- a/game/narrative/recovery_dialogues.py
+++ b/game/narrative/recovery_dialogues.py
@@ -1,0 +1,147 @@
+"""Compact mentor/support dialogue generation for recovery room scenes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..character import Character
+
+STRESS_TRIGGER_THRESHOLD = 65
+MAX_DIALOGUES_PER_TICK = 3
+
+_COMPLEMENTARY_ROLES = {
+    frozenset({"samurai", "netrunner"}),
+    frozenset({"medic", "samurai"}),
+    frozenset({"medic", "heavy"}),
+    frozenset({"netrunner", "scout"}),
+}
+
+_LINE_TEMPLATES = (
+    "{mentor} reste avec {partner} jusqu'à ce que la respiration revienne.",
+    "{mentor} rappelle à {partner} que l'escouade tient ensemble.",
+    "{mentor} partage un silence calme avec {partner} dans la salle de récupération.",
+)
+
+
+@dataclass(frozen=True)
+class RecoveryDialogue:
+    """Neutral payload for later UI rendering."""
+
+    pair: tuple[str, str]
+    line: str
+    stress_snapshot: dict[str, int]
+    affinity_reason: str
+
+    def to_output(self) -> dict:
+        return {
+            "line": self.line,
+            "pair": list(self.pair),
+            "stress_snapshot": dict(self.stress_snapshot),
+            "affinity_reason": self.affinity_reason,
+        }
+
+
+@dataclass
+class RecoveryNarrativeMemory:
+    """Light persistence for anti-repetition across consecutive days."""
+
+    last_day: int = 0
+    last_pairs: list[tuple[str, str]] = field(default_factory=list)
+    last_lines: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "last_day": self.last_day,
+            "last_pairs": [list(pair) for pair in self.last_pairs],
+            "last_lines": list(self.last_lines),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict | None) -> "RecoveryNarrativeMemory":
+        if not isinstance(data, dict):
+            return cls()
+        pairs = []
+        for pair in data.get("last_pairs", []):
+            if isinstance(pair, list) and len(pair) == 2:
+                pairs.append((str(pair[0]), str(pair[1])))
+        return cls(
+            last_day=int(data.get("last_day", 0)),
+            last_pairs=pairs,
+            last_lines=[str(line) for line in data.get("last_lines", [])],
+        )
+
+
+def _pair_affinity_score(
+    left: Character,
+    right: Character,
+    squad_by_agent: dict[str, str],
+) -> tuple[int, str]:
+    left_squad = squad_by_agent.get(left.name)
+    right_squad = squad_by_agent.get(right.name)
+    if left_squad and right_squad and left_squad == right_squad:
+        return 3, "same_squad"
+
+    if frozenset({left.role, right.role}) in _COMPLEMENTARY_ROLES:
+        return 2, "complementary_roles"
+
+    return 1, "baseline"
+
+
+def generate_recovery_dialogues(
+    agents: list[Character],
+    recovery_state: dict,
+) -> list[dict]:
+    """Generate 0..N short support dialogues from stress/recovery context."""
+    day = int(recovery_state.get("day", 0))
+    max_dialogues = int(recovery_state.get("max_dialogues", MAX_DIALOGUES_PER_TICK))
+    stress_threshold = int(
+        recovery_state.get("stress_threshold", STRESS_TRIGGER_THRESHOLD)
+    )
+    squad_by_agent = dict(recovery_state.get("squad_by_agent", {}))
+    memory = RecoveryNarrativeMemory.from_dict(recovery_state.get("memory"))
+
+    stressed = [agent for agent in agents if agent.stress >= stress_threshold]
+    if len(stressed) < 2 or max_dialogues <= 0:
+        return []
+
+    scored_pairs: list[tuple[int, str, Character, Character]] = []
+    for i, left in enumerate(stressed):
+        for right in stressed[i + 1 :]:
+            score, reason = _pair_affinity_score(left, right, squad_by_agent)
+            scored_pairs.append((score, reason, left, right))
+    scored_pairs.sort(key=lambda item: (-item[0], -(item[2].stress + item[3].stress)))
+
+    blocked_pairs = set(memory.last_pairs) if memory.last_day == day - 1 else set()
+    blocked_lines = set(memory.last_lines) if memory.last_day == day - 1 else set()
+
+    output: list[RecoveryDialogue] = []
+    for score, reason, left, right in scored_pairs:
+        if len(output) >= max_dialogues:
+            break
+        pair = (left.name, right.name)
+        if pair in blocked_pairs:
+            continue
+        line = _LINE_TEMPLATES[len(output) % len(_LINE_TEMPLATES)].format(
+            mentor=left.name,
+            partner=right.name,
+        )
+        if line in blocked_lines:
+            continue
+        output.append(
+            RecoveryDialogue(
+                pair=pair,
+                line=line,
+                stress_snapshot={left.name: left.stress, right.name: right.stress},
+                affinity_reason=reason,
+            )
+        )
+
+    if not output:
+        return []
+
+    memory.last_day = day
+    memory.last_pairs = [dialogue.pair for dialogue in output]
+    memory.last_lines = [dialogue.line for dialogue in output]
+    recovery_state["memory"] = memory.to_dict()
+
+    return [dialogue.to_output() for dialogue in output]

--- a/tests/test_recovery_dialogues.py
+++ b/tests/test_recovery_dialogues.py
@@ -1,0 +1,68 @@
+"""Recovery room support dialogue generation tests."""
+
+import unittest
+
+from game.character import Character
+from game.narrative.recovery_dialogues import generate_recovery_dialogues
+
+
+class RecoveryDialoguesTest(unittest.TestCase):
+    def test_triggers_when_stress_is_high(self):
+        agents = [
+            Character("Nyx", role="samurai", stress=80),
+            Character("Patch", role="medic", stress=72),
+            Character("Calm", role="scout", stress=20),
+        ]
+        state = {
+            "day": 7,
+            "squad_by_agent": {"Nyx": "Alpha", "Patch": "Alpha", "Calm": "Beta"},
+            "memory": {},
+        }
+
+        dialogues = generate_recovery_dialogues(agents, state)
+
+        self.assertEqual(len(dialogues), 1)
+        self.assertEqual(dialogues[0]["pair"], ["Nyx", "Patch"])
+        self.assertEqual(dialogues[0]["affinity_reason"], "same_squad")
+        self.assertIn("memory", state)
+
+    def test_no_dialogue_when_conditions_not_met(self):
+        agents = [
+            Character("LowA", stress=20),
+            Character("LowB", stress=30),
+        ]
+
+        dialogues = generate_recovery_dialogues(agents, {"day": 8, "memory": {}})
+
+        self.assertEqual(dialogues, [])
+
+    def test_avoids_repeating_pair_and_line_on_next_day(self):
+        agents = [
+            Character("Nyx", role="samurai", stress=82),
+            Character("Patch", role="medic", stress=75),
+            Character("Cipher", role="netrunner", stress=78),
+        ]
+        state_day_1 = {
+            "day": 10,
+            "squad_by_agent": {"Nyx": "Alpha", "Patch": "Alpha", "Cipher": "Beta"},
+            "memory": {},
+            "max_dialogues": 1,
+        }
+        day_1 = generate_recovery_dialogues(agents, state_day_1)
+
+        state_day_2 = {
+            "day": 11,
+            "squad_by_agent": state_day_1["squad_by_agent"],
+            "memory": state_day_1["memory"],
+            "max_dialogues": 1,
+        }
+        day_2 = generate_recovery_dialogues(agents, state_day_2)
+
+        self.assertEqual(len(day_1), 1)
+        self.assertEqual(len(day_2), 1)
+        self.assertNotEqual(day_1[0]["pair"], day_2[0]["pair"])
+        self.assertNotEqual(day_1[0]["line"], day_2[0]["line"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide small, memorable mentor/support interactions in the recovery room to increase emergent storytelling and emotional attachment without expanding scope. 
- Keep the system modular and UI-agnostic by producing render-neutral dialogue payloads and a tiny persistent memory to avoid repetition across days.

### Description
- Added `game/narrative/recovery_dialogues.py` exposing `generate_recovery_dialogues(agents, recovery_state)` which returns 0..N dialogue payloads as dictionaries (`line` + metadata). 
- Implemented minimal rules: stress trigger via `STRESS_TRIGGER_THRESHOLD`, affinity scoring (same squad > complementary roles > baseline), and one-day anti-repetition of pair/line via `RecoveryNarrativeMemory` with `to_dict`/`from_dict`. 
- Persisted narrative memory in `GameState` as `recovery_narrative_memory` and integrated it into `save`/`load` so conversation memory survives save files. 
- Added unit tests `tests/test_recovery_dialogues.py` covering trigger behavior, non-trigger cases, and anti-repetition across successive days, and updated `docs/roadmap.md` and `docs/backlog.md` with status and a short design rationale ("small memorable systems").

### Testing
- Ran `python -m pytest -q tests/test_recovery_dialogues.py tests/test_narrative_debrief.py tests/test_recovery_status.py` and the suite passed: `14 passed`.
- The new tests specifically verify stress-triggering, absence when conditions not met, and the non-repetition memory behavior; all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff54dd680832b9d8d6458de44df9e)