### PR TITLE
Add lightweight pressure-based mission complications

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -145,3 +145,10 @@ Automation status:
 [x] AGENT-05 Personality-trait mission log modulation (compact set + neutral fallback + tests)
 
 - UI-01 [done]: Added a compact narrative feed contract (`game/narrative/event_feed.py`) and widget presentation layer (`game/ui/widgets/narrative_feed_panel.py`) with category badges (`agent`, `mission`, `faction`, `base`), anti-chronological ordering, and bounded depth (8-12) to keep command-center readability centered on agent consequences.
+
+- [x] MISSION-03 Complications modulaires légères (pression + tags)
+  - Nouveau module: `game/missions/complications.py` avec table courte par niveau de pression (`low`/`medium`/`high`).
+  - API pure: `select_complications(district_pressure, mission_tags, seed=None)` pour sortie déterministe et testable.
+  - Intégration: enrichissement du briefing via `game/mission_generation.py` sans hausse systémique (complications narratif-first, conséquences neutres).
+  - Scope control: plafond strict à 1-2 complications par mission.
+  - Contrainte design: système léger, lisible, modulaire, non-systémique lourd.

--- a/game/mission_generation.py
+++ b/game/mission_generation.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .gamestate import GameState
 from .mission_templates import MissionTemplate, create_mission_templates
+from .missions.complications import select_complications
 from .missions.evacuation import create_evacuation_template
 
 
@@ -45,6 +46,15 @@ def generate_mission_board(game_state: "GameState", board_size: int = 3) -> list
         mission.starting_enemy_count = max(1, mission.starting_enemy_count + max(0, risk_delta))
         mission.id = f"{mission.id}_d{game_state.calendar.current_day}_s{slot}"
         mission.title = f"{mission.title} [Day {game_state.calendar.current_day}]"
+        mission_tag_names = [tag.name for tag in mission.tags]
+        mission.possible_complications.extend(
+            select_complications(
+                district_pressure=pressure_score,
+                mission_tags=mission_tag_names,
+                seed=_mission_seed(game_state) + slot,
+            )
+        )
+        mission.possible_complications = mission.possible_complications[:2]
         generated.append(mission)
 
     rng.shuffle(generated)

--- a/game/missions/complications.py
+++ b/game/missions/complications.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import random
+
+from game.consequences import Consequence
+from game.mission_templates import MissionComplication
+
+
+_COMPLICATION_TABLE: dict[str, tuple[dict[str, str], ...]] = {
+    "low": (
+        {"key": "signal_noise", "name": "Signal Noise", "trigger": "Encrypted comms crackle and delay callouts."},
+        {"key": "street_detour", "name": "Street Detour", "trigger": "A patrol sweep closes the shortest alley route."},
+    ),
+    "medium": (
+        {"key": "watcher_drone", "name": "Watcher Drone", "trigger": "A low-orbit drone tracks heat signatures near the objective."},
+        {"key": "crowd_choke", "name": "Crowd Choke", "trigger": "Night-market foot traffic compresses movement lanes."},
+    ),
+    "high": (
+        {"key": "counterintel_ping", "name": "Counterintel Ping", "trigger": "Corporate counterintel flags the operation in real time."},
+        {"key": "rapid_response", "name": "Rapid Response", "trigger": "A rapid-response squad is rerouted toward the extraction line."},
+    ),
+}
+
+_TAG_HINTS: dict[str, str] = {
+    "stealth": "signal_noise",
+    "extraction": "street_detour",
+    "rescue": "crowd_choke",
+    "sabotage": "watcher_drone",
+    "data": "counterintel_ping",
+    "infiltration": "counterintel_ping",
+    "assault": "rapid_response",
+}
+
+
+def _pressure_bucket(district_pressure: int) -> str:
+    if district_pressure >= 70:
+        return "high"
+    if district_pressure >= 35:
+        return "medium"
+    return "low"
+
+
+def _to_complication(entry: dict[str, str], pressure_level: str) -> MissionComplication:
+    return MissionComplication(
+        key=f"mod_{entry['key']}",
+        name=entry["name"],
+        trigger_text=entry["trigger"],
+        risk_threshold=1 if pressure_level == "low" else 2 if pressure_level == "medium" else 3,
+        relation_impact="low",
+        tags=[],
+        consequence=Consequence(),
+    )
+
+
+def select_complications(
+    district_pressure: int,
+    mission_tags: list[str] | tuple[str, ...] | None,
+    seed: int | None = None,
+) -> list[MissionComplication]:
+    """Pure selector: pressure + mission tags -> 1..2 compact complications.
+
+    The output is intentionally lightweight (narrative flavor only) and never exceeds
+    two entries to preserve scope control and avoid hidden difficulty spikes.
+    """
+    tags = [str(tag).strip().lower() for tag in (mission_tags or []) if str(tag).strip()]
+    level = _pressure_bucket(max(0, int(district_pressure)))
+    pool = list(_COMPLICATION_TABLE[level])
+    rng_seed = seed if seed is not None else (district_pressure * 131) + sum(ord(ch) for ch in "|".join(sorted(tags)))
+    rng = random.Random(rng_seed)
+
+    preferred_keys = {hint for tag, hint in _TAG_HINTS.items() if tag in tags}
+    preferred = [entry for entry in pool if entry["key"] in preferred_keys]
+    fallback = [entry for entry in pool if entry["key"] not in preferred_keys]
+
+    selected: list[dict[str, str]] = []
+    if preferred:
+        selected.append(rng.choice(preferred))
+
+    count = 2 if level == "high" else 1
+    remaining_pool = [entry for entry in (preferred + fallback) if entry not in selected]
+    rng.shuffle(remaining_pool)
+    selected.extend(remaining_pool[: max(0, count - len(selected))])
+
+    return [_to_complication(entry, level) for entry in selected[:2]]

