### PR TITLE
Show all available research branches in lab tree

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -31,6 +31,7 @@ Status vocabulary: `not started`, `in progress`, `functional`, `polished`.
 - [x] UI-22 Refresh title-screen background art: swapped the start screen to a new widescreen corporate skyline image with a cleaner center frame for the logo and menu, keeping the same cyberpunk tower mood as the rest of the game. (completed May 23, 2026)
 - [x] UI-23 Research UI tree presentation: research lab summary now renders available projects as a compact dependency tree (roots + child branches) so players can read progression paths at a glance; kept button actions unchanged and covered by research UI tests. (completed May 23, 2026)
 - [x] UI-24 Fix research tree state visibility: research lab now renders a compact stateful tree showing completed (✓), active (▶), and currently available (○) projects so selecting research immediately reveals prior and next branch context; added regression coverage in research management tests. (completed May 23, 2026)
+- [x] UI-25 Show all available research branches: removed research-lab tree clipping so the panel no longer collapses with an ellipsis and now lists every currently available branch line; added regression coverage. (completed May 23, 2026)
 TODO:
 
 - [x] RESEARCH-03 3X-style branching research trees + power-armor pilot replacement in mission manifests: piloted agents are hidden from mission roster and represented by the suit unit; expanded compact research branches (weapons/armor/equipment/robots/power-armor/vehicles/psy) with corp budget and advanced gear progression; tests and gameplay doc updated. (completed May 23, 2026)

--- a/game/ui/screens/research_lab.py
+++ b/game/ui/screens/research_lab.py
@@ -13,7 +13,6 @@ def _build_research_tree_lines(
     tree: ResearchTree,
     completed: set[str],
     active_ids: set[str],
-    max_lines: int = 8,
 ) -> list[str]:
     """Render completed and currently available projects in one compact tree."""
     available_projects = tree.available_projects(completed, active_ids)
@@ -49,10 +48,6 @@ def _build_research_tree_lines(
             if child.id in completed or child.id in available_ids or child.id in active_ids:
                 lines.append(f"  └─ {_status_prefix(child)} {_project_label(child)}")
 
-    if len(lines) > max_lines:
-        clipped = lines[: max_lines - 1]
-        clipped.append("  …more branches available")
-        return clipped
     return lines
 
 
@@ -79,7 +74,7 @@ def build_research_lab_lines(
     else:
         lines.append("No active project. Choose a starter study.")
 
-    lines.extend(_build_research_tree_lines(tree, completed, active_ids, max_lines=9 - len(lines)))
+    lines.extend(_build_research_tree_lines(tree, completed, active_ids))
 
     if completed:
         lines.append(
@@ -87,4 +82,4 @@ def build_research_lab_lines(
         )
     else:
         lines.append("Completed: none")
-    return lines[:9]
+    return lines

--- a/tests/test_research_management.py
+++ b/tests/test_research_management.py
@@ -106,6 +106,15 @@ class ResearchManagementTest(unittest.TestCase):
         self.assertIn("start_research_0", actions)
         self.assertIn("start_research_1", actions)
 
+
+    def test_research_lab_ui_displays_all_available_branches_without_ellipsis(self):
+        game_state = GameState()
+
+        lines = build_research_lab_lines(game_state)
+
+        self.assertFalse(any("…more branches available" in line for line in lines))
+        self.assertGreaterEqual(len(lines), 10)
+
     def test_research_lab_ui_shows_completed_and_available_tree_states(self):
         game_state = GameState()
         starter = game_state.research_tree.project("weapon_smartlink_mk1")


### PR DESCRIPTION
### Motivation
- Players should see every currently available research branch in the Research Lab without hidden lines or an ellipsis so progression is fully discoverable. 
- Keep the Research Lab text output aligned with the compact dependency view while removing an arbitrary visual clipping limit. 

### Description
- Removed the tree-clipping logic and the `max_lines` parameter so `_build_research_tree_lines` no longer truncates lines or inserts `…more branches available`. 
- Stopped slicing the final `lines` list in `build_research_lab_lines`, allowing the lab panel to return all generated branch lines. 
- Added a regression test `test_research_lab_ui_displays_all_available_branches_without_ellipsis` in `tests/test_research_management.py` to assert the ellipsis is not present and that output is expanded. 
- Updated `docs/backlog.md` with a completed `UI-25` entry describing the change. 

### Testing
- Ran the targeted test suite with `PYTHONPATH=. pytest -q tests/test_research_management.py` and the run passed: `10 passed`.
- The new regression test was included in that run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11d5dbc728832ba375b2b5500fbf40)