### PR TITLE
Add modular first-session onboarding, in‑game Help panel, and UI tooltips

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -192,3 +192,11 @@ Automation status:
 - [x] UI navigation: focus manager + input map + contextual hints overlay (keyboard/mouse parity for rooms, missions, agents).
 
 - [x] Refactor mission board into sectioned mission detail subcomponents (mission_card, mission_detail, impact_badges) with lock-state messaging and UI-ready emotional risk fields. (completed May 22, 2026)
+
+## Latest UI onboarding slice
+
+[x] Add first-session onboarding package (`game/ui/onboarding`) with separated tutorial steps, overlay state, and English copy
+[x] Add persistent cross-view Help panel content (Corp/City/RPG/Battle) with objective, controls, and next action
+[x] Add contextual tooltip dictionaries for command center/deck, mission board, and facility interactive elements
+[x] Save tutorial progress in `GameState` with replay/skip support
+[x] Add UI tests for tutorial progression, overlay visibility, and help panel English content

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -36,6 +36,7 @@ from .management.spec_ops_assets import (
 from .mission_templates import MissionTemplate, create_mission_templates
 from .operations import Operation, create_operation_templates
 from .world import District, create_vertical_slice_district
+from .ui.onboarding.tutorial_steps import apply_tutorial_event
 
 if TYPE_CHECKING:
     from .character import Character
@@ -115,6 +116,14 @@ class GameState:
     unavailable_mission_ids: list[str] = field(default_factory=list)
     ui_high_contrast: bool = False
     ui_audio_feedback_enabled: bool = False
+    tutorial_progress: dict = field(
+        default_factory=lambda: {
+            "tutorial_step_index": 0,
+            "tutorial_completed": False,
+            "tutorial_skipped": False,
+            "tutorial_replay_requested": False,
+        }
+    )
 
     # Experience points gained through battles
     x: int = 0
@@ -391,6 +400,24 @@ class GameState:
         """Resolve an active event with a command choice."""
         return apply_event_choice(self, event_id, choice_key)
 
+    def mark_tutorial_event(self, event: str) -> bool:
+        """Advance onboarding when the expected first-session event is reached."""
+        return apply_tutorial_event(self.tutorial_progress, event)
+
+    def replay_tutorial(self) -> None:
+        self.tutorial_progress.update(
+            {
+                "tutorial_step_index": 0,
+                "tutorial_completed": False,
+                "tutorial_skipped": False,
+                "tutorial_replay_requested": True,
+            }
+        )
+
+    def skip_tutorial(self) -> None:
+        self.tutorial_progress["tutorial_skipped"] = True
+        self.tutorial_progress["tutorial_completed"] = True
+
     def play_ui_audio_feedback(self, cue: str) -> None:
         """Log a minimal optional audio cue for major UI actions."""
         if self.ui_audio_feedback_enabled:
@@ -507,6 +534,7 @@ class GameState:
             "unavailable_mission_ids": list(self.unavailable_mission_ids),
             "ui_high_contrast": self.ui_high_contrast,
             "ui_audio_feedback_enabled": self.ui_audio_feedback_enabled,
+            "tutorial_progress": dict(self.tutorial_progress),
             "active_research": [
                 research.to_dict() for research in self.active_research
             ],
@@ -582,6 +610,7 @@ class GameState:
         gs.unavailable_mission_ids = list(data.get("unavailable_mission_ids", []))
         gs.ui_high_contrast = bool(data.get("ui_high_contrast", gs.ui_high_contrast))
         gs.ui_audio_feedback_enabled = bool(data.get("ui_audio_feedback_enabled", gs.ui_audio_feedback_enabled))
+        gs.tutorial_progress.update(data.get("tutorial_progress", {}))
         gs.research_tree = create_starter_research_tree()
         gs.active_research = [
             ActiveResearch.from_dict(research)

--- a/game/ui/onboarding/__init__.py
+++ b/game/ui/onboarding/__init__.py
@@ -1,0 +1,1 @@
+"""Onboarding package for first-session tutorial and help overlays."""

--- a/game/ui/onboarding/tutorial_copy_en.py
+++ b/game/ui/onboarding/tutorial_copy_en.py
@@ -1,0 +1,40 @@
+"""English-only tutorial and help copy for first-session onboarding."""
+
+from __future__ import annotations
+
+TUTORIAL_TITLES = {
+    "enter_rooms": "Open a room",
+    "select_agents": "Select an agent",
+    "form_squad": "Form your squad",
+    "open_mission_board": "Open mission board",
+    "launch_mission": "Launch mission",
+    "basic_battle_controls": "Learn battle controls",
+}
+
+TUTORIAL_OBJECTIVES = {
+    "enter_rooms": "Open any highlighted room in Corp or City command.",
+    "select_agents": "Move agent focus and toggle at least one agent.",
+    "form_squad": "Select at least two deployable agents.",
+    "open_mission_board": "Open the squad Operations Table room.",
+    "launch_mission": "Launch the selected mission from Insertion or Ops.",
+    "basic_battle_controls": "Use one move and one attack control in battle.",
+}
+
+HELP_COPY = {
+    "corp": {
+        "next": "Open rooms to allocate resources, then transition to Squad (R).",
+        "controls": ["H help", "Click rooms", "R squad", "C city", "D advance day"],
+    },
+    "city": {
+        "next": "Stabilize district pressure, then hand off to Squad (R).",
+        "controls": ["H help", "Click rooms", "R squad", "D advance day"],
+    },
+    "squad": {
+        "next": "Pick a mission, select agents, then launch.",
+        "controls": ["H help", "A/D agent", "Space toggle", "B launch", "Click cards/actions"],
+    },
+    "battle": {
+        "next": "Advance, attack, and complete the objective marker.",
+        "controls": ["Arrows move", "F fire", "Space melee", "P psi", "E interact", "Enter end turn"],
+    },
+}

--- a/game/ui/onboarding/tutorial_overlay.py
+++ b/game/ui/onboarding/tutorial_overlay.py
@@ -1,0 +1,51 @@
+"""Tutorial overlay rendering and cross-screen help panel content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .tutorial_copy_en import HELP_COPY, TUTORIAL_OBJECTIVES, TUTORIAL_TITLES
+from .tutorial_steps import current_step_key
+
+
+@dataclass(frozen=True)
+class OverlayHighlight:
+    screen: str
+    target: str
+    arrow: str
+
+
+HIGHLIGHTS = {
+    "enter_rooms": OverlayHighlight("corp", "facility_room", "Click any lit room."),
+    "select_agents": OverlayHighlight("squad", "barracks", "Choose an agent card."),
+    "form_squad": OverlayHighlight("squad", "insertion", "Toggle at least two agents."),
+    "open_mission_board": OverlayHighlight("squad", "ops", "Open Operations Table."),
+    "launch_mission": OverlayHighlight("squad", "launch", "Press launch."),
+    "basic_battle_controls": OverlayHighlight("battle", "action_bar", "Try move + attack."),
+}
+
+
+def build_help_panel(screen: str, objective: str | None) -> dict[str, object]:
+    copy = HELP_COPY.get(screen, HELP_COPY["corp"])
+    return {
+        "objective": objective or "No active objective.",
+        "controls": list(copy["controls"]),
+        "next": copy["next"],
+    }
+
+
+def overlay_state_for_screen(progress: dict, screen: str) -> dict[str, object]:
+    step = current_step_key(progress)
+    if step is None:
+        return {"visible": False}
+    highlight = HIGHLIGHTS.get(step)
+    objective = f"{TUTORIAL_TITLES[step]}: {TUTORIAL_OBJECTIVES[step]}"
+    visible = bool(highlight and highlight.screen == screen)
+    return {
+        "visible": visible,
+        "step": step,
+        "objective": objective,
+        "highlight_target": highlight.target if highlight else "",
+        "arrow_text": highlight.arrow if highlight else "",
+        "help": build_help_panel(screen, objective),
+    }

--- a/game/ui/onboarding/tutorial_steps.py
+++ b/game/ui/onboarding/tutorial_steps.py
@@ -1,0 +1,48 @@
+"""Ordered onboarding steps and completion checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TutorialStep:
+    key: str
+    order: int
+    event: str
+
+
+TUTORIAL_STEPS = [
+    TutorialStep("enter_rooms", 0, "entered_room"),
+    TutorialStep("select_agents", 1, "selected_agent"),
+    TutorialStep("form_squad", 2, "formed_squad"),
+    TutorialStep("open_mission_board", 3, "opened_mission_board"),
+    TutorialStep("launch_mission", 4, "launched_mission"),
+    TutorialStep("basic_battle_controls", 5, "used_battle_controls"),
+]
+
+STEP_BY_KEY = {step.key: step for step in TUTORIAL_STEPS}
+
+
+def current_step_key(progress: dict) -> str | None:
+    if progress.get("tutorial_completed"):
+        return None
+    index = int(progress.get("tutorial_step_index", 0))
+    if 0 <= index < len(TUTORIAL_STEPS):
+        return TUTORIAL_STEPS[index].key
+    return None
+
+
+def apply_tutorial_event(progress: dict, event: str) -> bool:
+    if progress.get("tutorial_skipped") or progress.get("tutorial_completed"):
+        return False
+    index = int(progress.get("tutorial_step_index", 0))
+    if not (0 <= index < len(TUTORIAL_STEPS)):
+        return False
+    expected = TUTORIAL_STEPS[index]
+    if event != expected.event:
+        return False
+    progress["tutorial_step_index"] = index + 1
+    if progress["tutorial_step_index"] >= len(TUTORIAL_STEPS):
+        progress["tutorial_completed"] = True
+    return True

--- a/game/ui/screens/command_center.py
+++ b/game/ui/screens/command_center.py
@@ -109,3 +109,9 @@ def build_command_title(mode: str, base_name: str, district_name: str) -> str:
 def build_action_strip(actions: list[str]) -> str:
     """Join controls into an XCOM-like bottom input strip."""
     return "  >  ".join(actions)
+
+
+
+def build_interactive_tooltips() -> dict[str, str]:
+    """English tooltip copy for key interactive UI elements."""
+    return {"primary": "Allocate strategic resources and review command status.", "top_right": "Open management suites and room actions.", "bottom_right": "Track narrative fallout and event pressure."}

--- a/game/ui/screens/command_deck/layout.py
+++ b/game/ui/screens/command_deck/layout.py
@@ -152,3 +152,9 @@ def build_event_panel_lines(active_events, current_day: int) -> list[str]:
             suffix = format_critical_choice_suffix(getattr(choice, "relation_impact", "low"))
             lines.append(f"   {index}.{choice_index} {choice.label}{summary}{suffix}")
     return lines
+
+
+
+def build_interactive_tooltips() -> dict[str, str]:
+    """English tooltip copy for key interactive UI elements."""
+    return {"squad": "Browse agents and toggle squad membership.", "mission": "Review mission cards and switch targets.", "details": "Read mission intel and outcomes.", "briefs": "Review morale, medbay, and fallout notes."}

--- a/game/ui/screens/facility.py
+++ b/game/ui/screens/facility.py
@@ -123,3 +123,9 @@ def facility_room_by_key(rooms: list[FacilityRoom], key: str) -> FacilityRoom:
         if room.key == key:
             return room
     raise KeyError(key)
+
+
+
+def build_interactive_tooltips() -> dict[str, str]:
+    """English tooltip copy for key interactive UI elements."""
+    return {"room": "Click room to open available actions.", "close": "Close current room panel.", "action_strip": "Use icons to execute room actions."}

--- a/game/ui/screens/mission_board.py
+++ b/game/ui/screens/mission_board.py
@@ -89,3 +89,9 @@ def build_selected_mission_lines(mission: MissionTemplate | None) -> list[str]:
         recommended_action_for_mission(mission),
         *build_mission_detail_sections(mission),
     ]
+
+
+
+def build_interactive_tooltips() -> dict[str, str]:
+    """English tooltip copy for key interactive UI elements."""
+    return {"mission_list": "Select a mission card to inspect details.", "launch_action": "Launch current mission with selected squad.", "risk": "Higher risk means heavier resistance."}

--- a/game/views.py
+++ b/game/views.py
@@ -71,6 +71,7 @@ from .ui.navigation import (
     build_view_focus_model,
 )
 from .management.morale import aggregate_squad_morale
+from .ui.onboarding.tutorial_overlay import overlay_state_for_screen
 from .unit import Unit
 
 
@@ -132,6 +133,17 @@ def build_roster_cards(
             }
         )
     return cards
