### PR TITLE
Spec-Ops assets: guide panel, mission prep indicators, HUD labels, and persistence

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -200,3 +200,5 @@ Automation status:
 [x] Add contextual tooltip dictionaries for command center/deck, mission board, and facility interactive elements
 [x] Save tutorial progress in `GameState` with replay/skip support
 [x] Add UI tests for tutorial progression, overlay visibility, and help panel English content
+
+- [x] UI-17 Spec-Ops assets clarity pass: dedicated guide panel module (`game/ui/screens/spec_ops_assets.py`), acquisition/deployment state copy, battle HUD asset labeling, and post-mission outcomes persisted for debrief/base management; plus docs `docs/gameplay/robots_power_armor.md` and coverage updates in `tests/test_spec_ops_assets.py`.

--- a/docs/gameplay/robots_power_armor.md
+++ b/docs/gameplay/robots_power_armor.md
@@ -1,0 +1,36 @@
+# Robots & Power Armor: How to use in game
+
+## 1) Understand what each asset is
+- **Combat robots** are autonomous support assets that deploy beside your agents.
+- **Power armor** is a support suit that still needs a selected, deployable agent as pilot.
+
+## 2) Unlock assets
+1. Open the **Research Lab**.
+2. Complete robot/power-armor research projects.
+3. Once completed, those assets become available for assignment/deployment.
+
+## 3) Assign and prepare assets
+1. Go to **Armory / Spec-Ops** room.
+2. Use **Toggle support** to add/remove support assets.
+3. Keep integrity at 50+ and cooldown at 0 day to be deployable.
+4. For power armor, ensure enough deployable agents are selected.
+
+## 4) Mission prep checks
+Before launch, confirm:
+- selected support assets,
+- ready slot usage,
+- projected maintenance,
+- projected fuel and ammo deployment costs.
+
+## 5) Battle usage
+- Assets are labeled as **Support Asset** in the HUD.
+- Agents are labeled as **Agent**.
+- Support assets focus on fire/missiles/defend actions.
+
+## 6) Post-mission outcomes
+After battle, review in debrief/base UI:
+- damage percentage,
+- repair cost,
+- availability cooldown.
+
+Then run maintenance service to restore integrity for future operations.

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -106,6 +106,7 @@ class GameState:
     selected_agent_names: list[str] = field(default_factory=list)
     spec_ops_assets: list[SpecOpsAsset] = field(default_factory=list)
     selected_asset_ids: list[str] = field(default_factory=list)
+    latest_spec_ops_outcomes: list[dict] = field(default_factory=list)
     event_log: list[str] = field(
         default_factory=lambda: [
             "Turn 1: Forward Base Kilo establishes overwatch in the Chrome Warrens."
@@ -521,6 +522,7 @@ class GameState:
             "selected_agent_names": list(self.selected_agent_names),
             "spec_ops_assets": [asset.to_dict() for asset in self.spec_ops_assets],
             "selected_asset_ids": list(self.selected_asset_ids),
+            "latest_spec_ops_outcomes": [dict(item) for item in self.latest_spec_ops_outcomes],
             "recent_consequences": [
                 consequence.to_dict() for consequence in self.recent_consequences
             ],
@@ -594,6 +596,9 @@ class GameState:
             SpecOpsAsset.from_dict(asset) for asset in data.get("spec_ops_assets", [])
         ]
         gs.selected_asset_ids = list(data.get("selected_asset_ids", []))
+        gs.latest_spec_ops_outcomes = [
+            dict(item) for item in data.get("latest_spec_ops_outcomes", [])
+        ]
         gs.recent_consequences = [
             Consequence.from_dict(consequence)
             for consequence in data.get("recent_consequences", [])

--- a/game/management/spec_ops_assets.py
+++ b/game/management/spec_ops_assets.py
@@ -83,15 +83,21 @@ class MaintenanceState:
     integrity: int = 100
     repair_cost_per_damage: int = 1
     base_upkeep: int = 1
+    cooldown_days: int = 0
+    fuel_cost_per_deploy: int = 0
+    ammo_cost_per_deploy: int = 0
 
     def __post_init__(self) -> None:
         self.integrity = max(0, min(int(self.integrity), 100))
         self.repair_cost_per_damage = max(0, int(self.repair_cost_per_damage))
         self.base_upkeep = max(0, int(self.base_upkeep))
+        self.cooldown_days = max(0, int(self.cooldown_days))
+        self.fuel_cost_per_deploy = max(0, int(self.fuel_cost_per_deploy))
+        self.ammo_cost_per_deploy = max(0, int(self.ammo_cost_per_deploy))
 
     @property
     def can_deploy(self) -> bool:
-        return self.integrity >= 50
+        return self.integrity >= 50 and self.cooldown_days <= 0
 
     @property
     def damage(self) -> int:
@@ -113,6 +119,9 @@ class MaintenanceState:
             "integrity": self.integrity,
             "repair_cost_per_damage": self.repair_cost_per_damage,
             "base_upkeep": self.base_upkeep,
+            "cooldown_days": self.cooldown_days,
+            "fuel_cost_per_deploy": self.fuel_cost_per_deploy,
+            "ammo_cost_per_deploy": self.ammo_cost_per_deploy,
         }
 
     @classmethod
@@ -121,6 +130,9 @@ class MaintenanceState:
             integrity=int(data.get("integrity", 100)),
             repair_cost_per_damage=int(data.get("repair_cost_per_damage", 1)),
             base_upkeep=int(data.get("base_upkeep", 1)),
+            cooldown_days=int(data.get("cooldown_days", 0)),
+            fuel_cost_per_deploy=int(data.get("fuel_cost_per_deploy", 0)),
+            ammo_cost_per_deploy=int(data.get("ammo_cost_per_deploy", 0)),
         )
 
 

