### PR TITLE
Add temporary narrative scars from severe injuries

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -115,3 +115,9 @@ Automation status:
   - Payload per link: `{"agent_id": str, "bond_level": int>=0, "strategic_day": int>=0}`.
   - Invariants: one entry per counterpart, monotonic `bond_level`, monotonic `strategic_day`, no empty `agent_id`.
   - Lifecycle: seeded on recruitment (`game/recruitment.py`), evolved after mission progression (`game/agent_aftermath.py`), persisted by regular character serialization (`to_dict`/`from_dict`) used by save/load.
+
+- [x] Relier les blessures graves à des séquelles narratives temporaires
+  - Module ajouté: `game/narrative/temporary_scars.py`.
+  - Scope strict: narratif-only (tonalité/tags/logs), sans buff/debuff gameplay.
+  - Dissipation journalière via calendrier stratégique (`GameState.advance_one_day`) et suppression automatique à expiration.
+  - Exposition UI data: résumé lisible dans le dossier agent, rendu non imposé.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,7 +3,7 @@
 1. [agent] AGENT-01 — Créer des scènes de débrief narratif post-mission basées sur les conséquences.
 2. [agent] AGENT-02 — [done] Ajouter des dialogues de soutien entre agents stressés dans la salle de récupération (small memorable systems: règles compactes stress/affinité/mémoire anti-répétition, sortie neutre pour UI future).
 3. [agent] AGENT-03 — Ajouter un historique de liens mentor/protégé entre agents recrutés.
-4. [agent] AGENT-04 — Relier les blessures graves à des séquelles narratives temporaires.
+4. [agent] AGENT-04 — [done] Relier les blessures graves à des séquelles narratives temporaires (narratif-only, sans empilement complexe).
 5. [agent] AGENT-05 — Ajouter des traits de personnalité qui modulent les logs de mission.
 6. [mission] MISSION-03 — Créer une mission d'évacuation qui privilégie la survie des agents.
 7. [ui] UI-02 — Créer un panneau compact de moral d'escouade dans la vue RPG.

--- a/game/battle_outcomes.py
+++ b/game/battle_outcomes.py
@@ -6,6 +6,7 @@ import random
 from typing import Callable
 
 from .character import Character
+from .narrative.temporary_scars import apply_temporary_scar_from_injury
 
 CRITICAL_INJURY_RECOVERY_TURNS = 2
 CAPTURED_RECOVERY_TURNS = 4
@@ -43,10 +44,16 @@ def resolve_defeated_agent_outcome(
             "Evacuated with critical injuries after being downed in battle. "
             f"Recovery required: {character.recovery_turns} turns."
         )
+        scar = apply_temporary_scar_from_injury(character, "Critical battle trauma")
         record_event(
             f"{character.name} survived with critical injuries "
             f"and needs {character.recovery_turns} turns to recover."
         )
+        if scar:
+            record_event(
+                f"{character.name} gains temporary scar '{scar['title']}' "
+                f"for {scar['days_remaining']} days."
+            )
     elif outcome == "captured":
         character.recovery_turns = max(character.recovery_turns, CAPTURED_RECOVERY_TURNS)
         character.history.append(

--- a/game/character.py
+++ b/game/character.py
@@ -27,6 +27,7 @@ class Character:
     mentor_links: dict[str, dict] = field(default_factory=dict)
     history: list[str] = field(default_factory=list)
     savage_tags: list[str] = field(default_factory=list)
+    temporary_scars: list[dict] = field(default_factory=list)
     recovery_turns: int = 0
     loadout: AgentLoadout = field(default_factory=AgentLoadout)
 
@@ -49,6 +50,7 @@ class Character:
             "mentor_links": serialize_links(self.mentor_links),
             "history": list(self.history),
             "savage_tags": list(self.savage_tags),
+            "temporary_scars": [dict(scar) for scar in self.temporary_scars],
             "recovery_turns": self.recovery_turns,
             "loadout": self.loadout.to_dict(),
         }
@@ -75,6 +77,7 @@ class Character:
             mentor_links=serialize_links(dict(data.get("mentor_links", {}))),
             history=list(data.get("history", [])),
             savage_tags=list(data.get("savage_tags", [])),
+            temporary_scars=[dict(scar) for scar in data.get("temporary_scars", [])],
             recovery_turns=data.get("recovery_turns", 0),
             loadout=AgentLoadout.from_dict(data.get("loadout")),
         )

