### PR TITLE
Add compact personality traits to modulate mission logs

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -121,3 +121,5 @@ Automation status:
   - Scope strict: narratif-only (tonalité/tags/logs), sans buff/debuff gameplay.
   - Dissipation journalière via calendrier stratégique (`GameState.advance_one_day`) et suppression automatique à expiration.
   - Exposition UI data: résumé lisible dans le dossier agent, rendu non imposé.
+
+[x] AGENT-05 Personality-trait mission log modulation (compact set + neutral fallback + tests)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
 2. [agent] AGENT-02 — [done] Ajouter des dialogues de soutien entre agents stressés dans la salle de récupération (small memorable systems: règles compactes stress/affinité/mémoire anti-répétition, sortie neutre pour UI future).
 3. [agent] AGENT-03 — Ajouter un historique de liens mentor/protégé entre agents recrutés.
 4. [agent] AGENT-04 — [done] Relier les blessures graves à des séquelles narratives temporaires (narratif-only, sans empilement complexe).
-5. [agent] AGENT-05 — Ajouter des traits de personnalité qui modulent les logs de mission.
+5. [agent] AGENT-05 — [done] Ajouter des traits de personnalité qui modulent les logs de mission.
 6. [mission] MISSION-03 — Créer une mission d'évacuation qui privilégie la survie des agents.
 7. [ui] UI-02 — Créer un panneau compact de moral d'escouade dans la vue RPG.
 8. [mission] MISSION-01 — Introduire des variantes d'objectifs multi-étapes avec embranchements lisibles.
@@ -20,3 +20,5 @@
 18. [tests] TEST-04 — Tester la cohérence des tags de domaine dans les exports markdown.
 19. [tests] TEST-02 — Valider la stabilité des seeds de mission par jour avec tests déterministes.
 20. [docs] DOC-03 — Décrire le pipeline backlog -> next steps -> roadmap dans docs.
+
+- Traits de personnalité agents (AGENT-05): ajout d'un set court (`steadfast`, `reckless`, `empathetic`, `cunning`) avec intention émotionnelle claire pour moduler la tonalité des logs mission (voix stable, impulsive, humaine, opportuniste) via une fonction dédiée et fallback neutre pour compatibilité des sauvegardes historiques.

--- a/game/character.py
+++ b/game/character.py
@@ -30,6 +30,8 @@ class Character:
     temporary_scars: list[dict] = field(default_factory=list)
     recovery_turns: int = 0
     loadout: AgentLoadout = field(default_factory=AgentLoadout)
+    personality_primary_trait: str = ""
+    personality_secondary_trait: str = ""
 
     def to_dict(self) -> dict:
         return {
@@ -53,6 +55,8 @@ class Character:
             "temporary_scars": [dict(scar) for scar in self.temporary_scars],
             "recovery_turns": self.recovery_turns,
             "loadout": self.loadout.to_dict(),
+            "personality_primary_trait": self.personality_primary_trait,
+            "personality_secondary_trait": self.personality_secondary_trait,
         }
 
     @classmethod
@@ -80,6 +84,8 @@ class Character:
             temporary_scars=[dict(scar) for scar in data.get("temporary_scars", [])],
             recovery_turns=data.get("recovery_turns", 0),
             loadout=AgentLoadout.from_dict(data.get("loadout")),
+            personality_primary_trait=str(data.get("personality_primary_trait", "")),
+            personality_secondary_trait=str(data.get("personality_secondary_trait", "")),
         )
 
     def gain_xp(self, amount: int) -> None:

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -8,6 +8,7 @@ from .mission_templates import (
     MissionComplication,
     MissionTemplate,
 )
+from .narrative.personality_traits import modulate_mission_log_tone
 
 
 def ensure_mission_templates(game_state: GameState) -> None:
