### PR TITLE
UI: centralize visual theme tokens and unify room-expanded hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ python main.py
   animation, so the opened room matches the clicked background room
 - Open rooms show the room title at the top, room-specific game info beneath it,
   and icon actions at the bottom center
+- UI visual rules are tokenized in `game/ui/theme/` (typography hierarchy: title/section/meta; spacing; stroke; opacity; z-order) and reused by expanded-room panels, roster cards, and action buttons to avoid magic numbers
 - Action buttons include short labels for recruit, level-up, navigation, and
   launch actions
 - `Esc` closes the open room and returns to the base map

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,4 +1,5 @@
 TODO:
+- [x] UI-05 Tokeniser les règles visuelles (typo/espacements/opacité/z-order), appliquer la hiérarchie titre-section-méta dans les room-expanded, et documenter les conventions UI.
 - [x] Add full multi-view save/load system with slot-path support and user-facing status log messages
 [x] Create mission UI
 [x] Add city/corporate tactical command deck to RPG UI

--- a/game/ui/command_center.py
+++ b/game/ui/command_center.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .theme import spacing
 
 @dataclass(frozen=True)
 class CommandPanel:
@@ -27,8 +28,8 @@ def build_command_center_layout(
     width: int, height: int, mode: str
 ) -> list[CommandPanel]:
     """Build a consistent corporate-tower layout for Corp and City screens."""
-    margin = 20
-    gutter = 16
+    margin = spacing.md + 2
+    gutter = spacing.sm + 2
     status_height = 58
     footer_height = 54
     top = height - status_height - margin

--- a/game/ui/command_deck.py
+++ b/game/ui/command_deck.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .theme import spacing
 from ..character import Character, is_deployable
 from ..dossier import build_agent_dossier_lines
 from ..mission_templates import MissionTemplate
@@ -29,8 +30,8 @@ class DeckPanel:
 
 def build_command_deck_layout(width: int, height: int) -> list[DeckPanel]:
     """Return a stable three-column RPG layout for a tactical command deck."""
-    margin = 18
-    gutter = 14
+    margin = spacing.md
+    gutter = spacing.sm
     status_height = 54
     footer_height = 62
     top = height - status_height - margin

--- a/game/ui/panels.py
+++ b/game/ui/panels.py
@@ -13,6 +13,7 @@ from .room_interaction import (
     close_button_rect,
     layout_roster_card_rects,
 )
+from .theme import opacity, spacing, stroke, typography
 
 
 _TEXTURE_CACHE = {}
