### PR TITLE
Add compact objective branch phases and mission integration

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -31,6 +31,7 @@ TODO:
 [x] Add reusable squad morale widget (global + per-agent trend)
 
 Done:
+- MISSION-01 [done]: Objective branches now use 3 compact phase templates (extraction, sabotage, data detour) with a testable evaluation API and UI-readable summaries.
 - Recovery-room support dialogues: added `game/narrative/recovery_dialogues.py` with a small deterministic generator driven by stress threshold, affinity priority (same squad then complementary roles), and one-day anti-repetition memory persisted in `GameState.recovery_narrative_memory`; output remains render-neutral (`line` + metadata) to keep narrative modular and memorable without UI coupling.
 - Mission narrative debrief API: added `game/narrative/debrief.py` with pure `DebriefLine`/`DebriefReport` data structures, deterministic emotional template mapping from stress/injury/recovery/outcome, post-mission integration in battle resolution, and persisted `latest_mission_debrief` on `GameState` for later UI consumption without view coupling.
 - Corporate tower base UI: Corp, City, RPG, and Battle screens now share a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,3 +22,10 @@
 20. [docs] DOC-03 — Décrire le pipeline backlog -> next steps -> roadmap dans docs.
 
 - Traits de personnalité agents (AGENT-05): ajout d'un set court (`steadfast`, `reckless`, `empathetic`, `cunning`) avec intention émotionnelle claire pour moduler la tonalité des logs mission (voix stable, impulsive, humaine, opportuniste) via une fonction dédiée et fallback neutre pour compatibilité des sauvegardes historiques.
+
+
+### Exemple concret — embranchement d'objectif compact
+- Mission d'extraction: phase `reach_witness` puis `escort_zone`.
+- Si `reach_witness` échoue: fin prématurée (`mission_failed`) pour préserver le scope.
+- Mission data-theft: échec du terminal principal redirige vers une route `field_proxy` avant retour vers `extract_data`.
+- L'UI peut afficher un résumé lisible type: `success -> escort_zone, failure -> mission_failed` par phase.

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -8,6 +8,11 @@ from .mission_templates import (
     MissionComplication,
     MissionTemplate,
 )
+from .missions.objective_branches import (
+    branch_summary_lines,
+    evaluate_objective_phase,
+    get_objective_branch,
+)
 from .narrative.personality_traits import modulate_mission_log_tone
 
 