--- a/game/ui/screens/spec_ops_assets.py
+++ b/game/ui/screens/spec_ops_assets.py
@@ -1,0 +1,70 @@
+"""Spec-ops assets guide and UI copy helpers."""
+
+from __future__ import annotations
+
+from game.deployment import deployable_assets, selected_deployable_agents
+
+
+def build_spec_ops_assets_guide_lines() -> list[str]:
+    return [
+        "Spec Ops Assets Guide",
+        "Robots are autonomous support units that deploy beside agents.",
+        "Power armor is a suit module: each selected suit reserves one pilot.",
+        "Prerequisites: complete relevant research and keep integrity >= 50.",
+        "Upkeep: each asset pays base maintenance plus repair from damage.",
+        "Deployment rules: ready assets only; pilot-gated suits need selected agents.",
+    ]
+
+
+def build_spec_ops_acquisition_lines(game_state) -> list[str]:
+    completed = set(getattr(game_state, "completed_research", []))
+    unlocks = [
+        project.id
+        for project in game_state.research_tree.projects.values()
+        if project.category in {"robot", "power_armor"} and project.id in completed
+    ]
+    return [
+        "Acquisition flow",
+        f"Unlock in Research Lab ({len(unlocks)} completed robot/power-armor projects).",
+        "Purchase/assign in Armory and Spec-Ops room via Toggle support.",
+        "Power armor users: requires one selected deployable agent per suit.",
+    ]
+
+
+def build_mission_prep_asset_state_lines(game_state) -> list[str]:
+    selected_agents = selected_deployable_agents(
+        game_state.characters, game_state.selected_agent_names
+    )
+    ready_assets = deployable_assets(game_state.spec_ops_assets, selected_agents)
+    selected_ids = set(game_state.selected_asset_ids)
+    selected_assets = [asset for asset in ready_assets if asset.id in selected_ids]
+    total_fuel = sum(a.maintenance.fuel_cost_per_deploy for a in selected_assets)
+    total_ammo = sum(a.maintenance.ammo_cost_per_deploy for a in selected_assets)
+    return [
+        "Mission prep asset state",
+        f"Selected support assets: {len(selected_assets)}",
+        f"Slot limits: {len(selected_assets)}/{len(ready_assets)} ready slots",
+        f"Projected fuel cost: {total_fuel}",
+        f"Projected ammo cost: {total_ammo}",
+        f"Projected maintenance/repair cycle: {sum(a.maintenance.maintenance_cost for a in selected_assets)}",
+    ]
+
+
+def battle_unit_label_and_hint(unit) -> tuple[str, str]:
+    if unit.spec_ops_asset:
+        label = "Support Asset"
+        hint = "Asset actions: Fire/Missiles/Defend; does not use morale abilities."
+        return label, hint
+    return "Agent", "Agent actions: Fire/Melee/Psi/First Aid based on loadout."
+
+
+def build_asset_outcome_lines(game_state) -> list[str]:
+    outcomes = getattr(game_state, "latest_spec_ops_outcomes", [])
+    if not outcomes:
+        return ["Spec-ops outcomes", "No deployed support assets in last mission."]
+    lines = ["Spec-ops outcomes"]
+    for row in outcomes:
+        lines.append(
+            f"{row['name']}: damage {row['damage']}%, repair {row['repair_cost']}, cooldown {row['cooldown_days']}d"
+        )
+    return lines

