### PR TITLE
Add compact faction narrative rewards on mission success

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -117,6 +117,14 @@ Done:
   lines; RPG room info now consumes the same widget output instead of duplicating
   morale rendering logic.
 
+- [x] Ajouter des récompenses narratives de faction post-mission (scope compact)
+  - Nouveau module: `game/narrative/faction_rewards.py`.
+  - Règle: attribution uniquement en cas de succès mission (`victory=True`), aucune attribution en échec total.
+  - Nature des récompenses: retours narratifs courts (rumeur/contact/confiance), sans buff système.
+  - Fallback: entrée neutre pour factions non mappées.
+  - Persistance: journal dédié `GameState.faction_reward_journal` sauvegardé/chargé.
+  - Limite de scope: aucun nouveau système économique/combat, seulement mémoire narrative et event-log.
+
 Automation status:
 - [done] Add roadmap next-steps generator script (`tools/docs/generate_docs.py`)
 - [done] Add unit tests for generator stability/format (`tests/test_generate_docs.py`)

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -101,6 +101,7 @@ class GameState:
     latest_agent_aftermath: list[str] = field(default_factory=list)
     latest_mission_debrief: dict = field(default_factory=dict)
     recovery_narrative_memory: dict = field(default_factory=dict)
+    faction_reward_journal: list[dict[str, str]] = field(default_factory=list)
     selected_agent_names: list[str] = field(default_factory=list)
     spec_ops_assets: list[SpecOpsAsset] = field(default_factory=list)
     selected_asset_ids: list[str] = field(default_factory=list)
@@ -492,6 +493,7 @@ class GameState:
             "latest_agent_aftermath": list(self.latest_agent_aftermath),
             "latest_mission_debrief": dict(self.latest_mission_debrief),
             "recovery_narrative_memory": dict(self.recovery_narrative_memory),
+            "faction_reward_journal": list(self.faction_reward_journal),
             "event_log": list(self.event_log),
             "active_events": [event.to_dict() for event in self.active_events],
             "next_event_id": self.next_event_id,
@@ -562,6 +564,7 @@ class GameState:
         gs.latest_agent_aftermath = list(data.get("latest_agent_aftermath", []))
         gs.latest_mission_debrief = dict(data.get("latest_mission_debrief", {}))
         gs.recovery_narrative_memory = dict(data.get("recovery_narrative_memory", {}))
