### PR TITLE
Add gameplay loop docs, blocked-action UI reasons, and static game-flow regression tests

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,3 +1,22 @@
+
+## Gameplay systems explicit status
+
+- funds: **functional**
+- calendar: **functional**
+- research: **in progress**
+- events: **in progress**
+- equipment: **in progress**
+- stress: **functional**
+- recovery: **functional**
+- faction rewards: **functional**
+- aftermath: **functional**
+- mission generation: **functional**
+- battle objectives: **functional**
+- blocked action reasons UI: **in progress**
+- static game-flow regression tests: **in progress**
+
+Status vocabulary: `not started`, `in progress`, `functional`, `polished`.
+
 - [x] UI-17 Contrat de layouts 4 zones: templates `OverviewLayout`/`DecisionLayout`/`RosterLayout`/`TacticalLayout` dans `game/ui/layouts/screen_templates.py`, mission board enrichi (risque, durée, coût, impact émotionnel, conséquence + recommended action), recommandations contextualisées en écrans de gestion, et tests de contrat `tests/ui/test_screen_layout_contracts.py`. (completed May 22, 2026)
 - [x] UI-16 Migration UI modulaire (phase 1): création des sous-répertoires `screens/command_center|command_deck|facility|battle_hud`, `components/cards|lists|agent|shared`, `layouts/grid|split|overlays`, `navigation/focus|input`, `feedback/toast|dialog|banner`; extraction initiale `command_deck` vers `game/ui/screens/command_deck/layout.py`; wrappers de compatibilité maintenus; mutualisation badge upgrade + rendu cartes agents via composants dédiés. (completed May 22, 2026)
 - [x] UI-15 Foundation design-system split: création `theme/spacing.py`, `theme/elevation.py`, `theme/radii.py`, normalisation des couleurs sémantiques, ajout de `game/ui/components/foundation/` (Panel/Button/Badge/Divider/ProgressBar/Tooltip), règle progressive anti-hardcode sur `game/ui/screens/`, docs design-system et tests dédiés. (completed May 22, 2026)

--- a/docs/gameplay/playable_loop.md
+++ b/docs/gameplay/playable_loop.md
@@ -1,0 +1,20 @@
+# Playable Loop (Required)
+
+CyberCity2085 playable loop must always follow this chain:
+
+1. **Base management**
+   - Player allocates resources, handles events, prepares economy and recovery.
+2. **Squad preparation**
+   - Player recruits/selects agents, equips loadouts, manages stress/recovery, assigns support assets.
+3. **Mission launch**
+   - Player picks an operation and confirms deployment.
+4. **Battle resolution**
+   - Tactical outcome resolves mission objectives, casualties, and objective branches.
+5. **Consequences**
+   - Rewards/penalties apply (funds/resources/faction/narrative aftermath/stress).
+6. **Next day**
+   - Strategic day advances (calendar/events/research/recovery/income), enabling next planning cycle.
+
+## Design decision
+
+This loop keeps **agents as the emotional core** while preserving a compact modular structure: each stage changes persistent state and leaves readable traces in logs/UI.

--- a/docs/gameplay/system_status.md
+++ b/docs/gameplay/system_status.md
@@ -1,0 +1,15 @@
+# Gameplay System Status Matrix
+
+| System | Current behavior | Missing behavior | UI entry point | Test coverage |
+|---|---|---|---|---|
+| funds | Corporate ledger supports spend/add/mission payouts and weekly income sync. | More explicit spend-preview UI before expensive actions. | Corp rooms + squad recruit flow. | `tests/test_funds_management.py`, `tests/test_weekly_corporate_funding.py` |
+| calendar | Day/week/month progression ticks daily systems and date labels. | Optional fast-forward planning tools. | Corp/City `D Advance day`. | `tests/test_calendar_management.py`, e2e flow test |
+| research | Projects can be started, tick down, complete with unlock flags/modifiers. | Richer project dependency display in UI. | Corp research room actions. | `tests/test_research_management.py`, e2e save/load flow |
+| events | Strategic events can spawn, be responded to, and expire. | Multi-event response queue UX depth. | Corp/City records + event actions. | `tests/test_strategic_events.py` |
+| equipment | Agents can cycle modular loadout slots in armory. | Costed equipment economy and rarity progression. | Squad armory room actions. | `tests/test_agent_equipment.py`, e2e save/load flow |
+| stress | Daily stress recovery and mission pressure integration exist. | Additional proactive stress-management actions. | Squad medbay/briefing summaries. | `tests/test_stress_management.py`, `tests/test_recovery_status.py` |
+| recovery | Recovery turns and medbay readiness are tracked. | Deeper treatment choices with tradeoffs. | Squad medbay + deployability checks. | `tests/test_recovery_status.py`, `tests/test_recovery_dialogues.py` |
+| faction rewards | Narrative faction reward journal on mission success. | Systemic faction economy effects (intentionally out-of-scope for now). | Post-mission logs / narrative feed. | `tests/test_faction_rewards.py` |
+| aftermath | Agent aftermath and debrief persistence/logging after missions. | Additional branching aftermath scenes. | Post-battle to command logs. | `tests/test_agent_aftermath.py`, `tests/test_narrative_debrief.py` |
+| mission generation | Daily mission board generation with pressure-aware template selection. | District-specific handcrafted mission pools. | Squad ops room / mission board. | `tests/test_mission_generation.py`, `tests/test_mission_board_ui.py` |
+| battle objectives | Objective variants/branches supported with tactical hooks. | Larger objective library per faction. | Battle resolution and mission briefing text. | `tests/test_mission_objectives.py`, `tests/test_objective_branches.py` |

