### PR TITLE
Add evacuation mission module with survival-first scoring

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -30,7 +30,10 @@ TODO:
 [x] Add mission debrief narrative module with GameState persistence and tests
 [x] Add reusable squad morale widget (global + per-agent trend)
 
+- [x] Add evacuation mission template focused on living-agent extraction with survival-first scoring, pressure-gated generation odds, and emotional-briefing metadata to reinforce attachment to squad outcomes over kill counts
+
 Done:
+- MISSION-02 [done]: Added `game/missions/evacuation.py` as a compact extraction-first mission module, including pressure-scaled constraints, survival-priority scoring, and UI briefing fields (risk/reward/emotional impact); integrated controlled spawn probability into mission generation and covered with dedicated tests. Design justification: emotional attachment is strongest when mission value is tied to who returns alive, not enemy body count.
 - MISSION-01 [done]: Objective branches now use 3 compact phase templates (extraction, sabotage, data detour) with a testable evaluation API and UI-readable summaries.
 - Recovery-room support dialogues: added `game/narrative/recovery_dialogues.py` with a small deterministic generator driven by stress threshold, affinity priority (same squad then complementary roles), and one-day anti-repetition memory persisted in `GameState.recovery_narrative_memory`; output remains render-neutral (`line` + metadata) to keep narrative modular and memorable without UI coupling.
 - Mission narrative debrief API: added `game/narrative/debrief.py` with pure `DebriefLine`/`DebriefReport` data structures, deterministic emotional template mapping from stress/injury/recovery/outcome, post-mission integration in battle resolution, and persisted `latest_mission_debrief` on `GameState` for later UI consumption without view coupling.

--- a/game/mission_generation.py
+++ b/game/mission_generation.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .gamestate import GameState
 from .mission_templates import MissionTemplate, create_mission_templates
+from .missions.evacuation import create_evacuation_template
 
 
 def _mission_seed(game_state: "GameState") -> int:
@@ -22,6 +23,10 @@ def _mission_seed(game_state: "GameState") -> int:
 def generate_mission_board(game_state: "GameState", board_size: int = 3) -> list[MissionTemplate]:
     """Generate a small daily mission board based on district pressure."""
     templates = create_mission_templates(game_state.district.name)
+    district_pressure = game_state.district.unrest + game_state.district.media_heat
+    evac_probability = min(0.65, max(0.15, district_pressure / 140))
+    if random.Random(_mission_seed(game_state) + 404).random() < evac_probability:
+        templates.append(create_evacuation_template(game_state.district.name, district_pressure))
     if not templates:
         return []
 

