### PR TITLE
Ajout navigation clavier modulaire + overlay de raccourcis contextuels

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -161,3 +161,5 @@ Automation status:
 
 
 [x] UI-04 Mission impact summary: payload enrichi côté génération (`normalized_tags` + `short_text`), affichage liste + détail avec hiérarchie sobre dans `game/ui/mission_board.py`, conventions d'écriture centralisées (`game/narrative/mission_briefing_conventions.py`) et tests de rendu couvrant tags absents/multiples + impact absent/présent.
+
+- [x] UI navigation: focus manager + input map + contextual hints overlay (keyboard/mouse parity for rooms, missions, agents).

--- a/game/ui/navigation/__init__.py
+++ b/game/ui/navigation/__init__.py
@@ -1,7 +1,8 @@
 """Keyboard focus and contextual hint helpers for command views."""
 
-from .focus_model import FocusItem, ViewFocusModel, build_view_focus_model
-from .help_overlay import HelpOverlayState, build_help_lines, build_hint_banner
+from .focus_manager import FocusItem, ViewFocusModel, build_view_focus_model
+from .hints_overlay import HelpOverlayState, build_help_lines, build_hint_banner
+from .input_map import active_shortcuts_for_screen, keyboard_action_for_focus
 
 __all__ = [
     "FocusItem",
@@ -10,4 +11,6 @@ __all__ = [
     "HelpOverlayState",
     "build_help_lines",
     "build_hint_banner",
+    "active_shortcuts_for_screen",
+    "keyboard_action_for_focus",
 ]

--- a/game/ui/navigation/focus_manager.py
+++ b/game/ui/navigation/focus_manager.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..facility import build_facility_rooms
+
+
+@dataclass(frozen=True)
+class FocusItem:
+    key: str
+    kind: str
+
+
+VIEW_ROOM_ORDER: dict[str, list[str]] = {
+    "command_center": ["executive", "hangar", "research", "security", "media", "black_ops", "logistics", "server"],
+    "facility": ["executive", "hangar", "research", "security", "media", "black_ops", "logistics", "server"],
+    "command_deck": ["briefing", "armory", "ops", "intel", "dossier", "medbay", "barracks", "insertion"],
+    "mission_board": ["ops", "intel", "briefing", "insertion", "armory", "medbay", "barracks", "dossier"],
+}
+
+
+@dataclass
+class ViewFocusModel:
+    view_key: str
+    room_keys: list[str]
+    action_keys: list[str]
+    mission_count: int = 0
+    agent_count: int = 0
+    current_index: int = 0
+
+    def _items(self) -> list[FocusItem]:
+        items = [FocusItem(room, "room") for room in self.room_keys]
+        items.extend(FocusItem(action, "action") for action in self.action_keys)
+        items.extend(FocusItem(f"mission_{index}", "mission") for index in range(self.mission_count))
+        items.extend(FocusItem(f"agent_{index}", "agent") for index in range(self.agent_count))
+        return items
+
+    def active(self) -> FocusItem | None:
+        items = self._items()
+        if not items:
+            return None
+        self.current_index %= len(items)
+        return items[self.current_index]
+
+    def move(self, step: int) -> FocusItem | None:
+        items = self._items()
+        if not items:
+            return None
+        self.current_index = (self.current_index + step) % len(items)
+        return self.active()
+
+    def set_actions(self, action_keys: list[str]) -> None:
+        self.action_keys = action_keys
+        self._normalize_index()
+
+    def set_list_counts(self, mission_count: int, agent_count: int) -> None:
+        self.mission_count = max(0, mission_count)
+        self.agent_count = max(0, agent_count)
+        self._normalize_index()
+
+    def _normalize_index(self) -> None:
+        items = self._items()
+        self.current_index = self.current_index % len(items) if items else 0
+
+
+def _normalize_view_key(view_key: str) -> str:
+    aliases = {"corp": "command_center", "city": "command_center", "squad": "command_deck", "battle": "mission_board"}
+    return aliases.get(view_key, view_key)
+
+
+def build_view_focus_model(view_key: str, width: int, height: int) -> ViewFocusModel:
+    normalized_key = _normalize_view_key(view_key)
+    rooms = build_facility_rooms(width, height, "squad" if normalized_key in {"command_deck", "mission_board"} else "corp")
+    discovered_keys = [room.key for room in rooms]
+    preferred_order = VIEW_ROOM_ORDER.get(normalized_key, discovered_keys)
+    ordered_keys = [key for key in preferred_order if key in discovered_keys]
+    ordered_keys.extend(key for key in discovered_keys if key not in ordered_keys)
+    return ViewFocusModel(view_key=normalized_key, room_keys=ordered_keys, action_keys=[])

--- a/game/ui/navigation/hints_overlay.py
+++ b/game/ui/navigation/hints_overlay.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .input_map import active_shortcuts_for_screen
+
+
+@dataclass
+class HelpOverlayState:
+    visible: bool = False
+
+    def toggle(self) -> None:
+        self.visible = not self.visible
+
+
+def build_hint_banner(view_key: str, room_key: str | None = None, has_room_open: bool = False) -> str:
+    context = room_key or "tower"
+    items = active_shortcuts_for_screen(view_key, has_room_open)
+    banner_items = items[:4]
+    if has_room_open and not any("Esc" in item for item in banner_items):
+        banner_items = banner_items[:-1] + ["Esc fermer room"]
+    shortcuts = " | ".join(banner_items)
+    return f"[{context}] {shortcuts}"
+
+
+def build_help_lines(view_key: str, room_key: str | None, actions: list[str], has_room_open: bool = False) -> list[str]:
+    lines = [
+        "AIDE CLAVIER // Command UI",
+        "Tab / Shift+Tab: naviguer le focus",
+        "Entrée: activer l'élément focalisé",
+        "H: afficher/masquer l'aide",
+        f"Vue: {view_key} | Contexte: {room_key or 'tower'}",
+        "Raccourcis actifs:",
+        *[f"- {line}" for line in active_shortcuts_for_screen(view_key, has_room_open)[:5]],
+    ]
+    if actions:
+        lines.append("Actions room/listes:")
+        lines.extend(f"- {action}" for action in actions[:4])
+    return lines

--- a/game/ui/navigation/input_map.py
+++ b/game/ui/navigation/input_map.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from .focus_manager import FocusItem
+
+
+def keyboard_action_for_focus(item: FocusItem | None) -> str | None:
+    if item is None:
+        return None
+    if item.kind == "room":
+        return "open_room"
+    if item.kind == "action":
+        return item.key
+    if item.kind == "mission":
+        return "select_mission"
+    if item.kind == "agent":
+        return "select_agent"
+    return None
+
+
+def active_shortcuts_for_screen(view_key: str, has_room_open: bool) -> list[str]:
+    if view_key == "command_deck":
+        shortcuts = ["Tab/Shift+Tab focus", "Entrée activer", "↑/↓ mission", "A/D agent", "H aide"]
+    elif view_key == "mission_board":
+        shortcuts = ["Tab/Shift+Tab focus", "Entrée activer", "↑/↓ mission", "1-3 choix rapide", "H aide"]
+    else:
+        shortcuts = ["Tab/Shift+Tab focus", "Entrée activer", "C ville", "R escouade", "H aide"]
+    if has_room_open:
+        shortcuts.append("Esc fermer room")
+    return shortcuts

--- a/tests/ui/test_context_hints.py
+++ b/tests/ui/test_context_hints.py
@@ -1,0 +1,28 @@
+"""Context hints overlay contract for command UI views."""
+
+import unittest
+
+from game.ui.navigation import active_shortcuts_for_screen, build_help_lines, build_hint_banner
+
+
+class ContextHintsTest(unittest.TestCase):
+    def test_overlay_is_dynamic_per_view(self):
+        center = build_hint_banner("command_center", "executive", has_room_open=False)
+        deck = build_hint_banner("command_deck", "ops", has_room_open=True)
+        self.assertNotEqual(center, deck)
+        self.assertIn("Esc", deck)
+
+    def test_active_shortcuts_include_room_close_only_when_open(self):
+        closed = active_shortcuts_for_screen("command_deck", has_room_open=False)
+        opened = active_shortcuts_for_screen("command_deck", has_room_open=True)
+        self.assertFalse(any("Esc" in shortcut for shortcut in closed))
+        self.assertTrue(any("Esc" in shortcut for shortcut in opened))
+
+    def test_help_lines_stay_compact_and_contextual(self):
+        lines = build_help_lines("mission_board", "ops", ["mission_prev", "mission_next"], has_room_open=True)
+        self.assertLessEqual(len(lines), 14)
+        self.assertTrue(any("Raccourcis actifs" in line for line in lines))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ui/test_keyboard_navigation.py
+++ b/tests/ui/test_keyboard_navigation.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from game.ui.navigation import build_help_lines, build_hint_banner, build_view_focus_model
+from game.ui.navigation import build_help_lines, build_hint_banner, build_view_focus_model, keyboard_action_for_focus
 from game.ui.room_interaction import RoomUIState, open_room
 
 
@@ -34,7 +34,7 @@ class KeyboardNavigationTest(unittest.TestCase):
 
     def test_mission_selection_is_part_of_shared_tab_order(self):
         model = build_view_focus_model("squad", 1280, 720)
-        model.mission_count = 3
+        model.set_list_counts(mission_count=3, agent_count=2)
         model.current_index = len(model.room_keys)
         mission = model.move(len(model.action_keys) + 1)
         self.assertIsNotNone(mission)
@@ -42,11 +42,19 @@ class KeyboardNavigationTest(unittest.TestCase):
         self.assertEqual(mission.key, "mission_1")
 
     def test_contextual_hints_and_help_overlay_stay_compact(self):
-        hint = build_hint_banner("corp", "executive")
-        help_lines = build_help_lines("corp", "executive", ["Advance day", "Fund politics"])
+        hint = build_hint_banner("command_center", "executive", has_room_open=True)
+        help_lines = build_help_lines("command_center", "executive", ["Advance day", "Fund politics"], has_room_open=True)
         self.assertIn("Tab focus", hint)
-        self.assertLessEqual(len(help_lines), 12)
-        self.assertTrue(any("Raccourcis contextuels" in line for line in help_lines))
+        self.assertLessEqual(len(help_lines), 14)
+        self.assertTrue(any("Raccourcis actifs" in line for line in help_lines))
+
+    def test_focus_item_maps_to_same_keyboard_activation_intent(self):
+        model = build_view_focus_model("command_deck", 1280, 720)
+        model.set_actions(["launch"])
+        model.set_list_counts(mission_count=1, agent_count=1)
+        self.assertEqual(keyboard_action_for_focus(model.active()), "open_room")
+        model.current_index = len(model.room_keys)
+        self.assertEqual(keyboard_action_for_focus(model.active()), "launch")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Fournir un graphe de focus cohérent et un ordre `Tab` stable par vue pour UI command screens (command_center, command_deck, mission_board, facility). 
- Garantir la parité clavier/souris pour les actions de room étendue et les listes mission/agents afin d’unifier l’intention d’activation. 
- Exposer un overlay discret et dynamique listant les raccourcis actifs par écran pour améliorer le feedback UX sans alourdir l’interface.

### Description
- Ajout du sous-module `game/ui/navigation/` avec trois fichiers spécialisés : `focus_manager.py` (modèle de focus, normalisation de vues et ordre déterministe des rooms), `input_map.py` (mapping focus→intention clavier et liste de raccourcis par écran) et `hints_overlay.py` (bannière compacte + lignes d’aide avec injection dynamique de `Esc fermer room`).
- Mise à jour des exports dans `game/ui/navigation/__init__.py` pour préserver l’import central tout en exposant les nouvelles utilitaires (`keyboard_action_for_focus`, `active_shortcuts_for_screen`).
- Tests: ajout de `tests/ui/test_context_hints.py` et adaptation/extension de `tests/ui/test_keyboard_navigation.py` pour valider le tab-order, l’entrée d’actions focalisées, la sélection de missions/agents et le comportement contextuel de l’overlay.
- Documentation: mise à jour de `docs/backlog.md` pour marquer la tâche navigation UI comme terminée.

### Testing
- Exécution initiale des tests via `pytest -q tests/ui/test_keyboard_navigation.py tests/ui/test_context_hints.py` sans `PYTHONPATH` a échoué lors de la collecte avec `ModuleNotFoundError: No module named 'game'` (attendu en contexte d’exécution par défaut).
- Ré-exécution avec `PYTHONPATH=. pytest -q tests/ui/test_keyboard_navigation.py tests/ui/test_context_hints.py` a abouti à la suite complète des tests ciblés.
- Résultat final : les deux fichiers de tests UI ciblés ont été exécutés et la suite a réussi (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10224daa44832b9e0694ac9415074d)