### PR TITLE
Add reusable squad morale widget and aggregation module

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -28,6 +28,7 @@ TODO:
 [x] Create mission generation system
 [x] Create stress system
 [x] Add mission debrief narrative module with GameState persistence and tests
+[x] Add reusable squad morale widget (global + per-agent trend)
 
 Done:
 - Recovery-room support dialogues: added `game/narrative/recovery_dialogues.py` with a small deterministic generator driven by stress threshold, affinity priority (same squad then complementary roles), and one-day anti-repetition memory persisted in `GameState.recovery_narrative_memory`; output remains render-neutral (`line` + metadata) to keep narrative modular and memorable without UI coupling.
@@ -104,6 +105,13 @@ Done:
 - Daily stress recovery now ticks from the strategic calendar: every day lowers
   agent stress by 1, while agents in medical recovery decompress by 2 and log
   visible command-room updates to keep emotional consequences readable.
+
+- Squad morale widget + logic split: added `game/management/morale.py` for
+  reusable aggregate morale computation (global score, trend delta, per-agent
+  contributions with stable/declining/critical states) and
+  `game/ui/widgets/squad_morale_panel.py` for compact render-neutral panel
+  lines; RPG room info now consumes the same widget output instead of duplicating
+  morale rendering logic.
 
 Automation status:
 - [done] Add roadmap next-steps generator script (`tools/docs/generate_docs.py`)

--- a/game/management/morale.py
+++ b/game/management/morale.py
@@ -1,0 +1,81 @@
+"""Compact morale aggregation for squad-level UI and narrative hooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..character import Character
+
+
+@dataclass(frozen=True)
+class AgentMoraleContribution:
+    """One agent contribution to squad morale."""
+
+    name: str
+    morale: int
+    delta: int
+
+
+@dataclass(frozen=True)
+class SquadMoraleSummary:
+    """Aggregated squad morale snapshot used by UI widgets."""
+
+    global_morale: int
+    state: str
+    trend_delta: int
+    contributions: list[AgentMoraleContribution]
+
+
+def _clamp(value: int, floor: int = 0, ceil: int = 100) -> int:
+    return max(floor, min(ceil, int(value)))
+
+
+def _agent_morale(character: Character) -> int:
+    loyalty_component = _clamp(character.loyalty * 10)
+    stress_penalty = _clamp(character.stress)
+    return _clamp(50 + loyalty_component - stress_penalty)
+
+
+def morale_state(value: int) -> str:
+    """Map morale value to sober command states."""
+    if value <= 30:
+        return "critical"
+    if value <= 50:
+        return "declining"
+    return "stable"
+
+
+def aggregate_squad_morale(
+    squad: list[Character],
+    previous_global_morale: int | None = None,
+) -> SquadMoraleSummary:
+    """Return global squad morale and per-agent contributions.
+
+    Morale favors high loyalty and low stress while keeping values in [0..100].
+    Empty squads return a neutral zero snapshot for robust UI rendering.
+    """
+    if not squad:
+        return SquadMoraleSummary(0, "critical", 0, [])
+
+    contributions = [
+        AgentMoraleContribution(
+            name=agent.name,
+            morale=_agent_morale(agent),
+            delta=(_agent_morale(agent) - 50),
+        )
+        for agent in squad
+    ]
+    global_morale = _clamp(
+        round(sum(contribution.morale for contribution in contributions) / len(contributions))
+    )
+    trend_delta = (
+        0
+        if previous_global_morale is None
+        else global_morale - _clamp(previous_global_morale)
+    )
+    return SquadMoraleSummary(
+        global_morale=global_morale,
+        state=morale_state(global_morale),
+        trend_delta=trend_delta,
+        contributions=contributions,
+    )

--- a/game/ui/widgets/squad_morale_panel.py
+++ b/game/ui/widgets/squad_morale_panel.py
@@ -1,0 +1,52 @@
+"""Reusable squad morale widget model and compact text rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...management.morale import SquadMoraleSummary
+
+
+@dataclass(frozen=True)
+class SquadMoraleWidgetLine:
+    """One render-ready morale line."""
+
+    text: str
+    emphasis: str = "normal"
+
+
+def _short_bar(value: int, width: int = 8) -> str:
+    safe = max(0, min(100, int(value)))
+    filled = int(round((safe / 100) * width))
+    return "█" * filled + "░" * (width - filled)
+
+
+def _trend_symbol(delta: int) -> str:
+    if delta <= -5:
+        return "↓"
+    if delta >= 5:
+        return "↑"
+    return "→"
+
+
+def build_squad_morale_panel_lines(summary: SquadMoraleSummary) -> list[SquadMoraleWidgetLine]:
+    """Build reusable compact lines: global morale + per-agent contributions."""
+    header = SquadMoraleWidgetLine(
+        (
+            f"Squad morale {_short_bar(summary.global_morale)} {summary.global_morale}/100 "
+            f"[{summary.state}] {_trend_symbol(summary.trend_delta)}"
+        ),
+        emphasis="header",
+    )
+    if not summary.contributions:
+        return [header, SquadMoraleWidgetLine("No active squad assigned.", emphasis="muted")]
+
+    lines = [header]
+    for contribution in summary.contributions:
+        lines.append(
+            SquadMoraleWidgetLine(
+                f"{contribution.name}: {_short_bar(contribution.morale, width=6)} "
+                f"{contribution.morale}/100 ({contribution.delta:+d})"
+            )
+        )
+    return lines