+
+
+
+
+def _help_lines_for_view(game_state: GameState, screen: str) -> list[str]:
+    overlay = overlay_state_for_screen(game_state.tutorial_progress, screen)
+    help_panel = overlay.get("help", {})
+    objective = help_panel.get("objective", "No active objective.")
+    controls = ", ".join(help_panel.get("controls", []))
+    nxt = help_panel.get("next", "")
+    return [f"Objective: {objective}", f"Controls: {controls}", f"Next: {nxt}"]
 
 
 class CorpView(GameView):
@@ -262,6 +274,7 @@ class CorpView(GameView):
         if room is None:
             return False
         open_room(self.room_ui, self.window.width, self.window.height, room.key)
+        self.game_state.mark_tutorial_event("entered_room")
         self._sync_focus_actions()
         return True
 
@@ -403,7 +416,7 @@ class CorpView(GameView):
                         [button.action.label for button in self.room_ui.action_buttons],
                     )[:5]
                 )
-            info[room_key] = hints + lines
+            info[room_key] = _help_lines_for_view(self.game_state, "corp") + hints + lines
         return info
 
 
@@ -514,6 +527,7 @@ class CityView(GameView):
         if room is None:
             return False
         open_room(self.room_ui, self.window.width, self.window.height, room.key)
+        self.game_state.mark_tutorial_event("entered_room")
         return True
 
     def _perform_room_action(self, action_key: str) -> None:
@@ -607,7 +621,7 @@ class CityView(GameView):
                         [button.action.label for button in self.room_ui.action_buttons],
                     )[:5]
                 )
-            info[room_key] = hints + lines
+            info[room_key] = _help_lines_for_view(self.game_state, "city") + hints + lines
         return info
 
 
@@ -668,6 +682,9 @@ class RPGView(GameView):
             self.message = blocked.to_ui_text()
             self.pending_breakdown_confirmation = False
             self.pending_breakdown_mission_id = None
+            self.game_state.mark_tutorial_event("selected_agent")
+            if len(self.game_state.selected_agent_names) >= 2:
+                self.game_state.mark_tutorial_event("formed_squad")
             self.notifications.warning(self.message)
             self.game_state.add_event(self.message)
             return
@@ -690,6 +707,7 @@ class RPGView(GameView):
 
         self.pending_breakdown_confirmation = False
         self.pending_breakdown_mission_id = None
+        self.game_state.mark_tutorial_event("launched_mission")
         mission = launch_mission_system(self.game_state)
         battle_view = BattleView(self.game_state)
         battle_view.setup(mission)
@@ -858,6 +876,8 @@ class RPGView(GameView):
         if room is None:
             return False
         open_room(self.room_ui, self.window.width, self.window.height, room.key)