@@ -70,6 +75,36 @@ def pick_complication(
         return None
     return random.choice(eligible)
 
+
+
+def evaluate_mission_objective_phase(
+    mission: MissionTemplate | None,
+    objective_state: dict,
+    current_phase_id: str | None = None,
+) -> dict | None:
+    """Evaluate one objective phase and return a UI/test-friendly payload."""
+    if not mission:
+        return None
+    branch = get_objective_branch(mission.objective_type)
+    if not branch:
+        return None
+    phase_id = current_phase_id or branch.start_phase
+    result = evaluate_objective_phase(branch, phase_id, objective_state)
+    return {
+        "branch_id": branch.template_id,
+        "phase_id": result.phase_id,
+        "succeeded": result.succeeded,
+        "issue_text": result.issue_text,
+        "next_phase_id": result.next_phase_id,
+        "finished": result.finished,
+    }
+
+
+def mission_objective_branch_summary(mission: MissionTemplate | None) -> list[str]:
+    """Expose a readable branch summary for mission data/UI."""
+    if not mission:
+        return []
+    return branch_summary_lines(mission.objective_type)
 
 def resolve_mission_outcome(
     game_state: GameState,

--- a/game/mission_templates.py
+++ b/game/mission_templates.py
@@ -99,7 +99,7 @@ class MissionTemplate:
             district_pressure=dict(data.get("district_pressure", {})),
             starting_enemy_count=data.get("starting_enemy_count", 1),
             objective_type=data.get("objective_type")
-            if data.get("objective_type") in {"extract", "sabotage", "data_theft", "eliminate"}
+            if data.get("objective_type") in {"extract", "sabotage", "data_theft", "eliminate", "safe_extraction", "data_with_detour", "sabotage_window"}
             else "eliminate",
             possible_complications=[
                 MissionComplication.from_dict(complication)
@@ -182,7 +182,7 @@ def create_mission_templates(
             district=district_name,
             district_pressure={"unrest": 3, "media_heat": 2},
             starting_enemy_count=2,
-            objective_type="extract",
+            objective_type="safe_extraction",
             possible_complications=[complications[0], complications[1]],
             success_consequences=[
                 Consequence(
@@ -216,7 +216,7 @@ def create_mission_templates(
             district=district_name,
             district_pressure={"unrest": 5, "media_heat": 1},
             starting_enemy_count=3,
-            objective_type="sabotage",
+            objective_type="sabotage_window",
             possible_complications=[complications[1], complications[2]],
             success_consequences=[
                 Consequence(
@@ -250,7 +250,7 @@ def create_mission_templates(
             district=district_name,
             district_pressure={"media_heat": 4, "stability": -1},
             starting_enemy_count=2,
-            objective_type="data_theft",
+            objective_type="data_with_detour",
             possible_complications=[complications[0], complications[2]],
             success_consequences=[
                 Consequence(

--- a/game/missions/__init__.py
+++ b/game/missions/__init__.py
@@ -1,0 +1,1 @@
+"""Mission progression helpers."""

--- a/game/missions/objective_branches.py
+++ b/game/missions/objective_branches.py
@@ -1,0 +1,151 @@
+"""Compact objective-phase branching rules for mission progression."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+BranchCondition = Callable[[dict], bool]
+
+
+@dataclass(frozen=True)
+class ObjectivePhase:
+    phase_id: str
+    condition: BranchCondition
+    on_success: str
+    on_failure: str
+    next_on_success: str | None = None
+    next_on_failure: str | None = None
+
+
+@dataclass(frozen=True)
+class ObjectiveBranchTemplate:
+    template_id: str
+    label: str
+    start_phase: str
+    phases: dict[str, ObjectivePhase]
+
+
+@dataclass(frozen=True)
+class ObjectivePhaseResult:
+    phase_id: str
+    succeeded: bool
+    issue_text: str
+    next_phase_id: str | None
+    finished: bool
+
+
+_BRANCHES: dict[str, ObjectiveBranchTemplate] = {
+    "safe_extraction": ObjectiveBranchTemplate(
+        template_id="safe_extraction",
+        label="Witness corridor",
+        start_phase="reach_witness",
+        phases={
+            "reach_witness": ObjectivePhase(
+                phase_id="reach_witness",
+                condition=lambda state: state.get("reached_witness", False),
+                on_success="Le témoin est sécurisé.",
+                on_failure="Le témoin reste introuvable.",
+                next_on_success="escort_zone",
+                next_on_failure="mission_failed",
+            ),
+            "escort_zone": ObjectivePhase(
+                phase_id="escort_zone",
+                condition=lambda state: state.get("witness_escorted", False),
+                on_success="Extraction propre confirmée.",
+                on_failure="Le témoin est perdu pendant l'escorte.",
+                next_on_success="mission_success",
+                next_on_failure="mission_failed",
+            ),
+        },
+    ),
+    "data_with_detour": ObjectiveBranchTemplate(
+        template_id="data_with_detour",
+        label="Ghost cache route",
+        start_phase="breach_terminal",
+        phases={
+            "breach_terminal": ObjectivePhase(
+                phase_id="breach_terminal",
+                condition=lambda state: state.get("terminal_breached", False),
+                on_success="Accès terminal obtenu.",
+                on_failure="Accès principal bloqué, route de secours engagée.",
+                next_on_success="extract_data",
+                next_on_failure="field_proxy",
+            ),
+            "field_proxy": ObjectivePhase(
+                phase_id="field_proxy",
+                condition=lambda state: state.get("proxy_reached", False),
+                on_success="Proxy tactique établi, reprise de l'extraction.",
+                on_failure="Le proxy s'effondre sous pression.",
+                next_on_success="extract_data",
+                next_on_failure="mission_failed",
+            ),
+            "extract_data": ObjectivePhase(
+                phase_id="extract_data",
+                condition=lambda state: state.get("cache_extracted", False),
+                on_success="Le cache Ghost Order est récupéré.",
+                on_failure="Le cache est corrompu avant transfert.",
+                next_on_success="mission_success",
+                next_on_failure="mission_failed",
+            ),
+        },
+    ),
+    "sabotage_window": ObjectiveBranchTemplate(
+        template_id="sabotage_window",
+        label="Relay demolition window",
+        start_phase="plant_charge",
+        phases={
+            "plant_charge": ObjectivePhase(
+                phase_id="plant_charge",
+                condition=lambda state: state.get("charge_armed", False),
+                on_success="Charges placées sur le relais.",
+                on_failure="Le relais alerte des renforts.",
+                next_on_success="detonation",
+                next_on_failure="mission_failed",
+            ),
+            "detonation": ObjectivePhase(
+                phase_id="detonation",
+                condition=lambda state: state.get("detonation_confirmed", False),
+                on_success="Relais détruit, fenêtre stratégique gagnée.",
+                on_failure="Détonation interrompue avant impact.",
+                next_on_success="mission_success",
+                next_on_failure="mission_failed",
+            ),
+        },
+    ),
+}
+
+
+def get_objective_branch(template_id: str) -> ObjectiveBranchTemplate | None:
+    return _BRANCHES.get(template_id)
+
+
+def evaluate_objective_phase(
+    branch: ObjectiveBranchTemplate,
+    phase_id: str,
+    objective_state: dict,
+) -> ObjectivePhaseResult:
+    phase = branch.phases[phase_id]
+    succeeded = bool(phase.condition(objective_state))
+    next_phase = phase.next_on_success if succeeded else phase.next_on_failure
+    issue = phase.on_success if succeeded else phase.on_failure
+    finished = next_phase in {None, "mission_success", "mission_failed"}
+    return ObjectivePhaseResult(
+        phase_id=phase.phase_id,
+        succeeded=succeeded,
+        issue_text=issue,
+        next_phase_id=next_phase,
+        finished=finished,
+    )
+
+
+def branch_summary_lines(template_id: str) -> list[str]:
+    branch = get_objective_branch(template_id)
+    if not branch:
+        return []
+    lines = [f"{branch.label} ({branch.template_id})"]
+    for phase in branch.phases.values():
+        lines.append(
+            f"- {phase.phase_id}: success -> {phase.next_on_success}, failure -> {phase.next_on_failure}"
+        )
+    return lines

--- a/tests/test_mission_objectives.py
+++ b/tests/test_mission_objectives.py
@@ -28,9 +28,9 @@ class MissionObjectivesTest(unittest.TestCase):
     def test_mission_templates_assign_distinct_objective_types(self):
         templates = {mission.id: mission for mission in create_mission_templates()}
 
-        self.assertEqual(templates["extraction"].objective_type, "extract")
-        self.assertEqual(templates["sabotage"].objective_type, "sabotage")
-        self.assertEqual(templates["data_theft"].objective_type, "data_theft")
+        self.assertEqual(templates["extraction"].objective_type, "safe_extraction")
+        self.assertEqual(templates["sabotage"].objective_type, "sabotage_window")
+        self.assertEqual(templates["data_theft"].objective_type, "data_with_detour")
 
     def test_objective_creation_uses_readable_label_for_type(self):
         objective = create_battle_objective(_mission("data_theft"))

--- a/tests/test_objective_branches.py
+++ b/tests/test_objective_branches.py
@@ -1,0 +1,66 @@
+import unittest
+
+from game.mission_system import evaluate_mission_objective_phase, mission_objective_branch_summary
+from game.mission_templates import MissionTemplate
+
+
+def _mission(objective_type: str) -> MissionTemplate:
+    return MissionTemplate(
+        id="branch_test",
+        title="Branch Test",
+        objective_text="Test objective branching.",
+        target_faction="Test",
+        district="Test District",
+        district_pressure={},
+        starting_enemy_count=1,
+        objective_type=objective_type,
+    )
+
+
+class ObjectiveBranchesTest(unittest.TestCase):
+    def test_nominal_progression_reaches_success_end(self):
+        mission = _mission("safe_extraction")
+
+        first = evaluate_mission_objective_phase(mission, {"reached_witness": True})
+        second = evaluate_mission_objective_phase(
+            mission,
+            {"witness_escorted": True},
+            current_phase_id=first["next_phase_id"],
+        )
+
+        self.assertEqual(first["next_phase_id"], "escort_zone")
+        self.assertTrue(second["finished"])
+        self.assertEqual(second["next_phase_id"], "mission_success")
+
+    def test_alternative_branch_uses_detour_then_recovers(self):
+        mission = _mission("data_with_detour")
+
+        detour = evaluate_mission_objective_phase(mission, {"terminal_breached": False})
+        recovered = evaluate_mission_objective_phase(
+            mission,
+            {"proxy_reached": True},
+            current_phase_id=detour["next_phase_id"],
+        )
+
+        self.assertEqual(detour["next_phase_id"], "field_proxy")
+        self.assertEqual(recovered["next_phase_id"], "extract_data")
+
+    def test_failure_condition_can_end_mission_early(self):
+        mission = _mission("sabotage_window")
+
+        failed = evaluate_mission_objective_phase(mission, {"charge_armed": False})
+
+        self.assertTrue(failed["finished"])
+        self.assertEqual(failed["next_phase_id"], "mission_failed")
+
+    def test_ui_summary_exposes_readable_branch_lines(self):
+        mission = _mission("safe_extraction")
+
+        summary = mission_objective_branch_summary(mission)
+
+        self.assertGreaterEqual(len(summary), 2)
+        self.assertIn("safe_extraction", summary[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Encapsulate multi-phase objective progression rules outside of `mission_system` to avoid increasing its complexity and to keep branching logic modular and testable.
- Provide a small, scope-controlled set of reusable branch schemas (2–3) that mission templates can reference without adding broad new systems.
- Surface a UI-friendly summary for branches so views can render readable mission progress without coupling to evaluation logic.

### Description
- Add `game/missions/objective_branches.py` implementing `ObjectivePhase`, `ObjectiveBranchTemplate`, `ObjectivePhaseResult` and three compact templates: `safe_extraction`, `data_with_detour`, and `sabotage_window`.
- Integrate a focused API into `game/mission_system.py` with `evaluate_mission_objective_phase(...)` to evaluate a single phase and `mission_objective_branch_summary(...)` to expose UI-readable lines, while keeping existing resolution flow untouched.
- Update `game/mission_templates.py` to accept the new branch-capable `objective_type` values and switch the three seed templates to reference the new branch types, and add `game/missions/__init__.py` to keep architecture tidy.
- Add `tests/test_objective_branches.py` covering nominal progression, alternative-detour recovery, early failure termination, and readable UI summary; adjust `tests/test_mission_objectives.py` assertions to align with the new objective types, and update `docs/roadmap.md` and `docs/backlog.md` with a concrete example and status update.

### Testing
- Ran the branch tests with `PYTHONPATH=. pytest -q tests/test_objective_branches.py tests/test_mission_objectives.py` and all tests passed (`11 passed`).
- The added unit tests exercise nominal flow, alternative detour recovery, and premature failure end-states for objective branches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1001cc9220832b9eee9eb7170be3b3)