--- a/game/missions/evacuation.py
+++ b/game/missions/evacuation.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from game.consequences import Consequence
+from game.mission_templates import MissionTemplate
+from game.savage_fate import SavageTag, tag_from_library
+
+
+@dataclass(frozen=True)
+class EvacuationOutcome:
+    """Compact result payload for extraction-first mission resolution."""
+
+    succeeded: bool
+    score: int
+    summary: str
+    extracted_agents: int
+    alive_agents: int
+    neutralized_enemies: int
+
+
+def create_evacuation_template(district_name: str, pressure: int = 0) -> MissionTemplate:
+    """Build one evacuation mission focused on saving squad members under pressure."""
+    risk_level = 3 if pressure >= 60 else 2
+    duration_days = 2 if pressure >= 70 else 1
+    min_extracted = 2 if pressure >= 60 else 1
+    tolerated_losses = 0 if pressure >= 60 else 1
+
+    return MissionTemplate(
+        id="evacuation",
+        title="Evacuation: Last Lift Corridor",
+        objective_text=(
+            "Extract a minimum number of living agents before corridor lockdown. "
+            "Neutralizations are optional; survival is mandatory."
+        ),
+        target_faction="Aegis Dynamics",
+        district=district_name,
+        district_pressure={"pressure": pressure, "unrest_weight": 2, "media_weight": 1},
+        starting_enemy_count=3,
+        objective_type="safe_extraction",
+        risk_level=risk_level,
+        fund_reward=55 + max(0, pressure // 10),
+        duration_days=duration_days,
+        tags=[
+            tag_from_library("civilian_panic"),
+            SavageTag(
+                name="evacuation_pressure",
+                description="Time pressure and fragile evac routes push squads into emotional triage.",
+                intensity=2 if pressure >= 60 else 1,
+                source="mission",
+            ),
+        ],
+        success_consequences=[
+            Consequence(
+                affected_district=district_name,
+                affected_faction="Evacuation Network",
+                severity=1,
+                narrative_text="Evac success: survivors spread trust through the district shelters.",
+                mechanical_effects={"stability": 4, "unrest": -3},
+            )
+        ],
+        failure_consequences=[
+            Consequence(
+                affected_district=district_name,
+                affected_faction="Aegis Dynamics",
+                severity=3,
+                narrative_text="Evac failure: missing agents become symbols of abandonment.",
+                mechanical_effects={"unrest": 7, "media_heat": 5, "stability": -4},
+            )
+        ],
+    )
+
+
+def evacuation_constraints(pressure: int) -> dict[str, int]:
+    """Expose extraction/loss/pressure constraints for UI and evaluation."""
+    return {
+        "min_extracted_agents": 2 if pressure >= 60 else 1,
+        "tolerated_losses": 0 if pressure >= 60 else 1,
+        "pressure": max(0, pressure),
+    }
+
+
+def evaluate_evacuation_outcome(
+    extracted_agents: int,
+    alive_agents: int,
+    neutralized_enemies: int,
+    min_extracted_agents: int,
+    tolerated_losses: int,
+) -> EvacuationOutcome:
+    """Score evacuation with survival-first weighting."""
+    extracted = max(0, extracted_agents)
+    alive = max(0, alive_agents)
+    neutralized = max(0, neutralized_enemies)
+    losses = max(0, alive - extracted)
+
+    succeeded = extracted >= max(1, min_extracted_agents) and losses <= max(0, tolerated_losses)
+    score = (extracted * 35) + (alive * 20) + (neutralized * 5) - (losses * 40)
+    summary = "Evacuation success: survival corridor held." if succeeded else "Evacuation failed: extraction threshold missed."
+
+    return EvacuationOutcome(
+        succeeded=succeeded,
+        score=score,
+        summary=summary,
+        extracted_agents=extracted,
+        alive_agents=alive,
+        neutralized_enemies=neutralized,
+    )
+
+
+def evacuation_briefing_fields(pressure: int) -> dict[str, str | int]:
+    """Return UI briefing metadata centered on emotional stakes."""
+    risk = "critical" if pressure >= 70 else "high" if pressure >= 45 else "elevated"
+    reward = "Survivors secured and district trust gains." if pressure >= 45 else "Safe extraction with moderate public goodwill."
+    impact = "High emotional attachment expected: squad survival and witness memory are foregrounded."
+    return {"risk": risk, "reward": reward, "emotional_impact": impact, "pressure": pressure}

--- a/tests/test_evacuation_mission.py
+++ b/tests/test_evacuation_mission.py
@@ -1,0 +1,57 @@
+import unittest
+
+from game.gamestate import GameState
+from game.mission_generation import generate_mission_board
+from game.missions.evacuation import (
+    create_evacuation_template,
+    evacuation_briefing_fields,
+    evacuation_constraints,
+    evaluate_evacuation_outcome,
+)
+
+
+class EvacuationMissionTest(unittest.TestCase):
+    def test_evacuation_can_appear_in_generation_under_pressure(self):
+        game_state = GameState(mission_templates=[])
+        game_state.district.unrest = 65
+        game_state.district.media_heat = 30
+
+        board = generate_mission_board(game_state, board_size=6)
+
+        self.assertTrue(any(m.id.startswith("evacuation") for m in board))
+
+    def test_success_and_failure_follow_extraction_threshold(self):
+        constraints = evacuation_constraints(pressure=70)
+
+        success = evaluate_evacuation_outcome(
+            extracted_agents=2,
+            alive_agents=2,
+            neutralized_enemies=6,
+            min_extracted_agents=constraints["min_extracted_agents"],
+            tolerated_losses=constraints["tolerated_losses"],
+        )
+        failure = evaluate_evacuation_outcome(
+            extracted_agents=1,
+            alive_agents=2,
+            neutralized_enemies=8,
+            min_extracted_agents=constraints["min_extracted_agents"],
+            tolerated_losses=constraints["tolerated_losses"],
+        )
+
+        self.assertTrue(success.succeeded)
+        self.assertFalse(failure.succeeded)
+        self.assertGreater(success.score, failure.score)
+
+    def test_template_tags_and_metadata_include_ui_briefing_fields(self):
+        template = create_evacuation_template("Chrome Warrens", pressure=52)
+        briefing = evacuation_briefing_fields(pressure=52)
+
+        self.assertEqual(template.objective_type, "safe_extraction")
+        self.assertTrue(any(tag.name == "evacuation_pressure" for tag in template.tags))
+        self.assertIn("risk", briefing)
+        self.assertIn("reward", briefing)
+        self.assertIn("emotional_impact", briefing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a compact evacuation mission that emphasizes returning living agents to increase emotional attachment to mission outcomes. 
- Make availability responsive to district pressure so evacuation ops appear when the city tension suggests urgent withdrawal scenarios. 

### Description
- Added `game/missions/evacuation.py` providing an `EvacuationOutcome` dataclass, `create_evacuation_template`, `evacuation_constraints`, `evaluate_evacuation_outcome`, and `evacuation_briefing_fields` implementing survival-first scoring, pressure-scaled constraints, tags, and UI briefing metadata. 
- Integrated the evacuation template into `game/mission_generation.py` by appending an evacuation template with a deterministic, pressure-driven spawn probability (seeded RNG). 
- Added unit tests in `tests/test_evacuation_mission.py` verifying generation appearance under pressure, extraction-threshold success/failure semantics, and template tag/briefing metadata consistency. 
- Updated `docs/backlog.md` to record the new mission, its design rationale prioritizing emotional attachment, and its done status. 

### Testing
- Ran the targeted test suite with `PYTHONPATH=. pytest -q tests/test_evacuation_mission.py tests/test_mission_generation.py` and all tests passed (`6 passed`). 
- The tests cover mission board generation inclusion, evacuation outcome scoring logic, and briefing/metadata coherence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10031609a0832bb1a2448cd198e249)