### PR TITLE
Add relation-impact metadata and critical choice UI highlight

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -143,3 +143,5 @@ Automation status:
   - Exposition UI data: résumé lisible dans le dossier agent, rendu non imposé.
 
 [x] AGENT-05 Personality-trait mission log modulation (compact set + neutral fallback + tests)
+
+- [x] UI-03 critical choice highlight relationnel (UX rationale: signal discret des décisions émotionnelles + journalisation des impacts élevés pour nourrir les conséquences relationnelles).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,7 +9,7 @@
 7. [ui] UI-02 — Créer un panneau compact de moral d'escouade dans la vue RPG.
 8. [mission] MISSION-01 — Introduire des variantes d'objectifs multi-étapes avec embranchements lisibles.
 9. [mission] MISSION-04 — Ajouter des récompenses narratives légères selon la faction ciblée.
-10. [ui] UI-03 — Mettre en évidence les choix critiques affectant les relations d'équipe.
+10. [ui] UI-03 — [done] Mettre en évidence les choix critiques affectant les relations d'équipe.
 11. [tests] TEST-01 — Couvrir la génération quotidienne de missions avec tests de régression supplémentaires.
 12. [tests] TEST-03 — Ajouter des tests d'intégration sur stress/récupération/calendrier.
 13. [ui] UI-01 — Afficher un fil narratif des événements récents dans le command center.
@@ -29,3 +29,6 @@
 - Si `reach_witness` échoue: fin prématurée (`mission_failed`) pour préserver le scope.
 - Mission data-theft: échec du terminal principal redirige vers une route `field_proxy` avant retour vers `extract_data`.
 - L'UI peut afficher un résumé lisible type: `success -> escort_zone, failure -> mission_failed` par phase.
+
+
+- UI-03 [done]: Ajout d'une convention `relation_impact: low|medium|high` sur missions/choix d'événements, nouveau widget dédié `game/ui/widgets/critical_choice_highlight.py`, intégration des marqueurs discrets sur les écrans de choix (command deck / mission board), et traçage des choix `high` dans `game/relationships/impact_tracker.py` pour soutenir les arcs relationnels sans gonfler le scope.

--- a/game/management/events.py
+++ b/game/management/events.py
@@ -36,6 +36,7 @@ class EventChoice:
     label: str
     effects: dict[str, Any] = field(default_factory=dict)
     summary: str = ""
+    relation_impact: str = "low"
 
     def to_dict(self) -> dict:
         return {
@@ -43,6 +44,7 @@ class EventChoice:
             "label": self.label,
             "effects": dict(self.effects),
             "summary": self.summary,
+            "relation_impact": self.relation_impact,
         }
 
     @classmethod
@@ -54,7 +56,17 @@ class EventChoice:
             label=str(data.get("label", "Respond")),
             effects=dict(data.get("effects", {})),
             summary=str(data.get("summary", "")),
+            relation_impact=_normalize_relation_impact(
+                str(data.get("relation_impact", "low"))
+            ),
         )
+
+
+def _normalize_relation_impact(value: str) -> str:
+    level = str(value).strip().lower()
+    if level not in {"low", "medium", "high"}:
+        return "low"
+    return level
 
 
 @dataclass(frozen=True)
@@ -67,6 +79,7 @@ class EventTemplate:
     severity: int
     choices: list[EventChoice]
     consequences: dict[str, Any] = field(default_factory=dict)
+    relation_impact: str = "low"
     expiration_days: int = 3
     weight: int = 1
 
@@ -78,6 +91,7 @@ class EventTemplate:
             "severity": max(1, int(self.severity)),
             "choices": [choice.to_dict() for choice in self.choices],
             "consequences": dict(self.consequences),
+            "relation_impact": self.relation_impact,
             "expiration_days": max(1, int(self.expiration_days)),
             "weight": max(1, int(self.weight)),
         }
@@ -97,6 +111,9 @@ class EventTemplate:
                 EventChoice.from_dict(choice) for choice in data.get("choices", [])
             ],
             consequences=dict(data.get("consequences", {})),