--- a/game/views.py
+++ b/game/views.py
@@ -57,6 +57,13 @@ from .recruitment import recruit_agent
 from .ui import GameView
 from .ui.command_deck import build_corporate_finance_lines, build_event_panel_lines
 from .ui.research_lab import build_research_lab_lines
+from .ui.screens.spec_ops_assets import (
+    battle_unit_label_and_hint,
+    build_asset_outcome_lines,
+    build_mission_prep_asset_state_lines,
+    build_spec_ops_acquisition_lines,
+    build_spec_ops_assets_guide_lines,
+)
 from .ui.widgets.squad_morale_panel import build_squad_morale_panel_lines
 from .ui.widgets.notification_center import NotificationCenter
 from .ui.action_feedback import confirm_message, push_action
@@ -1199,7 +1206,12 @@ class RPGView(GameView):
                 mission.title,
                 f"Selected squad {len(selected)} + {selected_asset_count} support",
                 "Launch moves agents and support assets to combat.",
-            ],
+            ] + build_mission_prep_asset_state_lines(self.game_state)[1:],
+            "spec_ops": (
+                build_spec_ops_assets_guide_lines()
+                + build_spec_ops_acquisition_lines(self.game_state)[1:]
+                + build_asset_outcome_lines(self.game_state)[1:]
+            ),
         }
         for room_key, lines in info.items():
             hints = [build_hint_banner("squad", room_key)]
@@ -1353,6 +1365,25 @@ class BattleView(GameView):
             surviving_participants, self.mission, victory, self.triggered_complication
         )
         self.game_state.latest_mission_debrief = debrief_report.to_dict()
+        outcomes = []
+        for unit in all_player_units:
+            if not unit.spec_ops_asset or not unit.stats:
+                continue
+            asset = unit.spec_ops_asset
+            max_hp = max(1, unit.stats.max_hp)
+            damage_pct = int(max(0, min(100, (max_hp - max(0, unit.health)) * 100 / max_hp)))
+            asset.maintenance.integrity = max(0, asset.maintenance.integrity - damage_pct)
+            asset.maintenance.cooldown_days = 1 if damage_pct >= 30 else 0
+            outcomes.append(
+                {
+                    "id": asset.id,
+                    "name": asset.name,
+                    "damage": damage_pct,
+                    "repair_cost": asset.maintenance.repair_cost,
+                    "cooldown_days": asset.maintenance.cooldown_days,
+                }
+            )
+        self.game_state.latest_spec_ops_outcomes = outcomes
         for line in aftermath_lines:
             self.game_state.add_event(line)
         rpg_view = RPGView(self.game_state)
@@ -1539,6 +1570,7 @@ class BattleView(GameView):
             )
         if self.turn == "player" and self.player_units:
             active_unit = self.player_units[self.active_index]
+            role_label, action_hint = battle_unit_label_and_hint(active_unit)
             unit_name = (
                 active_unit.character.name
                 if active_unit.character
@@ -1550,9 +1582,9 @@ class BattleView(GameView):
                 self.window.width,
                 self.window.height,
                 available_combat_actions(active_unit),
-                unit_name,
+                f"{unit_name} [{role_label}]",
                 active_unit.action_points,
-                self.message,
+                f"{self.message} | {action_hint}",
             )
         else:
             self.combat_action_buttons = []

--- a/tests/test_spec_ops_assets.py
+++ b/tests/test_spec_ops_assets.py
@@ -1,5 +1,6 @@
 """Spec-ops robot and power armor support assets."""
 
+import tempfile
 import unittest
 
 from game.character import Character
@@ -11,6 +12,7 @@ from game.deployment import (
     toggle_asset_selection,
 )
 from game.gamestate import GameState