--- a/tests/mission_generation/test_complications.py
+++ b/tests/mission_generation/test_complications.py
@@ -1,0 +1,30 @@
+import unittest
+
+from game.missions.complications import select_complications
+
+
+class MissionComplicationsTest(unittest.TestCase):
+    def test_selection_varies_by_pressure_bucket(self):
+        low = select_complications(district_pressure=10, mission_tags=["stealth"], seed=1)
+        high = select_complications(district_pressure=80, mission_tags=["stealth"], seed=1)
+
+        self.assertEqual(1, len(low))
+        self.assertEqual(2, len(high))
+        self.assertTrue(all(item.risk_threshold == 1 for item in low))
+        self.assertTrue(all(item.risk_threshold == 3 for item in high))
+
+    def test_selection_is_deterministic_with_seed(self):
+        first = select_complications(district_pressure=55, mission_tags=["data", "infiltration"], seed=42)
+        second = select_complications(district_pressure=55, mission_tags=["data", "infiltration"], seed=42)
+
+        self.assertEqual([c.key for c in first], [c.key for c in second])
+
+    def test_selection_works_without_tags(self):
+        selected = select_complications(district_pressure=45, mission_tags=None, seed=8)
+
+        self.assertTrue(selected)
+        self.assertLessEqual(len(selected), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a small, modular complications system to add narrative flavor to mission briefings without increasing systemic difficulty. 
- Provide a pure, deterministic selector driven by district pressure and mission tags so briefings remain testable and stable. 
- Keep scope tight by limiting complications to 1–2 per mission and making consequences neutral by default. 

### Description
- Added `game/missions/complications.py` which defines a short complication table keyed by pressure bucket (`low`/`medium`/`high`), a lightweight tag hint map, and the pure API `select_complications(district_pressure, mission_tags, seed=None)` that returns 1–2 `MissionComplication` items. 
- The selector uses an explicit seed (or derived seed) for determinism, prefers tag-matched complications, and converts table entries into `MissionComplication` instances with neutral `Consequence()` by default. 
- Integrated selection into `game/mission_generation.py` to extend `mission.possible_complications` for each generated mission while capping the list to two entries to avoid hidden difficulty spikes. 
- Added unit tests `tests/mission_generation/test_complications.py` and updated `docs/backlog.md` with the design constraints (lightweight, readable, modular, non-systemic). 

### Testing
- Ran `PYTHONPATH=. pytest -q tests/mission_generation/test_complications.py tests/test_mission_generation.py` and received all tests passing (`6 passed`). 
- Automated tests cover pressure-based selection behavior, deterministic output with an explicit seed, and compatibility when missions have no tags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100be2f77c832b8dbd28ad7b3fd49a)