--- a/game/views.py
+++ b/game/views.py
@@ -57,6 +57,8 @@ from .recruitment import recruit_agent
 from .ui import GameView
 from .ui.command_deck import build_corporate_finance_lines, build_event_panel_lines
 from .ui.research_lab import build_research_lab_lines
+from .ui.widgets.squad_morale_panel import build_squad_morale_panel_lines
+from .management.morale import aggregate_squad_morale
 from .unit import Unit
 
 
@@ -971,12 +973,17 @@ class RPGView(GameView):
             if active_agent
             else "No agent selected"
         )
+        previous_morale = getattr(self.game_state, "_last_squad_morale", None)
+        morale_summary = aggregate_squad_morale(selected, previous_morale)
+        self.game_state._last_squad_morale = morale_summary.global_morale
+        morale_lines = [line.text for line in build_squad_morale_panel_lines(morale_summary)]
+
         return {
             "barracks": [
                 f"Roster {len(self.game_state.characters)} agents",
                 f"Available funds {self.game_state.available_funds}",
                 "Recruit cost: 5 funds",
-            ],
+            ] + morale_lines[:2],
             "ops": [
                 mission.title,
                 f"Risk {mission.risk_level} | Objective {mission.objective_type}",
@@ -991,7 +998,7 @@ class RPGView(GameView):
                 f"Recovering agents {len(recovering)}",
                 agent_line,
                 f"Selected squad {len(selected)} + {selected_asset_count} support",
-            ],
+            ] + morale_lines[:1],
             "armory": (
                 [
                     f"Selected squad {len(selected)} + {selected_asset_count} support",

--- a/tests/test_squad_morale_panel.py
+++ b/tests/test_squad_morale_panel.py
@@ -1,0 +1,42 @@
+"""Tests for squad morale aggregation and reusable widget lines."""
+
+import unittest
+
+from game.character import Character
+from game.management.morale import aggregate_squad_morale, morale_state
+from game.ui.widgets.squad_morale_panel import build_squad_morale_panel_lines
+
+
+class SquadMoralePanelTest(unittest.TestCase):
+    def test_aggregate_calculation_is_consistent(self):
+        squad = [
+            Character("Calm", loyalty=3, stress=10),
+            Character("Frayed", loyalty=1, stress=40),
+        ]
+
+        summary = aggregate_squad_morale(squad, previous_global_morale=55)
+
+        self.assertEqual(summary.global_morale, 45)
+        self.assertEqual(summary.trend_delta, -10)
+        self.assertEqual(summary.state, "declining")
+        self.assertEqual([c.morale for c in summary.contributions], [70, 20])
+
+    def test_state_thresholds_cover_stable_declining_critical(self):
+        self.assertEqual(morale_state(75), "stable")
+        self.assertEqual(morale_state(45), "declining")
+        self.assertEqual(morale_state(30), "critical")
+
+    def test_empty_squad_is_robust_and_renderable(self):
+        summary = aggregate_squad_morale([])
+        lines = build_squad_morale_panel_lines(summary)
+
+        self.assertEqual(summary.global_morale, 0)
+        self.assertEqual(summary.trend_delta, 0)
+        self.assertEqual(summary.contributions, [])
+        self.assertEqual(summary.state, "critical")
+        self.assertEqual(len(lines), 2)
+        self.assertIn("No active squad assigned", lines[1].text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Separate squad-morale logic from view rendering to avoid bloating existing screens and enable reuse across RPG/management UIs.
- Provide a small, testable aggregation API that feeds a compact, render-neutral widget so multiple views can display the same morale snapshot without duplicating logic.
- Support sober visual states (stable / declining / critical) and robust behavior when a squad is empty.

### Description
- Add `game/management/morale.py` which implements `aggregate_squad_morale` producing a `SquadMoraleSummary` with `global_morale`, `state`, `trend_delta`, and per-agent `AgentMoraleContribution` values and thresholds (`stable`, `declining`, `critical`).
- Add `game/ui/widgets/squad_morale_panel.py` which builds render-ready lines (`build_squad_morale_panel_lines`) with short bar visuals and a trend symbol so UI code can remain render-neutral.
- Wire the widget into the RPG room-info flow in `game/views.py` so barracks and medbay reuse the same morale lines (no duplicated rendering logic) and persist last global morale to compute trend.
- Add tests `tests/test_squad_morale_panel.py` covering aggregated calculation, state thresholds, and empty-squad robustness, and update `docs/backlog.md` to record the delivered task.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_squad_morale_panel.py` which passed: `3 passed`.
- An initial broader test invocation failed to collect due to environment import configuration (`ModuleNotFoundError: No module named 'game'`) when not using `PYTHONPATH=.`; the targeted test run above succeeded after setting `PYTHONPATH=.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10009d3ed0832b8902fd5dd5568fc4)