### PR TITLE
Add lightweight mentor relationship tracking with save/load persistence

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -109,3 +109,9 @@ Automation status:
 - [done] Add roadmap next-steps generator script (`tools/docs/generate_docs.py`)
 - [done] Add unit tests for generator stability/format (`tests/test_generate_docs.py`)
 - [done] Generate and publish `## Next 20 Coding Steps` block in `docs/roadmap.md`
+
+- [x] Add lightweight relational tracking contract (mentor links)
+  - Field location: `Character.mentor_links` (dictionary keyed by other `agent_id`).
+  - Payload per link: `{"agent_id": str, "bond_level": int>=0, "strategic_day": int>=0}`.
+  - Invariants: one entry per counterpart, monotonic `bond_level`, monotonic `strategic_day`, no empty `agent_id`.
+  - Lifecycle: seeded on recruitment (`game/recruitment.py`), evolved after mission progression (`game/agent_aftermath.py`), persisted by regular character serialization (`to_dict`/`from_dict`) used by save/load.

--- a/game/agent_aftermath.py
+++ b/game/agent_aftermath.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .character import Character
 from .mission_templates import MissionComplication, MissionTemplate
+from .relationships.mentor_history import upsert_mentor_link
 
 MIN_STRESS = 0
 MAX_STRESS = 100
