### PR TITLE
UI-04: résumé d’impact mission (tags + hint émotionnel)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -152,3 +152,6 @@ Automation status:
   - Intégration: enrichissement du briefing via `game/mission_generation.py` sans hausse systémique (complications narratif-first, conséquences neutres).
   - Scope control: plafond strict à 1-2 complications par mission.
   - Contrainte design: système léger, lisible, modulaire, non-systémique lourd.
+
+
+[x] UI-04 Mission impact summary: widget UI dédié (`game/ui/widgets/mission_impact_summary.py`), affichage hiérarchisé tags -> impact humain, contrat `emotional_impact_hint` (level/text) + fallback neutre, tests ajoutés.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,3 +37,11 @@
 - Ordre: antéchronologique (plus récent en premier) après agrégation.
 - Profondeur: limitée à 8–12 lignes (par défaut 10) pour garder un panneau court et lisible.
 - But émotionnel: prioriser les signaux agent et conséquences humaines avant le bruit systémique.
+
+
+### Contrat `emotional_impact_hint` (UI-04)
+- Champ mission: `MissionTemplate.emotional_impact_hint` (dict render-neutral).
+- Producteur: génération de mission (`game/mission_generation.py`) à partir de l'objectif, du risque, de la durée et des complications.
+- Schéma minimal: `{"level": "low|medium|high|critical", "text": str non vide}`.
+- Consommation UI: `game/ui/widgets/mission_impact_summary.py` affiche d'abord les tags opérationnels puis l'impact humain attendu.
+- Fallback obligatoire: si payload absent/invalide, afficher `Impact humain attendu: informations limitées, vigilance recommandée.`

--- a/game/mission_generation.py
+++ b/game/mission_generation.py
@@ -21,6 +21,40 @@ def _mission_seed(game_state: "GameState") -> int:
     )
 
 
+
+
+def _build_emotional_impact_hint(mission: MissionTemplate) -> dict:
+    """Estimate emotional impact based on objective pressure, risk, duration, and complications."""
+    objective_weight = {
+        "safe_extraction": 2,
+        "extract": 2,
+        "data_with_detour": 2,
+        "data_theft": 1,
+        "sabotage_window": 1,
+        "sabotage": 1,
+        "eliminate": 0,
+    }.get(mission.objective_type, 1)
+    score = (
+        mission.risk_level
+        + max(0, mission.duration_days - 1)
+        + len(mission.possible_complications)
+        + objective_weight
+    )
+    if score >= 8:
+        level = "critical"
+        text = "Risque de séquelles émotionnelles durables pour l'escouade."
+    elif score >= 6:
+        level = "high"
+        text = "Mission susceptible de laisser une forte charge émotionnelle."
+    elif score >= 4:
+        level = "medium"
+        text = "Tension humaine notable, prévoir du soutien post-mission."
+    else:
+        level = "low"
+        text = "Impact humain contenu si l'exécution reste disciplinée."
+    return {"level": level, "text": text}
+
+
 def generate_mission_board(game_state: "GameState", board_size: int = 3) -> list[MissionTemplate]:
     """Generate a small daily mission board based on district pressure."""
     templates = create_mission_templates(game_state.district.name)
@@ -55,6 +89,7 @@ def generate_mission_board(game_state: "GameState", board_size: int = 3) -> list
             )
         )
         mission.possible_complications = mission.possible_complications[:2]
+        mission.emotional_impact_hint = _build_emotional_impact_hint(mission)
         generated.append(mission)
 
     rng.shuffle(generated)

--- a/game/mission_templates.py
+++ b/game/mission_templates.py
@@ -63,6 +63,7 @@ class MissionTemplate:
     duration_days: int = 1
     tags: list[SavageTag] = field(default_factory=list)
     relation_impact: str = "low"
+    emotional_impact_hint: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -88,6 +89,7 @@ class MissionTemplate:
             "duration_days": max(1, int(self.duration_days)),
             "tags": [tag.to_dict() for tag in self.tags],
             "relation_impact": self.relation_impact,
+            "emotional_impact_hint": dict(self.emotional_impact_hint),
         }
 
     @classmethod
@@ -122,6 +124,7 @@ class MissionTemplate:
             duration_days=max(1, int(data.get("duration_days", 1))),
             tags=[SavageTag.from_dict(tag) for tag in data.get("tags", [])],
             relation_impact=str(data.get("relation_impact", "low")),