+from game.management.research import advance_research_days
 from game.management.spec_ops_assets import (
     ArmorRating,
     CombatRobot,
@@ -21,6 +23,19 @@ from game.management.spec_ops_assets import (
 
 
 class SpecOpsAssetsTest(unittest.TestCase):
+    def test_unlock_path_research_to_available_asset_project(self):
+        state = GameState()
+        project = state.research_tree.project("power_armor_servo_prayer")
+        self.assertTrue(state.start_research(project.id))
+        advance_research_days(state, project.days_required, state.research_tree)
+        self.assertIn(project.id, state.completed_research)
+        self.assertTrue(
+            any(
+                "power_armor" in p.category
+                for p in state.research_tree.projects.values()
+            )
+        )
+
     def test_create_combat_robot_and_power_armor_models(self):
         robot = CombatRobot(
             id="drone_01",
@@ -114,6 +129,23 @@ class SpecOpsAssetsTest(unittest.TestCase):
         self.assertEqual(state.available_funds, starting_funds - 43)
         self.assertEqual(robot.maintenance.integrity, 100)
         self.assertEqual(state.funds.transaction_history[-1].source, "spec_ops_maintenance")
+
+    def test_asset_outcome_state_persists_after_save_load(self):
+        robot = CombatRobot(id="drone", name="Drone")
+        state = GameState(spec_ops_assets=[robot])
+        state.latest_spec_ops_outcomes = [
+            {"id": "drone", "name": "Drone", "damage": 35, "repair_cost": 70, "cooldown_days": 1}
+        ]
+        robot.maintenance.cooldown_days = 1
+        robot.maintenance.integrity = 65
+
+        with tempfile.NamedTemporaryFile(suffix=".json") as tmp:
+            state.save(tmp.name)
+            restored = GameState.load(tmp.name)
+
+        self.assertEqual(restored.latest_spec_ops_outcomes[0]["damage"], 35)
+        self.assertEqual(restored.spec_ops_assets[0].maintenance.cooldown_days, 1)
+        self.assertEqual(restored.spec_ops_assets[0].maintenance.integrity, 65)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide an explicit, player-facing guide and visible acquisition/deployment flow for spec-ops assets (robots and power armor) so players understand unlocks, upkeep, pilot constraints, and deployment rules.
- Surface deployment state and costs in mission preparation and distinguish assets from agents in the battle HUD to reduce ambiguity during tactical planning.
- Persist post-mission asset outcomes (damage/repair/cooldown) so the base UI and debrief can display concrete consequences and maintenance actions.

### Description
- Added a compact UI helper module `game/ui/screens/spec_ops_assets.py` that builds English guide lines, acquisition flow copy, mission-prep asset state lines (selected assets, slot limits, fuel/ammo projections, maintenance), battle unit labels/hints, and post-mission outcome text helpers.
- Extended the spec-ops asset model in `game/management/spec_ops_assets.py` by adding `cooldown_days`, `fuel_cost_per_deploy`, and `ammo_cost_per_deploy` to `MaintenanceState`, made deployability respect cooldown, and serialized the new fields via `to_dict`/`from_dict`.
- Integrated UI copy/state into `game/views.py`: injection of mission-prep indicators into the insertion info panel, a new `spec_ops` info payload, battle HUD labels/hints (`Support Asset` vs `Agent`) shown in the action bar, and collection of per-asset post-mission outcomes (damage %, repair cost, cooldown) at battle end.
- Persisted and restored post-mission outcomes via a new `latest_spec_ops_outcomes` field on `GameState` and wired it into `save`/`load` handling, plus added a player-facing doc `docs/gameplay/robots_power_armor.md` and backlog update in `docs/backlog.md`.
- Added and updated tests in `tests/test_spec_ops_assets.py` to cover the research unlock path, deployment/pilot eligibility (existing tests maintained), maintenance/payment behavior, and persistence of asset outcomes across save/load.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_spec_ops_assets.py`, which completed successfully with `8 passed`.
- Verified save/load roundtrip for `latest_spec_ops_outcomes` using `GameState.save`/`GameState.load` in tests and confirmed asset maintenance fields persist and restore.
- Exercised the research unlock flow in tests by advancing research via `advance_research_days` and confirmed the expected project completion and categories are present.
- The change is modular and limited to the spec-ops UI helper, asset model fields, view integration, gamestate persistence, docs, and tests to keep scope and maintainability focused.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105219bc88832b85bb5abf700ddd7c)