@@ -65,6 +66,21 @@ def _maybe_add_trauma(
     return trauma
 
 
+def _update_team_links(characters: list[Character], strategic_day: int, victory: bool) -> None:
+    """Increment compact bond levels for agents who share mission fallout."""
+    bond_delta = 2 if victory else 1
+    for character in characters:
+        for teammate in characters:
+            if teammate.name == character.name:
+                continue
+            upsert_mentor_link(
+                character.mentor_links,
+                agent_id=teammate.name,
+                strategic_day=strategic_day,
+                bond_delta=bond_delta,
+            )
+
+
 def apply_mission_aftermath(
     characters: list[Character],
     mission: MissionTemplate | None,
@@ -87,6 +103,8 @@ def apply_mission_aftermath(
     complication_stress = _complication_intensity(triggered_complication)
     outcome_label = "victory" if victory else "defeat"
     aftermath_lines: list[str] = []
+    strategic_day = max(0, int(getattr(mission, "duration_days", 1)))
+    _update_team_links(characters, strategic_day=strategic_day, victory=victory)
 
     for character in characters:
         stress_delta = base_stress + complication_stress

--- a/game/character.py
+++ b/game/character.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field, asdict
 
 from .management.equipment import AgentLoadout
 from .stats import PlayerStats
+from .relationships.mentor_history import serialize_links
 
 
 @dataclass
@@ -23,6 +24,7 @@ class Character:
     injuries: list[str] = field(default_factory=list)
     reputation: list[str] = field(default_factory=list)
     relationships: dict[str, int] = field(default_factory=dict)
+    mentor_links: dict[str, dict] = field(default_factory=dict)
     history: list[str] = field(default_factory=list)
     savage_tags: list[str] = field(default_factory=list)
     recovery_turns: int = 0
@@ -44,6 +46,7 @@ class Character:
             "injuries": list(self.injuries),
             "reputation": list(self.reputation),
             "relationships": dict(self.relationships),
+            "mentor_links": serialize_links(self.mentor_links),
             "history": list(self.history),
             "savage_tags": list(self.savage_tags),
             "recovery_turns": self.recovery_turns,
@@ -69,6 +72,7 @@ class Character:
             injuries=list(data.get("injuries", [])),
             reputation=list(data.get("reputation", [])),
             relationships=dict(data.get("relationships", {})),
+            mentor_links=serialize_links(dict(data.get("mentor_links", {}))),
             history=list(data.get("history", [])),
             savage_tags=list(data.get("savage_tags", [])),
             recovery_turns=data.get("recovery_turns", 0),

--- a/game/recruitment.py
+++ b/game/recruitment.py
@@ -2,6 +2,7 @@
 
 from .character import Character
 from .stats import PlayerStats
+from .relationships.mentor_history import upsert_mentor_link
 
 ROLE_STAT_BONUSES = {
     "samurai": "str",
@@ -23,5 +24,15 @@ def create_character(name: str, role: str) -> Character:
 def recruit_agent(roster: list[Character], role: str) -> Character:
     """Create the next numbered agent and append them to the supplied roster."""
     agent = create_character(f"Agent {len(roster) + 1}", role)
+    seed_roster_mentor_links(roster, agent)
     roster.append(agent)
     return agent
+
+
+def seed_roster_mentor_links(roster: list[Character], new_agent: Character, strategic_day: int = 0) -> None:
+    """Initialize lightweight social ties between a recruit and the current roster."""
+    for teammate in roster:
+        if teammate.name == new_agent.name:
+            continue
+        upsert_mentor_link(new_agent.mentor_links, agent_id=teammate.name, strategic_day=strategic_day, bond_delta=1)
+        upsert_mentor_link(teammate.mentor_links, agent_id=new_agent.name, strategic_day=strategic_day, bond_delta=1)

--- a/game/relationships/mentor_history.py
+++ b/game/relationships/mentor_history.py
@@ -1,0 +1,61 @@
+"""Utilities for lightweight mentor-link tracking between agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MentorLink:
+    """Compact relationship link persisted on each agent."""
+
+    agent_id: str
+    bond_level: int
+    strategic_day: int
+
+    def to_dict(self) -> dict:
+        return {
+            "agent_id": self.agent_id,
+            "bond_level": self.bond_level,
+            "strategic_day": self.strategic_day,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MentorLink":
+        return cls(
+            agent_id=str(data.get("agent_id", "")),
+            bond_level=max(0, int(data.get("bond_level", 0))),
+            strategic_day=max(0, int(data.get("strategic_day", 0))),
+        )
+
+
+def upsert_mentor_link(
+    links: dict[str, dict],
+    *,
+    agent_id: str,
+    strategic_day: int,
+    bond_delta: int = 1,
+) -> dict[str, dict]:
+    """Create or update one relationship link while keeping payload minimal."""
+    if not agent_id:
+        return links
+
+    previous = MentorLink.from_dict(links.get(agent_id, {}))
+    next_bond = previous.bond_level + max(0, int(bond_delta))
+    links[agent_id] = MentorLink(
+        agent_id=agent_id,
+        bond_level=next_bond,
+        strategic_day=max(previous.strategic_day, int(strategic_day)),
+    ).to_dict()
+    return links
+
+
+def serialize_links(links: dict[str, dict]) -> dict[str, dict]:
+    """Normalize links into a persistable dictionary of primitive values."""
+    normalized: dict[str, dict] = {}
+    for key, payload in links.items():
+        link = MentorLink.from_dict(payload)
+        if not link.agent_id:
+            continue
+        normalized[key] = link.to_dict()
+    return normalized

--- a/tests/test_mentor_history.py
+++ b/tests/test_mentor_history.py
@@ -1,0 +1,37 @@
+import unittest
+
+from game.agent_aftermath import apply_mission_aftermath
+from game.character import Character
+from game.mission_templates import create_mission_templates
+from game.recruitment import recruit_agent
+from game.relationships.mentor_history import upsert_mentor_link
+
+
+class MentorHistoryTests(unittest.TestCase):
+    def test_upsert_creates_then_increments_link(self):
+        links: dict[str, dict] = {}
+
+        upsert_mentor_link(links, agent_id="Nyx", strategic_day=3, bond_delta=1)
+        upsert_mentor_link(links, agent_id="Nyx", strategic_day=5, bond_delta=2)
+
+        self.assertEqual(links["Nyx"]["agent_id"], "Nyx")
+        self.assertEqual(links["Nyx"]["bond_level"], 3)
+        self.assertEqual(links["Nyx"]["strategic_day"], 5)
+
+    def test_recruitment_and_aftermath_evolve_links(self):
+        roster: list[Character] = []
+        alpha = recruit_agent(roster, "samurai")
+        bravo = recruit_agent(roster, "sniper")
+
+        self.assertIn(bravo.name, alpha.mentor_links)
+        self.assertIn(alpha.name, bravo.mentor_links)
+
+        mission = create_mission_templates()[0]
+        apply_mission_aftermath([alpha, bravo], mission, victory=True)
+
+        self.assertGreaterEqual(alpha.mentor_links[bravo.name]["bond_level"], 3)
+        self.assertGreaterEqual(bravo.mentor_links[alpha.name]["bond_level"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_save_system.py
+++ b/tests/test_save_system.py
@@ -24,6 +24,9 @@ class SaveSystemTests(unittest.TestCase):
         game_state.selected_agent_names = ["Nyx"]
         game_state.strategic_resources["credits"] = 55
         game_state.city_budget["armaments"] = 20
+        game_state.characters[0].mentor_links = {
+            "Cipher": {"agent_id": "Cipher", "bond_level": 4, "strategic_day": 12}
+        }
 
         with tempfile.TemporaryDirectory() as temp_dir:
             save_path = Path(temp_dir) / "slot_a" / "campaign.json"
@@ -39,6 +42,10 @@ class SaveSystemTests(unittest.TestCase):
         self.assertEqual(loaded.strategic_resources["credits"], 55)
         self.assertEqual(loaded.city_budget["armaments"], 20)
         self.assertEqual(len(loaded.characters), 1)
+        self.assertEqual(
+            loaded.characters[0].mentor_links,
+            {"Cipher": {"agent_id": "Cipher", "bond_level": 4, "strategic_day": 12}},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Introduire un suivi relationnel minimal entre agents pour ajouter continuité émotionnelle sans alourdir le modèle principal. 
- Garder la mécanique modulaire et lisible en isolant la logique relationnelle dans un sous-module dédié et en respectant les invariants de données. 

### Description
- Ajout du module `game/relationships/mentor_history.py` qui définit `MentorLink` et fournit `upsert_mentor_link` et `serialize_links` pour création/mise à jour et normalisation des liens (payload: `agent_id`, `bond_level`, `strategic_day`).
- Extension de `Character` dans `game/character.py` avec le champ `mentor_links` et intégration dans `to_dict`/`from_dict` via `serialize_links` pour garantir la persistance. 
- Mise à jour de `game/recruitment.py` pour semer des liens réciproques lors de l'ajout d'une recrue (`seed_roster_mentor_links`).
- Mise à jour de `game/agent_aftermath.py` pour faire évoluer les liens entre co-déployés via `_update_team_links` (progression plus forte en cas de victoire) et usage d’un `strategic_day` dérivé de la mission. 
- Ajout de tests unitaires `tests/test_mentor_history.py` et extension de `tests/test_save_system.py` pour couvrir la création/évolution et la persistance exacte des `mentor_links`, et documentation du contrat dans `docs/backlog.md`.

### Testing
- Initialement `pytest` a échoué en raison d’un `PYTHONPATH` manquant, ce qui a été corrigé. 
- Les tests ciblés ont été ajustés (utilisation de `create_mission_templates()` dans le test) et exécutés avec `PYTHONPATH=. pytest -q tests/test_mentor_history.py tests/test_save_system.py`.
- Résultat final : les suites ciblées ont réussi (4 tests passés).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff6708234832b8b2d6b4c79128651)