### PR TITLE
Add persistent Next Step guidance with routed UI actions

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -202,3 +202,5 @@ Automation status:
 [x] Add UI tests for tutorial progression, overlay visibility, and help panel English content
 
 - [x] UI-17 Spec-Ops assets clarity pass: dedicated guide panel module (`game/ui/screens/spec_ops_assets.py`), acquisition/deployment state copy, battle HUD asset labeling, and post-mission outcomes persisted for debrief/base management; plus docs `docs/gameplay/robots_power_armor.md` and coverage updates in `tests/test_spec_ops_assets.py`.
+
+- [done] Add persistent Next Step guidance system with clickable room/screen routing and stalled-state fallback rules.

--- a/game/ui/guidance/next_action.py
+++ b/game/ui/guidance/next_action.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NextActionGuidance:
+    text: str
+    target_screen: str
+    target_room: str
+
+
+def _injured_agents(game_state) -> int:
+    return sum(1 for c in getattr(game_state, "characters", []) if getattr(c, "recovery_turns", 0) > 0)
+
+
+def compute_next_action(game_state, screen: str) -> NextActionGuidance:
+    resources = getattr(game_state, "strategic_resources", {})
+    missions = getattr(game_state, "mission_templates", [])
+    selected = getattr(game_state, "selected_agent_names", [])
+
+    if getattr(game_state, "available_funds", 0) <= 0:
+        return NextActionGuidance("Advance one day to recover emergency funding.", "corp", "executive")
+    if not missions:
+        return NextActionGuidance("Advance one day to generate new mission opportunities.", "city", "records")
+    if _injured_agents(game_state) >= max(1, len(getattr(game_state, "characters", [])) // 2):
+        return NextActionGuidance("Open Medbay and rotate injured agents out of deployment.", "squad", "medbay")
+    if not getattr(game_state, "research_unlock_flags", []):
+        return NextActionGuidance("Start a research project to unlock strategic options.", "corp", "research")
+    if len(selected) < 2:
+        return NextActionGuidance("Select 2 more agents to complete your squad.", "squad", "armory")
+    if int(resources.get("credits", 0)) <= 2 and int(resources.get("intel", 0)) <= 1:
+        return NextActionGuidance("Open Mission Board and choose a low-risk resource mission.", "squad", "ops")
+    if screen == "battle":
+        return NextActionGuidance("Choose a drop zone to begin tactical insertion.", "battle", "maps")
+    return NextActionGuidance("Launch the selected mission to keep initiative.", "squad", "insertion")

--- a/game/ui/room_interaction.py
+++ b/game/ui/room_interaction.py
@@ -211,7 +211,8 @@ def room_at_point(
 
 def actions_for_room(mode: str, room_key: str) -> list[RoomAction]:
     """Return the icon actions available in a room."""
-    return ROOM_ACTIONS.get(mode, {}).get(room_key, [])
+    base_actions = list(ROOM_ACTIONS.get(mode, {}).get(room_key, []))
+    return [RoomAction("next_step", "radar", "Next step"), *base_actions]
 
 
 def layout_action_buttons(

--- a/game/views.py
+++ b/game/views.py
@@ -78,6 +78,7 @@ from .ui.navigation import (
     build_view_focus_model,
 )
 from .management.morale import aggregate_squad_morale
+from .ui.guidance.next_action import compute_next_action
 from .ui.onboarding.tutorial_overlay import overlay_state_for_screen
 from .unit import Unit
 
@@ -344,6 +345,9 @@ class CorpView(GameView):
             else:
                 self.game_state.add_event(push_action(self.notifications, "recruitment", False, "budget pool below 5"))
             return
+        if action_key == "next_step":
+            self._follow_next_step("corp")
+            return
         if action_key.startswith("event_"):
             self._respond_to_first_event(action_key)
             return
@@ -358,6 +362,20 @@ class CorpView(GameView):
         event = self.game_state.active_events[0]
         if 0 <= choice_index < len(event.choices):
             self.game_state.respond_to_event(event.id, event.choices[choice_index].key)
+
+    def _follow_next_step(self, screen: str) -> None:
+        guidance = compute_next_action(self.game_state, screen)
+        if guidance.target_screen == "city":
+            view = CityView(self.game_state)
+            view.setup()
+            self.window.show_view(view)
+            return
+        if guidance.target_screen == "squad":
+            view = RPGView(self.game_state)
+            view.setup()
+            self.window.show_view(view)
+            return
+        open_room(self.room_ui, self.window.width, self.window.height, guidance.target_room)
 
     def _room_info_lines(self) -> dict[str, list[str]]:
         resources = self.game_state.strategic_resources
@@ -423,7 +441,8 @@ class CorpView(GameView):
                         [button.action.label for button in self.room_ui.action_buttons],
                     )[:5]
                 )
-            info[room_key] = _help_lines_for_view(self.game_state, "corp") + hints + lines
+            guidance = compute_next_action(self.game_state, "corp")
+            info[room_key] = [f"Next Step: {guidance.text}"] + _help_lines_for_view(self.game_state, "corp") + hints + lines
         return info
 
 
@@ -546,6 +565,9 @@ class CityView(GameView):
         if action_key == "advance_day":
             self.game_state.advance_one_day("manual command")
             return
+        if action_key == "next_step":
+            self._follow_next_step("city")
+            return
         if action_key.startswith("event_"):
             self._respond_to_first_event(action_key)
             return
@@ -560,6 +582,20 @@ class CityView(GameView):
         event = self.game_state.active_events[0]
         if 0 <= choice_index < len(event.choices):
             self.game_state.respond_to_event(event.id, event.choices[choice_index].key)
+
+    def _follow_next_step(self, screen: str) -> None:
+        guidance = compute_next_action(self.game_state, screen)
+        if guidance.target_screen == "corp":
+            view = CorpView(self.game_state)
+            view.setup()
+            self.window.show_view(view)
+            return
+        if guidance.target_screen == "squad":
+            view = RPGView(self.game_state)
+            view.setup()
+            self.window.show_view(view)
+            return
+        open_room(self.room_ui, self.window.width, self.window.height, guidance.target_room)
 
     def _room_info_lines(self) -> dict[str, list[str]]:
         resources = self.game_state.strategic_resources
@@ -628,7 +664,8 @@ class CityView(GameView):
                         [button.action.label for button in self.room_ui.action_buttons],
                     )[:5]
                 )