--- a/game/dossier.py
+++ b/game/dossier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .character import Character
+from .narrative.temporary_scars import build_temporary_scar_summary
 
 
 NO_TRAIT = "No notable trait"
@@ -32,6 +33,7 @@ def build_agent_dossier_lines(character: Character) -> tuple[str, str]:
     detail = (
         f"  Trait: {first_or_default(character.traits, NO_TRAIT)} | "
         f"Scar: {first_wound_or_trauma(character)} | "
+        f"Temp: {build_temporary_scar_summary(character)[0]} | "
         f"History: {first_or_default(character.history, NO_HISTORY)}"
     )
     return summary, detail

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -28,6 +28,7 @@ from .management.funds import (
     default_mission_fund_distribution,
 )
 from .management.stress import daily_stress_recovery
+from .narrative.temporary_scars import tick_temporary_scars
 from .management.spec_ops_assets import (
     SpecOpsAsset,
     pay_asset_maintenance,
@@ -314,6 +315,12 @@ class GameState:
             stress_result = daily_stress_recovery(character)
             if stress_result.changed:
                 stress_recovery_log.append((character.name, stress_result.amount, character.stress))
+            expired_scars = tick_temporary_scars(character, 1)
+            for scar in expired_scars:
+                self.add_event(
+                    f"{self.calendar.campaign_date_label}: {character.name} leaves behind scar "
+                    f"'{scar.get('title', 'Unknown')}'."
+                )
             if character.recovery_turns > 0:
                 character.recovery_turns -= 1
                 if character.recovery_turns == 0:

--- a/game/narrative/temporary_scars.py
+++ b/game/narrative/temporary_scars.py
@@ -1,0 +1,94 @@
+"""Temporary narrative scars derived from severe battlefield injuries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..character import Character
+
+
+@dataclass(frozen=True)
+class TemporaryScarTemplate:
+    """Compact narrative-only scar template keyed by severe injury label."""
+
+    key: str
+    title: str
+    strategic_days: int
+    tone: str
+    tags: tuple[str, ...]
+    log_line: str
+
+
+SEVERE_INJURY_TO_SCAR: dict[str, TemporaryScarTemplate] = {
+    "Critical battle trauma": TemporaryScarTemplate(
+        key="critical_battle_trauma",
+        title="Nights of Sirens",
+        strategic_days=4,
+        tone="vigilant",
+        tags=("injury", "hypervigilance", "nightmares"),
+        log_line="Every distant siren drags the battle back into focus.",
+    )
+}
+
+
+def apply_temporary_scar_from_injury(character: Character, injury: str) -> dict | None:
+    """Attach or refresh a compact narrative scar when injury is severe."""
+    template = SEVERE_INJURY_TO_SCAR.get(injury)
+    if template is None:
+        return None
+
+    existing = next(
+        (scar for scar in character.temporary_scars if scar.get("key") == template.key),
+        None,
+    )
+    if existing is not None:
+        existing["days_remaining"] = max(
+            int(existing.get("days_remaining", 0)), template.strategic_days
+        )
+        return existing
+
+    scar = {
+        "key": template.key,
+        "title": template.title,
+        "days_remaining": template.strategic_days,
+        "tone": template.tone,
+        "tags": list(template.tags),
+        "log_line": template.log_line,
+    }
+    character.temporary_scars.append(scar)
+    character.history.append(f"Narrative scar gained: {template.title}.")
+    return scar
+
+
+def tick_temporary_scars(character: Character, days: int = 1) -> list[dict]:
+    """Decrease scar duration and remove expired scars."""
+    if days <= 0:
+        return []
+
+    expired: list[dict] = []
+    remaining: list[dict] = []
+    for scar in character.temporary_scars:
+        updated = dict(scar)
+        updated["days_remaining"] = int(updated.get("days_remaining", 0)) - days
+        if updated["days_remaining"] <= 0:
+            expired.append(updated)
+            character.history.append(f"Narrative scar faded: {updated.get('title', 'Unknown')}.")
+            continue
+        remaining.append(updated)
+
+    character.temporary_scars = remaining
+    return expired
+
+
+def build_temporary_scar_summary(character: Character) -> list[str]:
+    """Return readable, render-neutral lines for UI consumers."""
+    if not character.temporary_scars:
+        return ["Temporary scars: none"]
+    lines = []
+    for scar in character.temporary_scars:
+        tags = ", ".join(scar.get("tags", []))
+        lines.append(
+            f"{scar.get('title', 'Unknown')} ({scar.get('days_remaining', 0)}d, "
+            f"tone {scar.get('tone', 'neutral')}, tags: {tags})"
+        )
+    return lines

--- a/tests/test_temporary_scars.py
+++ b/tests/test_temporary_scars.py
@@ -1,0 +1,66 @@
+"""Tests for temporary narrative scars derived from severe injuries."""
+
+from __future__ import annotations
+
+import unittest
+
+from game.battle_outcomes import resolve_defeated_agent_outcome
+from game.character import Character
+from game.gamestate import GameState
+from game.narrative.temporary_scars import apply_temporary_scar_from_injury
+
+
+class TemporaryScarsTest(unittest.TestCase):
+    def test_add_on_severe_injury(self):
+        character = Character("Rook")
+
+        scar = apply_temporary_scar_from_injury(character, "Critical battle trauma")
+
+        self.assertIsNotNone(scar)
+        self.assertEqual(len(character.temporary_scars), 1)
+        self.assertEqual(character.temporary_scars[0]["key"], "critical_battle_trauma")
+
+    def test_decrement_when_days_advance(self):
+        character = Character("Nyx")
+        game_state = GameState(characters=[character])
+        apply_temporary_scar_from_injury(character, "Critical battle trauma")
+
+        game_state.advance_one_day("test")
+
+        self.assertEqual(character.temporary_scars[0]["days_remaining"], 3)
+
+    def test_remove_when_expired(self):
+        character = Character("Vale")
+        game_state = GameState(characters=[character])
+        apply_temporary_scar_from_injury(character, "Critical battle trauma")
+
+        game_state.advance_days(4, "test")
+
+        self.assertEqual(character.temporary_scars, [])
+        self.assertTrue(
+            any("leaves behind scar" in entry for entry in game_state.event_log)
+        )
+
+    def test_critical_outcome_applies_scar(self):
+        character = Character("Mara")
+        events: list[str] = []
+
+        import game.battle_outcomes as outcomes
+
+        original_choice = outcomes.random.choice
+        outcomes.random.choice = lambda _: "critically injured"
+        try:
+            resolve_defeated_agent_outcome(
+                character,
+                remove_character=lambda _: None,
+                record_event=events.append,
+            )
+        finally:
+            outcomes.random.choice = original_choice
+
+        self.assertEqual(len(character.temporary_scars), 1)
+        self.assertTrue(any("temporary scar" in event for event in events))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a compact, narrative-only system that maps severe battlefield injuries to temporary “scars” to support emergent storytelling and emotional attachment without changing gameplay mechanics.  
- Keep the feature modular and scope-limited (narrative tags/tone/log lines only) so it remains easy to maintain and does not introduce mechanical stacking.  
- Integrate scars into existing aftermath and calendar flows so they appear and naturally dissipate over campaign days.  

### Description
- Add `game/narrative/temporary_scars.py` which defines `TemporaryScarTemplate`, a `SEVERE_INJURY_TO_SCAR` mapping, and API functions `apply_temporary_scar_from_injury`, `tick_temporary_scars`, and `build_temporary_scar_summary`.  
- Persist scar data on the agent model by adding `temporary_scars` to `Character` and including it in `to_dict`/`from_dict`.  
- Hook scar creation into combat fallout by calling `apply_temporary_scar_from_injury` in `game/battle_outcomes.py` for the `critically injured` outcome and emitting an event log entry.  
- Decrement and expire scars daily by calling `tick_temporary_scars` from `GameState.advance_one_day`, generating an event when a scar fades, and surface a readable scar summary in the agent dossier via `game/dossier.py`.  
- Add unit tests in `tests/test_temporary_scars.py` covering application on severe injury, day-based decrement, expiration/removal, and combat-outcome integration, and update `docs/backlog.md` and `docs/roadmap.md` to mark AGENT-04 done with scope notes.  

### Testing
- Ran the focused test suite: `python -m pytest -q tests/test_temporary_scars.py tests/test_agent_aftermath.py tests/test_calendar_management.py`.  
- All tests passed: `16 passed` (run completed successfully).  
- `tests/test_temporary_scars.py` verifies add / decrement / expiration and that the critical injury branch applies a temporary scar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff9936c34832ba0265263f9912cca)