### PR TITLE
Add modular UI feedback package with standardized toasts and confirmations

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,3 +1,4 @@
+- [x] UI-11 Feedback system modulaire: création de `game/ui/feedback/` (`toast_center.py`, `confirm_dialog.py`, `error_banner.py`), standardisation des messages `Action/Result/Impact/Next`, confirmations pour actions coûteuses/irréversibles (mission risquée, dépenses, load), et tests de rendu/dispatch `tests/ui/test_feedback_system.py`.
 TODO:
 - [x] UI-10 Polish motion/audio: centralisation des timings/easings (`game/ui/theme/motion.py`), harmonisation transition room-expanded + sélection mission, micro-animations légères sur boutons, feedback audio optionnel (toggle `M`) pour actions majeures, checklist `docs/ui/polish-checklist.md`.
 - [x] UI-09 Design system modulaire: séparation `theme/` (tokens/typography/colors), création de composants partagés `game/ui/components/`, remplacement des styles hardcodés critiques dans les écrans de commande, documentation `docs/ui/design-system.md` + référence README, et validation par tests UI ciblés.

--- a/game/ui/action_feedback.py
+++ b/game/ui/action_feedback.py
@@ -2,36 +2,42 @@
 
 from __future__ import annotations
 
+from game.ui.feedback.confirm_dialog import build_confirm_message
+from game.ui.feedback.error_banner import build_error_banner
+from game.ui.feedback.toast_center import FeedbackToast, dispatch_toast
 from game.ui.widgets.notification_center import NotificationCenter
 
 
+_ACTION_LABELS = {
+    "recruitment": "Recruitment",
+    "budget_allocation": "Budget allocation",
+    "mission_launch": "Mission launch",
+    "save": "Save",
+    "load": "Load",
+    "upgrade": "Upgrade",
+}
+
+
 def action_message(action: str, ok: bool, detail: str = "") -> tuple[str, str]:
-    status = "SUCCESS" if ok else "FAILURE"
-    base = {
-        "recruitment": "Recruitment",
-        "budget_allocation": "Budget allocation",
-        "mission_launch": "Mission launch",
-        "save": "Save",
-        "load": "Load",
-    }.get(action, action.replace("_", " ").title())
-    text = f"{base} {status.lower()}"
-    if detail:
-        text = f"{text}: {detail}"
-    return status.lower(), text
+    level = "success" if ok else "failure"
+    action_label = _ACTION_LABELS.get(action, action.replace("_", " ").title())
+    result = "completed" if ok else "failed"
+    impact = detail or "funds/stress/time unchanged"
+    next_step = "Continue strategic planning" if ok else "Review resources and retry"
+    toast = FeedbackToast(action_label, result, impact, next_step)
+    return level, toast.message
 
 
 def confirm_message(action: str) -> str:
-    if action == "mission_launch_risk":
-        return "Confirmation required: launch risky mission? Repeat action to confirm."
-    if action == "spend_funds":
-        return "Confirmation required: this action spends funds and cannot be undone."
-    return "Confirmation required before irreversible action."
+    return build_confirm_message(action)
 
 
 def push_action(center: NotificationCenter, action: str, ok: bool, detail: str = "") -> str:
     level, text = action_message(action, ok, detail)
-    if level == "success":
-        center.success(text)
-    else:
-        center.failure(text)
-    return text
+    if not ok and detail:
+        text = f"{text} | {build_error_banner(action, detail)}"
+    impact = detail or "n/a"
+    if not ok and detail:
+        impact = f"{impact}; {build_error_banner(action, detail)}"
+    toast = FeedbackToast(action, "completed" if ok else "failed", impact, "Proceed")
+    return dispatch_toast(center, "success" if ok else "failure", toast)

--- a/game/ui/feedback/confirm_dialog.py
+++ b/game/ui/feedback/confirm_dialog.py
@@ -1,0 +1,34 @@
+"""Confirmation rules for costly or irreversible actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ConfirmRule:
+    key: str
+    message: str
+
+
+CONFIRM_RULES = {
+    "mission_launch_risk": ConfirmRule(
+        "mission_launch_risk",
+        "Confirmation required: risky launch may trigger agent breakdown. Repeat action to confirm.",
+    ),
+    "spend_funds": ConfirmRule(
+        "spend_funds",
+        "Confirmation required: this spend is costly and cannot be fully undone.",
+    ),
+    "load": ConfirmRule(
+        "load",
+        "Confirmation required: loading overwrites current unsaved progress.",
+    ),
+}
+
+
+def build_confirm_message(action_key: str) -> str:
+    return CONFIRM_RULES.get(
+        action_key,
+        ConfirmRule(action_key, "Confirmation required before irreversible action."),
+    ).message

--- a/game/ui/feedback/error_banner.py
+++ b/game/ui/feedback/error_banner.py
@@ -1,0 +1,7 @@
+"""Error banner for failed actions in tactical UI."""
+
+from __future__ import annotations
+
+
+def build_error_banner(action: str, reason: str) -> str:
+    return f"[ERROR] {action}: {reason}"

--- a/game/ui/feedback/toast_center.py
+++ b/game/ui/feedback/toast_center.py
@@ -1,0 +1,32 @@
+"""Toast-style feedback payload and dispatch helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from game.ui.widgets.notification_center import NotificationCenter
+
+
+@dataclass(frozen=True)
+class FeedbackToast:
+    action: str
+    result: str
+    impact: str
+    next_step: str
+
+    @property
+    def message(self) -> str:
+        return (
+            f"Action: {self.action} | Result: {self.result} | "
+            f"Impact: {self.impact} | Next: {self.next_step}"
+        )
+
+
+def dispatch_toast(center: NotificationCenter, level: str, toast: FeedbackToast) -> str:
+    if level == "success":
+        center.success(toast.message)
+    elif level == "warning":
+        center.warning(toast.message)
+    else:
+        center.failure(toast.message)
+    return toast.message