+            relation_impact=_normalize_relation_impact(
+                str(data.get("relation_impact", "low"))
+            ),
             expiration_days=max(1, int(data.get("expiration_days", 3))),
             weight=max(1, int(data.get("weight", 1))),
         )
@@ -403,6 +420,15 @@ def apply_event_choice(game_state, event_id: str, choice_key: str) -> bool:
             if choice.key != choice_key:
                 continue
             apply_event_effects(game_state, choice.effects)
+            from ..relationships.impact_tracker import record_relation_impact
+
+            if choice.relation_impact == "high":
+                record_relation_impact(
+                    game_state,
+                    source=f"event:{active_event.id}:{choice.key}",
+                    level=choice.relation_impact,
+                    context=active_event.title,
+                )
             game_state.active_events.remove(active_event)
             game_state.add_event(
                 f"Event response: {active_event.title} -> {choice.label}."

--- a/game/mission_templates.py
+++ b/game/mission_templates.py
@@ -15,6 +15,7 @@ class MissionComplication:
     trigger_text: str
     risk_threshold: int
     tags: list[SavageTag] = field(default_factory=list)
+    relation_impact: str = "low"
     consequence: Consequence = field(default_factory=Consequence)
 
     def to_dict(self) -> dict:
@@ -24,6 +25,7 @@ class MissionComplication:
             "trigger_text": self.trigger_text,
             "risk_threshold": self.risk_threshold,
             "tags": [tag.to_dict() for tag in self.tags],
+            "relation_impact": self.relation_impact,
             "consequence": self.consequence.to_dict(),
         }
 
@@ -60,6 +62,7 @@ class MissionTemplate:
     fund_reward: int = 0
     duration_days: int = 1
     tags: list[SavageTag] = field(default_factory=list)
+    relation_impact: str = "low"
 
     def to_dict(self) -> dict:
         return {
@@ -84,6 +87,7 @@ class MissionTemplate:
             "fund_reward": self.fund_reward,
             "duration_days": max(1, int(self.duration_days)),
             "tags": [tag.to_dict() for tag in self.tags],
+            "relation_impact": self.relation_impact,
         }
 
     @classmethod
@@ -117,6 +121,7 @@ class MissionTemplate:
             fund_reward=int(data.get("fund_reward", 0)),
             duration_days=max(1, int(data.get("duration_days", 1))),
             tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
+            relation_impact=str(data.get("relation_impact", "low")),
         )
 
 