@@ -319,7 +320,7 @@ def draw_expanded_room_ui(
 
     room, rect = active
     border = _room_accent_color(room)
-    arcade.draw_lrbt_rectangle_filled(0, width, 0, height, (0, 0, 0, 164))
+    arcade.draw_lrbt_rectangle_filled(0, width, 0, height, (0, 0, 0, opacity.overlay_dim))
     texture = _load_texture_once(room.image_path) if room.image_path else None
     if texture is not None:
         room_rect = arcade.LBWH(rect.left, rect.bottom, rect.width, rect.height)
@@ -375,28 +376,31 @@ def draw_expanded_room_ui(
 
 def draw_room_title_and_info(title: str, lines: list[str], rect, buttons, border) -> None:
     """Draw room title and compact room state above the action controls."""
-    left = rect.left + max(24, rect.width // 28)
-    right = rect.right - max(24, rect.width // 28)
+    left = rect.left + max(spacing.lg, rect.width // 28)
+    right = rect.right - max(spacing.lg, rect.width // 28)
     top = rect.top - max(32, rect.height // 12)
     action_top = max((button.rect.top for button in buttons), default=rect.bottom + 92)
     info_bottom = action_top + 42
     panel_bottom = max(info_bottom, top - 190)
 
     arcade.draw_lrbt_rectangle_filled(
-        left - 14,
-        right + 14,
-        panel_bottom - 16,
-        top + 34,
+        left - spacing.sm,
+        right + spacing.sm,
+        panel_bottom - (spacing.sm + 2),
+        top + spacing.xl,
         palette.PANEL_FILL_DARK,
     )
-    arcade.draw_line(left, top + 20, right, top + 20, border, 2)
-    arcade.draw_text(title.upper(), left, top, palette.HEADER, 22)
+    arcade.draw_line(left, top + spacing.md + 2, right, top + spacing.md + 2, border, stroke.regular)
+    arcade.draw_text("ROOM", left, top + spacing.sm, palette.MUTED_TEXT, typography.meta)
+    arcade.draw_text(title.upper(), left, top, palette.HEADER, typography.title)
 
-    y = top - 34
-    max_lines = max(1, int((y - info_bottom) // 22) + 1)
-    for line in lines[:max_lines]:
-        arcade.draw_text(_fit_room_line(line), left, y, palette.TEXT, 13)
-        y -= 22
+    y = top - (spacing.xl)
+    max_lines = max(1, int((y - info_bottom) // (spacing.md + 4)) + 1)
+    for index, line in enumerate(lines[:max_lines]):
+        color = palette.TEXT if index == 0 else palette.MUTED_TEXT
+        font_size = typography.section if index == 0 else typography.meta
+        arcade.draw_text(_fit_room_line(line), left, y, color, font_size)
+        y -= spacing.md + 4
 
 
 def _fit_room_line(line: str, limit: int = 76) -> str:
@@ -450,8 +454,8 @@ def draw_agent_card(card: dict, left: int, bottom: int, width: int, height: int,
     portrait_bottom = bottom + (height - portrait_size) // 2
     _draw_agent_portrait_asset(card, portrait_left, portrait_bottom, portrait_size, border)
     text_left = portrait_left + portrait_size + 14
-    arcade.draw_text(card.get("name", "Agent").upper(), text_left, bottom + height - 28, palette.TEXT, 12)
-    arcade.draw_text(card.get("role", "unknown").upper(), text_left, bottom + height - 48, _role_color(card), 9)
+    arcade.draw_text(card.get("name", "Agent").upper(), text_left, bottom + height - 28, palette.TEXT, typography.section - 1)
+    arcade.draw_text(card.get("role", "unknown").upper(), text_left, bottom + height - 48, _role_color(card), typography.meta)
     meter_width = max(38, width - (text_left - left) - 14)
     draw_small_meter(text_left, bottom + 22, meter_width, card.get("hp_ratio", 0), palette.TACTICAL_GREEN)
     draw_small_meter(text_left, bottom + 10, meter_width, card.get("stress_ratio", 0), palette.WARNING)
@@ -523,11 +527,11 @@ def _draw_active_agent_brackets(left: int, bottom: int, width: int, height: int)
     top = bottom + height
     color = palette.ACTIVE_AGENT_BORDER
     bracket = 34
-    arcade.draw_line(left - 2, top + 2, left + bracket, top + 2, color, 3)
+    arcade.draw_line(left - 2, top + 2, left + bracket, top + 2, color, stroke.strong)
     arcade.draw_line(left - 2, top + 2, left - 2, top - bracket, color, 3)
     arcade.draw_line(right + 2, top + 2, right - bracket, top + 2, color, 3)
     arcade.draw_line(right + 2, top + 2, right + 2, top - bracket, color, 3)
-    arcade.draw_text("ACTIVE", right - 58, top - 18, color, 9)
+    arcade.draw_text("ACTIVE", right - 58, top - 18, color, typography.meta)
 
 
 def _draw_deployed_marker(center_x: int, center_y: int) -> None:
@@ -578,7 +582,7 @@ def draw_action_button(button: ActionButton, border) -> None:
             rect.center_x,
             rect.bottom - 20,
             palette.TEXT,
-            9,
+            typography.meta,
             anchor_x="center",
         )
 

--- a/game/ui/room_interaction.py
+++ b/game/ui/room_interaction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .facility import FacilityRoom, build_facility_rooms, facility_room_by_key
+from .theme import spacing
 
 
 @dataclass(frozen=True)
@@ -167,9 +168,9 @@ def room_rect(room: FacilityRoom) -> UIRect:
 
 def expanded_room_rect(width: int, height: int) -> UIRect:
     """Return the full-screen room target bounds."""
-    margin_x = max(28, int(width * 0.035))
-    margin_bottom = max(46, int(height * 0.06))
-    margin_top = max(34, int(height * 0.045))
+    margin_x = max(spacing.xl - 6, int(width * 0.035))
+    margin_bottom = max(spacing.xl + 12, int(height * 0.06))
+    margin_top = max(spacing.xl, int(height * 0.045))
     return UIRect(
         margin_x,
         margin_bottom,
@@ -181,7 +182,7 @@ def expanded_room_rect(width: int, height: int) -> UIRect:
 def close_button_rect(width: int, height: int) -> UIRect:
     """Return the icon-only close button area."""
     size = max(42, min(58, int(min(width, height) * 0.065)))
-    return UIRect(width - size - 28, height - size - 28, size, size)
+    return UIRect(width - size - (spacing.xl - 6), height - size - (spacing.xl - 6), size, size)
 
 
 def interpolate_rect(start: UIRect, end: UIRect, progress: float) -> UIRect:
@@ -218,10 +219,10 @@ def layout_action_buttons(
     if not actions:
         return []
     button_size = max(58, min(92, int(min(width, height) * 0.11)))
-    gap = max(18, button_size // 3)
+    gap = max(spacing.md, button_size // 3)
     total_width = len(actions) * button_size + (len(actions) - 1) * gap
     start_x = (width - total_width) // 2
-    bottom = max(72, int(height * 0.11))
+    bottom = max(spacing.xl * 2 + 4, int(height * 0.11))
     buttons = []
     for index, action in enumerate(actions):
         left = start_x + index * (button_size + gap)
@@ -245,15 +246,15 @@ def layout_roster_card_rects(
     """Place roster cards above the action buttons inside an expanded room."""
     if card_count <= 0:
         return []
-    left = rect.left + max(30, rect.width // 24)
-    right = rect.right - max(30, rect.width // 24)
+    left = rect.left + max(spacing.lg + 6, rect.width // 24)
+    right = rect.right - max(spacing.lg + 6, rect.width // 24)
     action_top = max((button.rect.top for button in buttons), default=rect.bottom + 100)
-    bottom = action_top + 48
+    bottom = action_top + spacing.xl + 14
     top_limit = rect.top - max(250, rect.height // 3)
     card_height = max(86, min(112, int((top_limit - bottom) * 0.9)))
     if card_height < 72:
         card_height = 72
-    gap = 14
+    gap = spacing.sm
     columns = min(4, max(1, card_count))
     card_width = max(190, min(260, int((right - left - gap * (columns - 1)) / columns)))
     card_rects = []

--- a/game/ui/theme/__init__.py
+++ b/game/ui/theme/__init__.py
@@ -1,0 +1,5 @@
+"""Theme tokens namespace for reusable UI values."""
+
+from .tokens import opacity, radius, spacing, stroke, typography, z_order
+
+__all__ = ["typography", "stroke", "spacing", "radius", "opacity", "z_order"]

--- a/game/ui/theme/tokens.py
+++ b/game/ui/theme/tokens.py
@@ -1,0 +1,55 @@
+"""Reusable UI design tokens for CyberCity command surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TypographyTokens:
+    title: int = 22
+    section: int = 13
+    meta: int = 9
+
+
+@dataclass(frozen=True)
+class StrokeTokens:
+    hairline: int = 1
+    regular: int = 2
+    strong: int = 3
+
+
+@dataclass(frozen=True)
+class SpacingTokens:
+    xs: int = 8
+    sm: int = 14
+    md: int = 18
+    lg: int = 24
+    xl: int = 34
+
+
+@dataclass(frozen=True)
+class RadiusTokens:
+    sm: int = 8
+    md: int = 14
+
+
+@dataclass(frozen=True)
+class OpacityTokens:
+    overlay_dim: int = 164
+
+
+@dataclass(frozen=True)
+class ZOrderTokens:
+    backdrop: int = 0
+    panel: int = 10
+    modal: int = 20
+    controls: int = 30
+
+
+typography = TypographyTokens()
+stroke = StrokeTokens()
+spacing = SpacingTokens()
+radius = RadiusTokens()
+opacity = OpacityTokens()
+z_order = ZOrderTokens()

--- a/tests/test_ui_theme_tokens.py
+++ b/tests/test_ui_theme_tokens.py
@@ -1,0 +1,22 @@
+from game.ui.command_center import build_command_center_layout
+from game.ui.command_deck import build_command_deck_layout
+from game.ui.room_interaction import expanded_room_rect, layout_action_buttons, RoomAction
+from game.ui.theme import spacing, typography
+
+
+def test_typography_hierarchy_ordered() -> None:
+    assert typography.title > typography.section > typography.meta
+
+
+def test_layouts_keep_tokenized_spacing() -> None:
+    center_panels = build_command_center_layout(1280, 720, "corp")
+    deck_panels = build_command_deck_layout(1280, 720)
+    assert center_panels[0].left == spacing.md + 2
+    assert deck_panels[0].left == spacing.md
+
+
+def test_expanded_room_and_actions_use_spacing_tokens() -> None:
+    expanded = expanded_room_rect(1280, 720)
+    assert expanded.left >= spacing.lg
+    buttons = layout_action_buttons(1280, 720, [RoomAction("a", "city"), RoomAction("b", "city")])
+    assert buttons[1].rect.left - buttons[0].rect.right >= spacing.md


### PR DESCRIPTION
### Motivation
- Reduce scattered "magic number" UI constants by centralizing reusable visual tokens for typography, spacing, stroke, radius, opacity and z-order.
- Apply a clear three-level text hierarchy (title / section / meta) to expanded room panels to improve readability and consistency.
- Make spacing of action buttons, roster cards and close controls deterministic and maintainable via tokens.

### Description
- Added a new theme module `game/ui/theme/` with `tokens.py` and package entry `__init__.py` providing `typography`, `spacing`, `stroke`, `opacity`, `radius` and `z_order` token instances.
- Replaced hard-coded layout/spacing values in `game/ui/command_center.py`, `game/ui/command_deck.py`, and `game/ui/room_interaction.py` with the new spacing tokens.
- Updated expanded-room rendering in `game/ui/panels.py` to use typography and stroke tokens and applied the 3-level hierarchy (meta label `ROOM`, title, section/meta lines) and tokenized paddings/opacities.
- Added `tests/test_ui_theme_tokens.py` to assert the typography ordering and that key layouts use the tokenized spacing; updated `README.md` and `docs/backlog.md` to document the change.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_ui_theme_tokens.py` which passed (`3 passed`).
- Ran `PYTHONPATH=. pytest -q tests/test_command_center_ui.py tests/test_command_deck_ui.py tests/test_room_interaction_ui.py` which passed (`11 passed`).
- A plain `pytest -q ...` run without `PYTHONPATH=.` initially failed during collection with `ModuleNotFoundError: No module named 'game'`; setting `PYTHONPATH=.` resolves this environment issue and the tests above succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1010768170832baf552eb0603ef9e8)