-            info[room_key] = _help_lines_for_view(self.game_state, "city") + hints + lines
+            guidance = compute_next_action(self.game_state, "city")
+            info[room_key] = [f"Next Step: {guidance.text}"] + _help_lines_for_view(self.game_state, "city") + hints + lines
         return info
 
 
@@ -994,6 +1031,9 @@ class RPGView(GameView):
             self.game_state.play_ui_audio_feedback("toggle")
             self._refresh_squad_room_actions()
             return
+        if action_key == "next_step":
+            self._follow_next_step("squad")
+            return
         if action_key.startswith("equip_"):
             self._equip_active_agent(action_key.removeprefix("equip_"))
             self._refresh_squad_room_actions()
@@ -1010,6 +1050,21 @@ class RPGView(GameView):
             return None
         self.deployment_cursor_index %= len(self.game_state.characters)
         return self.game_state.characters[self.deployment_cursor_index]
+
+    def _follow_next_step(self, screen: str) -> None:
+        guidance = compute_next_action(self.game_state, screen)
+        if guidance.target_screen == "corp":
+            view = CorpView(self.game_state)
+            view.setup()
+            self.window.show_view(view)
+            return
+        if guidance.target_screen == "city":
+            view = CityView(self.game_state)
+            view.setup()
+            self.window.show_view(view)
+            return
+        open_room(self.room_ui, self.window.width, self.window.height, guidance.target_room)
+        self._refresh_squad_room_actions()
 
     def _refresh_squad_room_actions(self) -> None:
         room_key = self.room_ui.active_room_key
@@ -1223,7 +1278,8 @@ class RPGView(GameView):
                         [button.action.label for button in self.room_ui.action_buttons],
                     )[:6]
                 )