--- a/tests/test_command_center_ui.py
+++ b/tests/test_command_center_ui.py
@@ -70,4 +70,4 @@ class NotificationCenterUITest(unittest.TestCase):
         center.push(level, text)
         center.failure("Mission launch failure: no deployable agents")
         self.assertIn("[FAILURE] Mission launch failure", center.latest_text_lines(2)[0])
-        self.assertIn("[SUCCESS] Save success", center.latest_text_lines(2)[1])
+        self.assertIn("[SUCCESS] Action: Save", center.latest_text_lines(2)[1])

--- a/tests/ui/test_feedback_system.py
+++ b/tests/ui/test_feedback_system.py
@@ -1,0 +1,35 @@
+import unittest
+
+from game.ui.action_feedback import action_message, confirm_message, push_action
+from game.ui.feedback.error_banner import build_error_banner
+from game.ui.widgets.notification_center import NotificationCenter
+
+
+class FeedbackSystemTest(unittest.TestCase):
+    def test_action_message_standard_structure(self):
+        level, text = action_message("save", True, "funds +0, stress +0, time +0")
+        self.assertEqual(level, "success")
+        self.assertIn("Action:", text)
+        self.assertIn("Result:", text)
+        self.assertIn("Impact:", text)
+        self.assertIn("Next:", text)
+
+    def test_confirm_messages_for_costly_irreversible_actions(self):
+        self.assertIn("Confirmation required", confirm_message("spend_funds"))
+        self.assertIn("overwrites", confirm_message("load"))
+
+    def test_dispatch_pushes_notification(self):
+        center = NotificationCenter(max_items=3)
+        message = push_action(center, "recruitment", True, "funds -5, stress +1, time +0")
+        self.assertIn("Action:", message)
+        self.assertTrue(any("[SUCCESS]" in line for line in center.latest_text_lines(1)))
+
+    def test_error_banner_used_on_failure(self):
+        center = NotificationCenter(max_items=3)
+        message = push_action(center, "load", False, "save file missing")
+        self.assertIn("[ERROR]", message)
+        self.assertEqual(build_error_banner("load", "save file missing"), "[ERROR] load: save file missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Centralize and modularize UI feedback so notifications, confirmations and error banners are consistent and maintainable across command/CORP/RPG flows.
- Standardize feedback payloads to the requested `Action | Result | Impact | Next` structure to improve emotional readability and next-step guidance for players.
- Provide explicit confirmation rules for costly or irreversible actions (risky mission launches, spending funds, loading saves) to avoid accidental destructive actions.
- Surface feedback for key events (recruitment, upgrades/allocations, mission launch, save/load) via the shared notification center so views can remain thin.

### Description
- Added a small feedback package under `game/ui/feedback/` with `toast_center.py` (structured `FeedbackToast` and `dispatch_toast`), `confirm_dialog.py` (central `CONFIRM_RULES` and `build_confirm_message`) and `error_banner.py` (consistent `build_error_banner`).
- Refactored `game/ui/action_feedback.py` to produce standardized toasts via the new feedback modules and to expose `action_message`, `confirm_message` and `push_action` that dispatch into `NotificationCenter` with proper impact/error decoration. 
- Wired confirmations and toasts into gameplay flows already emitting feedback (recruitment, budget allocation/upgrade attempts, mission launch, save/load) without changing view-level presentation code. 
- Added `tests/ui/test_feedback_system.py` to validate message structure, confirmation text, dispatch behavior and error-banner usage, and updated `tests/test_command_center_ui.py` expectations to match the new standardized format, and updated `docs/backlog.md` with the completed item.

### Testing
- Ran `pytest -q tests/ui/test_feedback_system.py tests/test_command_center_ui.py` and all tests passed (9 passed). 
- Existing notification-related unit tests were adjusted to assert the new `Action: ... | Result: ...` message format and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10248c5ef0832b872654e665f5c194)