+            emotional_impact_hint=dict(data.get("emotional_impact_hint", {})),
         )
 
 

--- a/game/ui/mission_board.py
+++ b/game/ui/mission_board.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from ..consequences import Consequence
 from ..mission_templates import MissionComplication, MissionTemplate
 from .widgets.critical_choice_highlight import format_critical_choice_suffix
+from .widgets.mission_impact_summary import build_mission_impact_summary_lines
 
 OBJECTIVE_LABELS = {
     "extract": "EXTRACT",
@@ -115,7 +116,7 @@ def build_selected_mission_lines(mission: MissionTemplate | None) -> list[str]:
         f"District: {mission.district} | Pressure: {_pressure_summary(mission.district_pressure)}",
         f"Fund Reward: {mission.fund_reward} corporate funds",
         f"Duration: {mission.duration_days} day{'s' if mission.duration_days != 1 else ''}",
-        f"Tags: {_tag_names(mission.tags)}",
+        *build_mission_impact_summary_lines(mission),
         f"Complications: {_complication_names(mission.possible_complications)}",
         _outcome_line("Success", mission.success_consequences),
         _outcome_line("Failure", mission.failure_consequences),

--- a/game/ui/widgets/mission_impact_summary.py
+++ b/game/ui/widgets/mission_impact_summary.py
@@ -1,0 +1,35 @@
+"""Helpers to render mission impact summary with operational tags and human impact hint."""
+
+from __future__ import annotations
+
+NEUTRAL_IMPACT_TEXT = "Impact humain attendu: informations limitées, vigilance recommandée."
+IMPACT_LEVEL_LABELS = {
+    "low": "faible",
+    "medium": "modéré",
+    "high": "élevé",
+    "critical": "critique",
+}
+
+
+def _tag_names(tagged_items: list[object], empty: str = "none") -> str:
+    names = [getattr(tag, "name", str(tag)) for tag in tagged_items]
+    return ", ".join(names) if names else empty
+
+
+def impact_hint_text(emotional_impact_hint: dict | None) -> str:
+    """Return a readable impact hint with fallback for missing/invalid payload."""
+    if not emotional_impact_hint:
+        return NEUTRAL_IMPACT_TEXT
+
+    level = str(emotional_impact_hint.get("level", "")).lower()
+    text = str(emotional_impact_hint.get("text", "")).strip()
+    if level not in IMPACT_LEVEL_LABELS or not text:
+        return NEUTRAL_IMPACT_TEXT
+    return f"Impact humain attendu ({IMPACT_LEVEL_LABELS[level]}): {text}"
+
+
+def build_mission_impact_summary_lines(mission: object) -> list[str]:
+    """Build ordered mission impact lines: operational tags first, then human hint."""
+    tags = _tag_names(getattr(mission, "tags", []))
+    hint = impact_hint_text(getattr(mission, "emotional_impact_hint", None))
+    return [f"Tags opérationnels: {tags}", hint]

--- a/tests/test_mission_board_ui.py
+++ b/tests/test_mission_board_ui.py
@@ -40,11 +40,12 @@ class MissionBoardUITest(unittest.TestCase):
         self.assertIn("Pressure: Unrest +3, Media Heat +2", lines[1])
         self.assertEqual(lines[2], "Fund Reward: 40 corporate funds")
         self.assertEqual(lines[3], "Duration: 1 day")
-        self.assertEqual(lines[4], "Tags: neon_blackout")
-        self.assertIn("Media Leak", lines[5])
-        self.assertIn("Civilian Panic", lines[5])
-        self.assertIn("Success: Warrens Free Clinic", lines[6])
-        self.assertIn("Failure: Chrome Jackals", lines[7])
+        self.assertEqual(lines[4], "Tags opérationnels: neon_blackout")
+        self.assertIn("Impact humain attendu", lines[5])
+        self.assertIn("Media Leak", lines[6])
+        self.assertIn("Civilian Panic", lines[6])
+        self.assertIn("Success: Warrens Free Clinic", lines[7])
+        self.assertIn("Failure: Chrome Jackals", lines[8])
 
     def test_empty_mission_board_has_operator_guidance(self):
         self.assertEqual(build_mission_board_lines([], 0), ["No missions available."])

--- a/tests/ui/test_mission_impact_summary.py
+++ b/tests/ui/test_mission_impact_summary.py
@@ -1,0 +1,41 @@
+"""Tests for mission impact summary widget and emotional hint mapping."""
+
+import unittest
+
+from game.gamestate import GameState
+from game.mission_generation import generate_mission_board
+from game.mission_templates import create_mission_templates
+from game.ui.widgets.mission_impact_summary import (
+    NEUTRAL_IMPACT_TEXT,
+    build_mission_impact_summary_lines,
+    impact_hint_text,
+)
+
+
+class MissionImpactSummaryTest(unittest.TestCase):
+    def test_summary_lines_include_operational_tags(self):
+        mission = create_mission_templates("Chrome Warrens")[0]
+        mission.emotional_impact_hint = {"level": "medium", "text": "test hint"}
+
+        lines = build_mission_impact_summary_lines(mission)
+
+        self.assertEqual(lines[0], "Tags opérationnels: neon_blackout")
+        self.assertIn("Impact humain attendu (modéré):", lines[1])
+
+    def test_impact_levels_are_coherent_with_generation_pressure(self):
+        game_state = GameState(mission_templates=[])
+        missions = generate_mission_board(game_state, board_size=3)
+
+        allowed = {"low", "medium", "high", "critical"}
+        for mission in missions:
+            self.assertIn(mission.emotional_impact_hint.get("level"), allowed)
+            self.assertTrue(mission.emotional_impact_hint.get("text"))
+
+    def test_neutral_fallback_when_hint_missing_or_invalid(self):
+        self.assertEqual(impact_hint_text(None), NEUTRAL_IMPACT_TEXT)
+        self.assertEqual(impact_hint_text({"level": "unknown", "text": "x"}), NEUTRAL_IMPACT_TEXT)
+        self.assertEqual(impact_hint_text({"level": "low", "text": ""}), NEUTRAL_IMPACT_TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Centraliser le rendu côté UI d’un résumé de mission qui combine tags opérationnels et un indice d’impact humain attendu pour renforcer l’attachement émotionnel lors de l’inspection d’une mission.
- Fournir un champ render‑neutral dans les données mission (`emotional_impact_hint`) calculé depuis objectif, risque, durée et complications pour que l’UI puisse afficher un message lisible et un fallback neutre.
- Préserver la modularité et le scope en ajoutant un petit composant widget sans réécrire l’architecture existante.

### Description
- Ajout du widget `game/ui/widgets/mission_impact_summary.py` qui expose `build_mission_impact_summary_lines` et `impact_hint_text` et fournit un fallback neutre `NEUTRAL_IMPACT_TEXT` pour payload absent ou invalide.
- Extension de `MissionTemplate` avec le champ `emotional_impact_hint` (sérialisation via `to_dict`/`from_dict`).
- Implémentation de la logique de calcul dans `game/mission_generation.py` via la fonction `_build_emotional_impact_hint` qui combine `objective_type`, `risk_level`, `duration_days` et `possible_complications` et écrit le champ sur chaque mission générée.
- Intégration dans `game/ui/mission_board.py` pour afficher d’abord les `Tags opérationnels` puis la ligne d’`Impact humain attendu` dans le panneau détail mission sélectionnée.
- Ajout de tests `tests/ui/test_mission_impact_summary.py` couvrant la présence des tags, la cohérence des niveaux (`low|medium|high|critical`) et le fallback neutre, ainsi qu’ajustement du test existant `tests/test_mission_board_ui.py` pour refléter le nouvel ordre visuel.
- Mise à jour de la documentation `docs/roadmap.md` et `docs/backlog.md` avec le contrat minimal du champ `emotional_impact_hint`.

### Testing
- Exécuté initialement `pytest -q tests/ui/test_mission_impact_summary.py tests/test_mission_board_ui.py` qui a échoué en collecte sans `PYTHONPATH` (ModuleNotFoundError), puis relancé avec `PYTHONPATH=. pytest -q tests/ui/test_mission_impact_summary.py tests/test_mission_board_ui.py` et tous les tests ont réussi.
- Résultat final des tests automatisés listés: `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100f67b7c0832b9cbb9ca443cdc538)