-            info[room_key] = _help_lines_for_view(self.game_state, "squad") + hints + lines
+            guidance = compute_next_action(self.game_state, "squad")
+            info[room_key] = [f"Next Step: {guidance.text}"] + _help_lines_for_view(self.game_state, "squad") + hints + lines
         return info
 
 
@@ -1898,7 +1954,8 @@ class BattleView(GameView):
                 "Uplink returns to corporate command after combat.",
             ],
         }
-        help_lines = _help_lines_for_view(self.game_state, "battle")
+        guidance = compute_next_action(self.game_state, "battle")
+        help_lines = [f"Next Step: {guidance.text}"] + _help_lines_for_view(self.game_state, "battle")
         return {key: help_lines + value for key, value in base.items()}
 
     def check_active_player(self):

--- a/tests/test_next_action_guidance.py
+++ b/tests/test_next_action_guidance.py
@@ -1,0 +1,28 @@
+import unittest
+
+from game.gamestate import GameState
+from game.ui.guidance.next_action import compute_next_action
+
+
+class NextActionGuidanceTest(unittest.TestCase):
+    def test_guidance_never_empty(self):
+        gs = GameState()
+        for screen in ("corp", "city", "squad", "battle"):
+            guidance = compute_next_action(gs, screen)
+            self.assertTrue(guidance.text.strip())
+            self.assertTrue(guidance.target_screen.strip())
+            self.assertTrue(guidance.target_room.strip())
+
+    def test_guidance_changes_when_state_changes(self):
+        gs = GameState()
+        first = compute_next_action(gs, "squad").text
+        gs.research_unlock_flags.append("starter_unlock")
+        gs.selected_agent_names = ["A", "B"]
+        gs.strategic_resources["credits"] = 20
+        gs.strategic_resources["intel"] = 3
+        second = compute_next_action(gs, "squad").text
+        self.assertNotEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_room_interaction_ui.py
+++ b/tests/test_room_interaction_ui.py
@@ -43,7 +43,7 @@ class RoomInteractionUITest(unittest.TestCase):
 
         action = action_at_point(buttons, first.rect.center_x, first.rect.center_y)
 
-        self.assertEqual(action.key, "mission_prev")
+        self.assertEqual(action.key, "next_step")
 
     def test_room_animation_opens_and_closes_without_text_state(self):
         state = RoomUIState("city")


### PR DESCRIPTION
### Motivation
- Provide players a persistent, actionable “Next Step” hint across major screens to reduce stalled states and improve emergent storytelling and emotional attachment. 
- Centralize small, readable guidance logic so the UI can display a single imperative instruction and route the player to the relevant room or screen. 
- Offer safe fallbacks for common stalled conditions (no funds, no missions, injured squad, missing unlocks, low resources) without adding large new systems. 
- Keep changes modular and testable with separated guidance logic and small UI wiring edits.

### Description
- Added a new guidance module `game/ui/guidance/next_action.py` exposing `compute_next_action(game_state, screen)` returning a `NextActionGuidance` dataclass with text and routing targets. 
- Integrated the guidance into Corp/City/Squad/Battle info payloads so each room’s info lines now prepend a `Next Step: ...` line. 
- Introduced a universal `next_step` room action by prepending it to room action lists and wired handlers in Corp/City/Squad views to open target rooms or switch views when the action is triggered. 
- Implemented lightweight stalled-state rules (low funds, no missions, many injured agents, missing research unlocks, low credits/intel) and kept logic compact and centralized. 
- Updated `docs/backlog.md` and added unit tests in `tests/test_next_action_guidance.py` and adapted `tests/test_room_interaction_ui.py` to reflect the new action ordering.

### Testing
- Ensured the modified modules compile with `python -m py_compile game/views.py game/ui/guidance/next_action.py game/ui/room_interaction.py` which succeeded. 
- Ran the focused test suite with `PYTHONPATH=. pytest -q tests/test_next_action_guidance.py tests/test_room_interaction_ui.py` and the tests passed. 
- The guidance tests verify guidance never returns empty text and that guidance text changes when `GameState` is mutated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105358dacc832bbbf5bfd128775a9f)