+        gs.faction_reward_journal = list(data.get("faction_reward_journal", []))
         gs.event_log = list(data.get("event_log", gs.event_log))
         gs.active_events = [
             ActiveEvent.from_dict(event) for event in data.get("active_events", [])

--- a/game/mission_system.py
+++ b/game/mission_system.py
@@ -14,6 +14,7 @@ from .missions.objective_branches import (
     get_objective_branch,
 )
 from .narrative.personality_traits import modulate_mission_log_tone
+from .narrative.faction_rewards import build_reward_log_entries, rewards_for_faction
 
 
 def ensure_mission_templates(game_state: GameState) -> None:
@@ -106,6 +107,34 @@ def mission_objective_branch_summary(mission: MissionTemplate | None) -> list[st
         return []
     return branch_summary_lines(mission.objective_type)
 
+def apply_faction_narrative_rewards(
+    game_state: GameState, mission: MissionTemplate | None, victory: bool
+) -> list[dict[str, str]]:
+    """Grant compact faction narrative beats only on partial/total mission success."""
+    if not mission or not victory:
+        return []
+
+    rewards = rewards_for_faction(mission.target_faction)
+    reward_entries: list[dict[str, str]] = []
+    for reward in rewards:
+        reward_entries.append(
+            {
+                "faction": mission.target_faction,
+                "mission_id": mission.id,
+                "mission_title": mission.title,
+                "kind": reward.kind,
+                "text": reward.text,
+            }
+        )
+    game_state.faction_reward_journal.extend(reward_entries)
+    game_state.faction_reward_journal = game_state.faction_reward_journal[-24:]
+
+    for line in build_reward_log_entries(mission.target_faction, mission.title):
+        game_state.add_event(line)
+
+    return reward_entries
+
+
 def resolve_mission_outcome(
     game_state: GameState,
     mission: MissionTemplate | None,
@@ -123,6 +152,7 @@ def resolve_mission_outcome(
         game_state.apply_consequence(consequence)
 
     game_state.award_mission_funds(mission, victory)
+    apply_faction_narrative_rewards(game_state, mission, victory)
 
     complication = pick_complication(mission, triggered_complication)
     if complication:

--- a/game/narrative/faction_rewards.py
+++ b/game/narrative/faction_rewards.py
@@ -1,0 +1,52 @@
+"""Compact narrative-only faction rewards granted after successful missions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FactionNarrativeReward:
+    """Small narrative beat recorded in campaign memory."""
+
+    kind: str
+    text: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "text": self.text}
+
+
+_FACTION_REWARDS: dict[str, list[FactionNarrativeReward]] = {
+    "Warrens Free Clinic": [
+        FactionNarrativeReward("local_trust", "La clinique diffuse un mot de confiance discret.")
+    ],
+    "Chrome Jackals": [
+        FactionNarrativeReward("street_rumor", "Une rumeur de rue affirme que vous avez brisé une ligne de trafic.")
+    ],
+    "Aegis Dynamics": [
+        FactionNarrativeReward("contact", "Un contact d'entreprise transmet un canal de secours à usage unique.")
+    ],
+}
+
+_NEUTRAL_FALLBACK = FactionNarrativeReward(
+    "neutral_echo",
+    "Le district retient un écho prudent de l'opération, sans nouvel appui direct.",
+)
+
+
+def rewards_for_faction(faction_name: str) -> list[FactionNarrativeReward]:
+    """Return small narrative rewards for a faction with a neutral fallback."""
+    rewards = _FACTION_REWARDS.get(faction_name)
+    if rewards:
+        return list(rewards)
+    return [_NEUTRAL_FALLBACK]
+
+
+def build_reward_log_entries(faction_name: str, mission_title: str) -> list[str]:
+    """Build readable campaign-log lines from faction narrative rewards."""
+    entries = []
+    for reward in rewards_for_faction(faction_name):
+        entries.append(
+            f"Récompense narrative ({reward.kind}) après '{mission_title}': {reward.text}"
+        )
+    return entries

--- a/tests/test_faction_rewards.py
+++ b/tests/test_faction_rewards.py
@@ -1,0 +1,61 @@
+"""Tests for compact post-mission faction narrative rewards."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from game.gamestate import GameState
+from game.mission_system import apply_faction_narrative_rewards
+from game.mission_templates import MissionTemplate
+
+
+def _mission(target_faction: str = "Warrens Free Clinic") -> MissionTemplate:
+    return MissionTemplate(
+        id="faction-reward-test",
+        title="Quiet Circuit",
+        objective_text="Secure a relay alley.",
+        target_faction=target_faction,
+        district="Chrome Warrens",
+        district_pressure={},
+        starting_enemy_count=2,
+        risk_level=2,
+    )
+
+
+class FactionRewardsTest(unittest.TestCase):
+    def test_assignment_matches_faction_mapping(self):
+        game_state = GameState()
+
+        entries = apply_faction_narrative_rewards(
+            game_state, _mission("Warrens Free Clinic"), victory=True
+        )
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["kind"], "local_trust")
+        self.assertTrue(game_state.faction_reward_journal)
+
+    def test_no_assignment_on_total_failure(self):
+        game_state = GameState()
+
+        entries = apply_faction_narrative_rewards(
+            game_state, _mission("Warrens Free Clinic"), victory=False
+        )
+
+        self.assertEqual(entries, [])
+        self.assertEqual(game_state.faction_reward_journal, [])
+
+    def test_journal_persists_through_save_load(self):
+        game_state = GameState()
+        apply_faction_narrative_rewards(game_state, _mission("Unknown Faction"), victory=True)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            save_path = Path(tmp_dir) / "savegame.json"
+            game_state.save(str(save_path))
+            loaded = GameState.load(str(save_path))
+
+        self.assertEqual(len(loaded.faction_reward_journal), 1)
+        self.assertEqual(loaded.faction_reward_journal[0]["kind"], "neutral_echo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Add lightweight narrative beats tied to factions after successful missions to support emergent storytelling without introducing mechanical buffs. 
- Keep the feature narrow and modular so it only records short narrative returns (rumor/contact/trust) and persists them for later UI consumption. 

### Description
- New module `game/narrative/faction_rewards.py` defines a small `faction -> list of FactionNarrativeReward` table and a neutral fallback for unmapped factions. 
- Added `apply_faction_narrative_rewards(game_state, mission, victory)` in `game/mission_system.py` and call it from `resolve_mission_outcome(...)`, with the strict rule that rewards are granted only when `victory=True`. 
- Added `GameState.faction_reward_journal` and wired it into `GameState.save`/`GameState.load` so reward entries persist across save/load cycles. 
- Emitted readable event-log lines via `game_state.add_event(...)` for each awarded narrative beat and updated `docs/backlog.md` to document scope/limits. 

### Testing
- Ran the new unit tests in `tests/test_faction_rewards.py` which exercise mapped attribution, absence on total failure, and save/load persistence. 
- Test command: `python -m unittest tests/test_faction_rewards.py` and the suite passed (3 tests run, OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1005d097c0832baac843191490cdb1)