+        if room.key == "ops":
+            self.game_state.mark_tutorial_event("opened_mission_board")
         self._refresh_squad_room_actions()
         self._sync_focus_actions()
         return True
@@ -946,6 +966,9 @@ class RPGView(GameView):
             )
             self.pending_breakdown_confirmation = False
             self.pending_breakdown_mission_id = None
+            self.game_state.mark_tutorial_event("selected_agent")
+            if len(self.game_state.selected_agent_names) >= 2:
+                self.game_state.mark_tutorial_event("formed_squad")
             self.game_state.play_ui_audio_feedback("toggle")
             self._refresh_squad_room_actions()
             return
@@ -1188,7 +1211,7 @@ class RPGView(GameView):
                         [button.action.label for button in self.room_ui.action_buttons],
                     )[:6]
                 )
-            info[room_key] = hints + lines
+            info[room_key] = _help_lines_for_view(self.game_state, "squad") + hints + lines
         return info
 
 
@@ -1570,9 +1593,11 @@ class BattleView(GameView):
             return False
         if action_key == "move":
             self.message = "Move with arrow keys."
+            self.game_state.mark_tutorial_event("used_battle_controls")
             return True
         if action_key in {"fire", "melee", "psi"}:
             self._begin_target_action(player, action_key)
+            self.game_state.mark_tutorial_event("used_battle_controls")
             return True
         if action_key == "first_aid":
             if player.action_points <= 0 or not player.stats:
@@ -1715,18 +1740,22 @@ class BattleView(GameView):
             new_x, new_y = player.position[0], player.position[1] + 32
             if not self.is_occupied(new_x, new_y, exclude=player):
                 player.move(0, 32)
+                self.game_state.mark_tutorial_event("used_battle_controls")
         elif key == arcade.key.DOWN:
             new_x, new_y = player.position[0], player.position[1] - 32
             if not self.is_occupied(new_x, new_y, exclude=player):
                 player.move(0, -32)
+                self.game_state.mark_tutorial_event("used_battle_controls")
         elif key == arcade.key.LEFT:
             new_x, new_y = player.position[0] - 32, player.position[1]
             if not self.is_occupied(new_x, new_y, exclude=player):
                 player.move(-32, 0)
+                self.game_state.mark_tutorial_event("used_battle_controls")
         elif key == arcade.key.RIGHT:
             new_x, new_y = player.position[0] + 32, player.position[1]
             if not self.is_occupied(new_x, new_y, exclude=player):
                 player.move(32, 0)
+                self.game_state.mark_tutorial_event("used_battle_controls")
         elif key == arcade.key.SPACE:
             self._perform_combat_action("melee")
         elif key == arcade.key.F:
@@ -1795,7 +1824,7 @@ class BattleView(GameView):
 
     def _room_info_lines(self) -> dict[str, list[str]]:
         mission_title = self.mission.title if self.mission else "No active mission"
-        return {
+        base = {
             "drop": [
                 mission_title,
                 f"Available drop zones {len(self.available_maps)}",
@@ -1837,6 +1866,8 @@ class BattleView(GameView):
                 "Uplink returns to corporate command after combat.",
             ],
         }
+        help_lines = _help_lines_for_view(self.game_state, "battle")
+        return {key: help_lines + value for key, value in base.items()}
 
     def check_active_player(self):
         while self.active_index < len(self.player_units) and (

--- a/tests/ui/test_onboarding_flow.py
+++ b/tests/ui/test_onboarding_flow.py
@@ -1,0 +1,32 @@
+from game.gamestate import GameState
+from game.ui.onboarding.tutorial_overlay import overlay_state_for_screen
+
+
+def test_tutorial_step_progression():
+    gs = GameState()
+    assert gs.mark_tutorial_event("entered_room") is True
+    assert gs.tutorial_progress["tutorial_step_index"] == 1
+    assert gs.mark_tutorial_event("formed_squad") is False
+    gs.mark_tutorial_event("selected_agent")
+    gs.mark_tutorial_event("formed_squad")
+    gs.mark_tutorial_event("opened_mission_board")
+    gs.mark_tutorial_event("launched_mission")
+    gs.mark_tutorial_event("used_battle_controls")
+    assert gs.tutorial_progress["tutorial_completed"] is True
+
+
+def test_overlay_visibility_on_target_screens():
+    gs = GameState()
+    corp = overlay_state_for_screen(gs.tutorial_progress, "corp")
+    squad = overlay_state_for_screen(gs.tutorial_progress, "squad")
+    assert corp["visible"] is True
+    assert squad["visible"] is False
+
+
+def test_help_panel_content_presence_in_english():
+    gs = GameState()
+    panel = overlay_state_for_screen(gs.tutorial_progress, "battle")["help"]
+    assert "Objective" not in panel["objective"]  # sentence content only
+    assert any("Arrows move" in control for control in panel["controls"])
+    assert "objective" in panel
+    assert panel["next"]


### PR DESCRIPTION
### Motivation
- Provide a small, modular first-session onboarding flow so new players can be guided through core systems (rooms, agents, squad formation, mission flow, and basic combat) without changing high-level architecture.

### Description
- Added a dedicated onboarding package `game/ui/onboarding/` containing `tutorial_steps.py`, `tutorial_overlay.py`, and `tutorial_copy_en.py` to separate ordered step logic, per-screen overlay/help payloads, and English copy.
- Persisted tutorial progress in `GameState` via a new `tutorial_progress` field and APIs `mark_tutorial_event`, `replay_tutorial`, and `skip_tutorial`, and wired `tutorial_progress` into the save/load JSON payload.
- Hooked onboarding triggers into core view interactions so expected events advance the flow: room entry (`entered_room`), agent selection and squad formation (`selected_agent`, `formed_squad`), mission-board open (`opened_mission_board`), mission launch (`launched_mission`), and basic battle control usage (`used_battle_controls`).
- Added a persistent cross-view Help panel rendered into room info (objective, controls, one-line “what to do next”) and a small `_help_lines_for_view` helper in `game/views.py` to surface overlay content for `corp`, `city`, `squad`, and `battle` screens.
- Added simple contextual tooltip dictionaries via `build_interactive_tooltips()` to the requested screen modules (`game/ui/screens/command_center.py`, `game/ui/screens/command_deck/layout.py`, `game/ui/screens/mission_board.py`, `game/ui/screens/facility.py`).
- Added UI tests `tests/ui/test_onboarding_flow.py` covering tutorial progression, overlay visibility on target screens, and English help panel content, and updated `docs/backlog.md` to reflect the onboarding slice.

### Testing
- `pytest -q tests/ui/test_onboarding_flow.py` initially failed during collection with `ModuleNotFoundError: No module named 'game'` when run without `PYTHONPATH` set, which was an environment import issue and unrelated to the code logic.
- `PYTHONPATH=. pytest -q tests/ui/test_onboarding_flow.py` passed with `3 passed`.
- `PYTHONPATH=. pytest -q tests/ui/test_panels_imports.py` passed with `1 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1050bd1688832b943a0027883edea8)