@@ -207,6 +212,7 @@ def create_mission_templates(
             risk_level=2,
             fund_reward=40,
             tags=[tag_from_library("neon_blackout")],
+            relation_impact="medium",
         ),
         MissionTemplate(
             id="sabotage",
@@ -241,6 +247,7 @@ def create_mission_templates(
             risk_level=4,
             fund_reward=70,
             tags=[tag_from_library("gang_pressure")],
+            relation_impact="low",
         ),
         MissionTemplate(
             id="data_theft",

--- a/game/relationships/impact_tracker.py
+++ b/game/relationships/impact_tracker.py
@@ -1,0 +1,28 @@
+"""Track high-impact relational choices for narrative follow-up."""
+
+from __future__ import annotations
+
+
+def _ensure_relation_log(game_state) -> list[dict[str, str]]:
+    log = getattr(game_state, "relation_impact_log", None)
+    if isinstance(log, list):
+        return log
+    game_state.relation_impact_log = []
+    return game_state.relation_impact_log
+
+
+def record_relation_impact(
+    game_state, source: str, level: str, context: str = ""
+) -> dict[str, str]:
+    """Persist one relation-impact decision and emit a compact event beat."""
+    entry = {
+        "source": str(source),
+        "level": str(level),
+        "context": str(context),
+        "day": str(getattr(game_state.calendar, "current_day", 0)),
+    }
+    log = _ensure_relation_log(game_state)
+    log.append(entry)
+    del log[:-24]
+    game_state.add_event(f"Relationship pressure tracked ({entry['level']}): {entry['context']}.")
+    return entry

--- a/game/ui/command_deck.py
+++ b/game/ui/command_deck.py
@@ -12,6 +12,7 @@ from ..character import Character, is_deployable
 from ..dossier import build_agent_dossier_lines
 from ..mission_templates import MissionTemplate
 from .mission_board import objective_label, risk_label
+from .widgets.critical_choice_highlight import format_critical_choice_suffix
 
 
 @dataclass(frozen=True)
@@ -147,5 +148,6 @@ def build_event_panel_lines(active_events, current_day: int) -> list[str]:
         )
         for choice_index, choice in enumerate(event.choices[:2], start=1):
             summary = f" - {choice.summary}" if choice.summary else ""
-            lines.append(f"   {index}.{choice_index} {choice.label}{summary}")
+            suffix = format_critical_choice_suffix(getattr(choice, "relation_impact", "low"))
+            lines.append(f"   {index}.{choice_index} {choice.label}{summary}{suffix}")
     return lines

--- a/game/ui/mission_board.py
+++ b/game/ui/mission_board.py
@@ -6,12 +6,16 @@ from collections.abc import Iterable
 
 from ..consequences import Consequence
 from ..mission_templates import MissionComplication, MissionTemplate
+from .widgets.critical_choice_highlight import format_critical_choice_suffix
 
 OBJECTIVE_LABELS = {
     "extract": "EXTRACT",
     "sabotage": "SABOTAGE",
     "data_theft": "DATA THEFT",
     "eliminate": "ELIMINATE",
+    "safe_extraction": "EXTRACT",
+    "data_with_detour": "DATA THEFT",
+    "sabotage_window": "SABOTAGE",
 }
 
 
@@ -115,4 +119,5 @@ def build_selected_mission_lines(mission: MissionTemplate | None) -> list[str]:
         f"Complications: {_complication_names(mission.possible_complications)}",
         _outcome_line("Success", mission.success_consequences),
         _outcome_line("Failure", mission.failure_consequences),
+        f"Relational impact:{format_critical_choice_suffix(getattr(mission, 'relation_impact', 'low')) or ' none'}",
     ]