--- a/game/ui/management/action_requirements.py
+++ b/game/ui/management/action_requirements.py
@@ -1,0 +1,58 @@
+"""Management action requirement checks.
+
+Small focused helpers for blocked-action reasons so UI flows stay readable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ActionBlockReason:
+    action: str
+    missing_requirement: str
+    guidance: str
+
+    def to_ui_text(self) -> str:
+        return (
+            f"Action blocked: {self.action}. Missing {self.missing_requirement}. "
+            f"Requirement: {self.guidance}."
+        )
+
+
+def blocked_recruit_reason(available_funds: int, recruit_cost: int = 5) -> ActionBlockReason | None:
+    if available_funds >= recruit_cost:
+        return None
+    return ActionBlockReason(
+        action="Recruit agent",
+        missing_requirement="corporate funds",
+        guidance=f"need at least {recruit_cost} funds (current {available_funds})",
+    )
+
+
+def blocked_launch_reason(
+    has_deployable_agent: bool,
+    selected_count: int,
+    mission_unavailable: bool,
+    mission_title: str,
+) -> ActionBlockReason | None:
+    if not has_deployable_agent:
+        return ActionBlockReason(
+            action="Launch mission",
+            missing_requirement="deployable agent",
+            guidance="recruit or recover at least one deployable agent",
+        )
+    if selected_count <= 0:
+        return ActionBlockReason(
+            action="Launch mission",
+            missing_requirement="selected squad",
+            guidance="toggle at least one deployable agent into the squad",
+        )
+    if mission_unavailable:
+        return ActionBlockReason(
+            action=f"Launch {mission_title}",
+            missing_requirement="mission availability",
+            guidance="advance day or select another mission",
+        )
+    return None

--- a/game/views.py
+++ b/game/views.py
@@ -60,6 +60,10 @@ from .ui.research_lab import build_research_lab_lines
 from .ui.widgets.squad_morale_panel import build_squad_morale_panel_lines
 from .ui.widgets.notification_center import NotificationCenter
 from .ui.action_feedback import confirm_message, push_action
+from .ui.management.action_requirements import (
+    blocked_launch_reason,
+    blocked_recruit_reason,
+)
 from .ui.navigation import (
     HelpOverlayState,
     build_help_lines,
@@ -652,28 +656,20 @@ class RPGView(GameView):
         return selected_agents
 
     def launch_selected_mission(self) -> None:
-        if not self.has_deployable_agent():
-            self.message = (
-                "Recruit at least one deployable agent before launching an operation."
-            )
-            self.pending_breakdown_confirmation = False
-            self.pending_breakdown_mission_id = None
-            return
-
         selected_squad = self.selected_deployment()
-        if not selected_squad:
-            self.message = (
-                "Select at least one deployable agent before launching an operation."
-            )
-            self.pending_breakdown_confirmation = False
-            self.pending_breakdown_mission_id = None
-            return
-
         selected_mission = self.selected_mission()
-        if selected_mission.id in self.game_state.unavailable_mission_ids:
-            self.message = f"{selected_mission.title} is temporarily unavailable."
+        blocked = blocked_launch_reason(
+            has_deployable_agent=self.has_deployable_agent(),
+            selected_count=len(selected_squad),
+            mission_unavailable=selected_mission.id in self.game_state.unavailable_mission_ids,
+            mission_title=selected_mission.title,
+        )
+        if blocked is not None:
+            self.message = blocked.to_ui_text()
             self.pending_breakdown_confirmation = False
             self.pending_breakdown_mission_id = None
+            self.notifications.warning(self.message)
+            self.game_state.add_event(self.message)
             return
         agents_at_risk = agents_at_breaking_risk(selected_squad, selected_mission)
         confirmation_matches = (
@@ -791,7 +787,11 @@ class RPGView(GameView):
                 self.selected_role = None
                 self.message = ""
             else:
-                pass
+                blocked = blocked_recruit_reason(self.game_state.available_funds)
+                if blocked:
+                    self.message = blocked.to_ui_text()
+                    self.notifications.warning(self.message)
+                    self.game_state.add_event(self.message)
         elif self.recruiting:
             if key in (arcade.key.KEY_1, arcade.key.KEY_2, arcade.key.KEY_3):
                 role_map = {
@@ -1087,6 +1087,7 @@ class RPGView(GameView):
         item = options[next_index]
         active_agent.loadout.equip(slot, item)
         self.message = f"{active_agent.name} equipped {item.name}."
+        self.game_state.add_event(self.message)
 
     def _level_active_agent(self, stat_key: str) -> None:
         active_agent = self._active_agent()
@@ -1097,6 +1098,8 @@ class RPGView(GameView):
         setattr(active_agent.stats, stat_key, getattr(active_agent.stats, stat_key) + 1)
         active_agent.pending_points -= 1
         active_agent.stats.recalculate_hp()
+        self.message = f"{active_agent.name} trained {stat_key.upper()} (+1)."
+        self.game_state.add_event(self.message)
 
     def _room_info_lines(self) -> dict[str, list[str]]:
         mission = self.selected_mission()

--- a/tests/test_static_game_flow_e2e.py
+++ b/tests/test_static_game_flow_e2e.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from game.gamestate import GameState
+from game.mission_system import resolve_mission_outcome, selected_mission
+from game.persistence.save_system import SaveSystem
+from game.management.equipment import default_equipment_catalog
+from game.recruitment import recruit_agent
+
+
+def test_advancing_day_updates_calendar_and_logs():
+    state = GameState()
+    before_day = state.calendar.current_day
+    before_log_count = len(state.event_log)
+
+    state.advance_one_day("test progression")
+
+    assert state.calendar.current_day == before_day + 1
+    assert len(state.event_log) >= before_log_count
+
+
+def test_mission_completion_applies_rewards_or_penalties():
+    state = GameState()
+    mission = selected_mission(state)
+    before_funds = state.available_funds
+
+    resolve_mission_outcome(
+        state,
+        mission,
+        victory=True,
+        triggered_complication=mission.possible_complications[0] if mission.possible_complications else None,
+    )
+
+    assert state.calendar.current_day >= 2
+    assert state.available_funds >= before_funds
+    assert state.faction_reward_journal
+
+
+def test_events_research_equipment_persist_across_save_load(tmp_path: Path):
+    state = GameState()
+    state.active_events = state.active_events[:1]
+    available = state.research_tree.available_projects(set(), set())
+    if available:
+        state.start_research(available[0].id)
+    recruit_agent(state.characters, "samurai")
+    agent = state.characters[0]
+    catalog = default_equipment_catalog()
+    agent.loadout.equip("primary_weapon", catalog["primary_weapon"][0])
+
+    save_path = tmp_path / "flow_save.json"
+    save_result = SaveSystem.save_game(state, save_path)
+    assert save_result.ok
+
+    loaded, load_result = SaveSystem.load_game(save_path)
+    assert load_result.ok
+    assert loaded is not None
+    assert len(loaded.active_events) == len(state.active_events)
+    assert len(loaded.active_research) == len(state.active_research)
+    assert loaded.calendar.current_day == state.calendar.current_day
+    assert loaded.characters[0].loadout.primary_weapon is not None


### PR DESCRIPTION
### Motivation
- Make the required playable loop explicit (management → squad prep → mission → battle → consequences → next day) so design and dev stay aligned.  
- Surface clear, actionable reasons in the UI when management actions are blocked to improve player clarity.  
- Keep view logic modular by moving requirement checks into a focused helper module to avoid bloating `views.py`.  
- Add a minimal static end-to-end regression test to protect the core management→mission→persistence flow.

### Description
- Added `docs/gameplay/playable_loop.md` documenting the canonical loop and a short design rationale.  
- Added `docs/gameplay/system_status.md` with a status matrix for requested systems (`funds`, `calendar`, `research`, `events`, `equipment`, `stress`, `recovery`, `faction rewards`, `aftermath`, `mission generation`, `battle objectives`) listing current behavior, missing behavior, UI entry point, and test coverage.  
- Introduced `game/ui/management/action_requirements.py` implementing `ActionBlockReason` and helpers `blocked_recruit_reason` and `blocked_launch_reason` for concise blocked-action checks.  
- Integrated blocked-action feedback into `game/views.py` so recruit and mission-launch flows now display and log human-readable blocked reasons, and equipment/level actions emit visible log events.  
- Added static regression tests `tests/test_static_game_flow_e2e.py` validating day advancement, mission outcome application (rewards/penalties/faction journal), and persistence of events/research/equipment across save/load.  
- Updated `docs/backlog.md` with explicit statuses using the vocabulary `not started`, `in progress`, `functional`, `polished`.

### Testing
- Ran `pytest -q tests/test_static_game_flow_e2e.py` with `PYTHONPATH=.`, which passed (`3 passed`).  
- Attempting to run `pytest -q tests/test_static_game_flow_e2e.py tests/test_command_deck_ui.py tests/test_command_center_ui.py` without `PYTHONPATH=.` failed during collection due to import-path resolution in this environment (module import errors), which is an environment configuration issue rather than a code failure.  
- The new e2e tests exercise `advance_one_day`, `resolve_mission_outcome`, and save/load persistence and completed successfully under the tested import configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104f66a5a8832b8b96f7bde0bd5b64)