@@ -94,7 +95,15 @@ def resolve_mission_outcome(
         if not consequence.affected_faction:
             consequence.affected_faction = mission.target_faction
         game_state.apply_consequence(consequence)
-        game_state.add_event(f"Complication triggered: {complication.trigger_text}")
+        base_text = f"Complication triggered: {complication.trigger_text}"
+        leader = game_state.selected_agents[0] if game_state.selected_agents else None
+        game_state.add_event(
+            modulate_mission_log_tone(
+                base_text,
+                getattr(leader, "personality_primary_trait", ""),
+                getattr(leader, "personality_secondary_trait", ""),
+            )
+        )
 
     game_state.active_mission = None
     duration_days = max(1, int(getattr(mission, "duration_days", 1)))

--- a/game/narrative/personality_traits.py
+++ b/game/narrative/personality_traits.py
@@ -1,0 +1,72 @@
+"""Compact agent personality traits used to modulate mission narrative tone."""
+
+from __future__ import annotations
+
+import random
+
+TRAIT_TONE_MODULATORS: dict[str, dict[str, str]] = {
+    "steadfast": {
+        "prefix": "Steady voice:",
+        "suffix": "Holds formation under pressure.",
+    },
+    "reckless": {
+        "prefix": "Hot-blooded report:",
+        "suffix": "Pushes ahead before the smoke clears.",
+    },
+    "empathetic": {
+        "prefix": "Human-focused brief:",
+        "suffix": "Keeps civilians and squad morale in sight.",
+    },
+    "cunning": {
+        "prefix": "Sharp-angle debrief:",
+        "suffix": "Finds leverage in chaos.",
+    },
+}
+
+
+NEUTRAL_TRAIT = "neutral"
+
+
+def list_personality_traits() -> list[str]:
+    """Return available trait keys for assignment and UI display."""
+    return list(TRAIT_TONE_MODULATORS.keys())
+
+
+def assign_personality_traits(
+    name: str,
+    role: str,
+    roster_index: int,
+    seed: int | None = None,
+) -> tuple[str, str | None]:
+    """Deterministically assign one primary trait and optional secondary trait."""
+    trait_pool = list_personality_traits()
+    rng_seed = seed if seed is not None else f"{name}:{role}:{roster_index}"
+    rng = random.Random(rng_seed)
+    primary = rng.choice(trait_pool)
+
+    if len(trait_pool) < 2 or rng.random() < 0.45:
+        return primary, None
+
+    secondary_pool = [trait for trait in trait_pool if trait != primary]
+    return primary, rng.choice(secondary_pool)
+
+
+def modulate_mission_log_tone(
+    text: str,
+    primary_trait: str | None,
+    secondary_trait: str | None = None,
+) -> str:
+    """Return mission log text with personality-tone wrappers.
+
+    Fallback is fully neutral for old saves with no trait metadata.
+    """
+    primary = TRAIT_TONE_MODULATORS.get(primary_trait or "")
+    if not primary:
+        return text
+
+    secondary = TRAIT_TONE_MODULATORS.get(secondary_trait or "")
+    suffix = primary["suffix"]
+    if secondary:
+        suffix = f"{suffix} {secondary['suffix']}"
+
+    return f"{primary['prefix']} {text} {suffix}"

--- a/game/recruitment.py
+++ b/game/recruitment.py
@@ -3,6 +3,7 @@
 from .character import Character
 from .stats import PlayerStats
 from .relationships.mentor_history import upsert_mentor_link
+from .narrative.personality_traits import assign_personality_traits
 
 ROLE_STAT_BONUSES = {
     "samurai": "str",
@@ -18,12 +19,23 @@ def create_character(name: str, role: str) -> Character:
     if bonus_stat:
         setattr(stats, bonus_stat, getattr(stats, bonus_stat) + 5)
     stats.recalculate_hp()
-    return Character(name=name, role=role, stats=stats)
+    primary_trait, secondary_trait = assign_personality_traits(name, role, roster_index=0)
+    return Character(
+        name=name,
+        role=role,
+        stats=stats,
+        personality_primary_trait=primary_trait,
+        personality_secondary_trait=secondary_trait or "",
+    )
 
 
 def recruit_agent(roster: list[Character], role: str) -> Character:
     """Create the next numbered agent and append them to the supplied roster."""
-    agent = create_character(f"Agent {len(roster) + 1}", role)
+    next_index = len(roster) + 1
+    agent = create_character(f"Agent {next_index}", role)
+    primary_trait, secondary_trait = assign_personality_traits(agent.name, role, roster_index=next_index)
+    agent.personality_primary_trait = primary_trait
+    agent.personality_secondary_trait = secondary_trait or ""
     seed_roster_mentor_links(roster, agent)
     roster.append(agent)
     return agent

--- a/tests/test_personality_traits.py
+++ b/tests/test_personality_traits.py
@@ -1,0 +1,35 @@
+"""Tests for compact agent personality traits and mission-log modulation."""
+
+import unittest
+
+from game.narrative.personality_traits import (
+    assign_personality_traits,
+    modulate_mission_log_tone,
+)
+
+
+class PersonalityTraitsTest(unittest.TestCase):
+    def test_modulation_effective_on_text(self):
+        text = "Complication triggered: blackout spread through sector 9."
+
+        modulated = modulate_mission_log_tone(text, "steadfast", "cunning")
+
+        self.assertIn("Steady voice:", modulated)
+        self.assertIn(text, modulated)
+        self.assertIn("Finds leverage in chaos.", modulated)
+
+    def test_trait_assignment_is_deterministic_with_identical_seed(self):
+        first = assign_personality_traits("Agent 3", "sniper", roster_index=3, seed=99)
+        second = assign_personality_traits("Agent 3", "sniper", roster_index=3, seed=99)
+
+        self.assertEqual(first, second)
+
+    def test_neutral_fallback_without_traits(self):
+        text = "Mission launched: Quiet Static against Chrome Jackals."
+
+        self.assertEqual(modulate_mission_log_tone(text, None, None), text)
+        self.assertEqual(modulate_mission_log_tone(text, "", ""), text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduire un petit set de traits d'agent pour enrichir la tonalité des logs et débriefs sans refondre l'architecture narrative.
- Permettre une modulation de ton réutilisable (fonction dédiée) et non-inline pour garder la logique narrative isolée et testable.
- Garantir compatibilité ascendante en conservant un fallback neutre lorsque les traits sont absents dans d'anciennes sauvegardes.

### Description
- Ajout d'un module dédié `game/narrative/personality_traits.py` contenant un petit dictionnaire de traits (`steadfast`, `reckless`, `empathetic`, `cunning`), la fonction déterministe `assign_personality_traits` et la fonction `modulate_mission_log_tone` pour appliquer des wrappers de ton aux textes de log.
- Extension du modèle `Character` avec les champs `personality_primary_trait` et `personality_secondary_trait` et ajout de leur sérialisation/désérialisation pour préserver les sauvegardes existantes (valeurs vides => fallback neutre).
- Assignation des traits lors de la création/recrutement d'agents dans `game/recruitment.py` via la nouvelle API de trait, sans modifier l'architecture existante.
- Injection de la modulation de tonalité dans le flux de logs de complication de mission en `game/mission_system.py` en appelant `modulate_mission_log_tone` (aucune logique de tonalité inline ajoutée).
- Ajout d'un test unitaire `tests/test_personality_traits.py` et mise à jour de `docs/roadmap.md` et `docs/backlog.md` pour documenter l'AGENT-05 comme terminé et décrire l'intention émotionnelle du set de traits.

### Testing
- Une exécution initiale de `pytest -q tests/test_personality_traits.py tests/test_save_system.py tests/test_mission_generation.py` a échoué à la collecte à cause d'un `ModuleNotFoundError` sans `PYTHONPATH` configuré (environnement de test global).
- Avec `PYTHONPATH=.`, `pytest -q tests/test_personality_traits.py` a réussi (3 passed).
- Avec `PYTHONPATH=.`, `pytest -q tests/test_save_system.py` a réussi (2 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ffcddb56c832b94738bd472011fe4)