--- a/game/ui/widgets/critical_choice_highlight.py
+++ b/game/ui/widgets/critical_choice_highlight.py
@@ -1,0 +1,39 @@
+"""Render-ready helper for discreetly flagging relationship-critical choices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CriticalChoiceHighlight:
+    marker: str
+    text: str
+    emphasis: str = "muted"
+
+
+_IMPACT_COPY = {
+    "low": CriticalChoiceHighlight("", "", "muted"),
+    "medium": CriticalChoiceHighlight("◦", "Lien: impact modéré", "normal"),
+    "high": CriticalChoiceHighlight("◆", "Lien: impact élevé", "accent"),
+}
+
+
+def normalize_relation_impact(relation_impact: str | None) -> str:
+    level = str(relation_impact or "low").strip().lower()
+    if level not in {"low", "medium", "high"}:
+        return "low"
+    return level
+
+
+def build_critical_choice_highlight(relation_impact: str | None) -> CriticalChoiceHighlight:
+    """Return display metadata for a relation-impact marker."""
+    return _IMPACT_COPY[normalize_relation_impact(relation_impact)]
+
+
+def format_critical_choice_suffix(relation_impact: str | None) -> str:
+    """Return a compact inline suffix for line-based UI screens."""
+    highlight = build_critical_choice_highlight(relation_impact)
+    if not highlight.marker:
+        return ""
+    return f" {highlight.marker} {highlight.text}"

--- a/tests/test_critical_choice_highlight.py
+++ b/tests/test_critical_choice_highlight.py
@@ -1,0 +1,78 @@
+"""Tests for relationship-critical choice highlighting."""
+
+import unittest
+
+from game.management.events import ActiveEvent, EventChoice, EventTemplate, apply_event_choice
+from game.gamestate import GameState
+from game.ui.command_deck import build_event_panel_lines
+from game.ui.widgets.critical_choice_highlight import (
+    build_critical_choice_highlight,
+    format_critical_choice_suffix,
+)
+
+
+class CriticalChoiceHighlightTest(unittest.TestCase):
+    def test_render_logic_for_each_impact_level(self):
+        low = build_critical_choice_highlight("low")
+        medium = build_critical_choice_highlight("medium")
+        high = build_critical_choice_highlight("high")
+
+        self.assertEqual(low.marker, "")
+        self.assertIn("modéré", medium.text)
+        self.assertEqual(high.marker, "◆")
+        self.assertIn("élevé", format_critical_choice_suffix("high"))
+
+    def test_marker_presence_for_critical_choices(self):
+        event = ActiveEvent(
+            id="event-1",
+            template=EventTemplate(
+                title="Crossfire",
+                category="social unrest",
+                description="desc",
+                severity=3,
+                choices=[
+                    EventChoice("calm", "Calmer", relation_impact="high"),
+                    EventChoice("delay", "Reporter", relation_impact="low"),
+                ],
+            ),
+            created_day=1,
+            expires_day=3,
+        )
+
+        lines = build_event_panel_lines([event], current_day=1)
+
+        self.assertTrue(any("◆" in line for line in lines))
+        self.assertTrue(any("impact élevé" in line for line in lines))
+
+    def test_neutral_choices_do_not_regress_and_high_impact_is_logged(self):
+        game_state = GameState()
+        game_state.active_events = [
+            ActiveEvent(
+                id="event-2",
+                template=EventTemplate(
+                    title="Council Vote",
+                    category="city politics",
+                    description="desc",
+                    severity=2,
+                    choices=[
+                        EventChoice("safe", "Safe option", relation_impact="low"),
+                        EventChoice("bond", "Bond option", relation_impact="high"),
+                    ],
+                ),
+                created_day=1,
+                expires_day=2,
+            )
+        ]
+
+        neutral_lines = build_event_panel_lines(game_state.active_events, current_day=1)
+        self.assertFalse(any("impact modéré" in line for line in neutral_lines if "Safe option" in line))
+
+        resolved = apply_event_choice(game_state, "event-2", "bond")
+
+        self.assertTrue(resolved)
+        self.assertTrue(hasattr(game_state, "relation_impact_log"))
+        self.assertEqual(game_state.relation_impact_log[-1]["level"], "high")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Signal decisions that affect character relationships with a small, consistent metadata contract (`relation_impact: low|medium|high`).
- Provide a lightweight, reusable UI affordance so relationship-impact choices are visible without changing core flows or adding large systems.
- Capture only the high-impact choices in a compact tracker to support future narrative consequences while keeping scope limited.

### Description
- Add `relation_impact` to `EventChoice`, `EventTemplate`, and `MissionTemplate` with a normalizer (`_normalize_relation_impact`) and serialization support in `game/management/events.py` and `game/mission_templates.py`.
- Introduce a small UI helper widget `game/ui/widgets/critical_choice_highlight.py` that maps `low|medium|high` to a discrete marker, short text, and emphasis, and provide `format_critical_choice_suffix` for inline line-based screens.
- Integrate the highlight into event choice lists in the command deck (`game/ui/command_deck.py`) and into the mission detail panel on the mission board (`game/ui/mission_board.py`).
- Add a compact relationship impact tracker module `game/relationships/impact_tracker.py` and wire `relation_impact == "high"` choices to `record_relation_impact` inside `apply_event_choice` so high-impact decisions are logged for narrative follow-up.
- Seed existing mission templates with `relation_impact` where appropriate and update `docs/roadmap.md` and `docs/backlog.md` to mark `UI-03` done with an explanatory rationale.

### Testing
- Added `tests/test_critical_choice_highlight.py` covering rendering for each impact level, presence of markers on critical choices, and logging behavior for high-impact resolutions.
- Ran the UI-related unit tests with `PYTHONPATH=. pytest -q tests/test_critical_choice_highlight.py tests/test_command_deck_ui.py tests/test_mission_board_ui.py` and observed all tests succeed.
- Test run summary: `10 passed` (no failures or errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1009579e9c832b91ed7c83d14aa452)