### PR TITLE
Add compact FR/EN i18n layer for mission and narrative UI

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -217,3 +217,5 @@ Automation status:
 - [x] UI-17 Spec-Ops assets clarity pass: dedicated guide panel module (`game/ui/screens/spec_ops_assets.py`), acquisition/deployment state copy, battle HUD asset labeling, and post-mission outcomes persisted for debrief/base management; plus docs `docs/gameplay/robots_power_armor.md` and coverage updates in `tests/test_spec_ops_assets.py`.
 
 - [done] Add persistent Next Step guidance system with clickable room/screen routing and stalled-state fallback rules.
+
+- [x] UI-26 Internationalisation compacte (FR/EN): nouveau sous-répertoire `game/i18n/` (`fr.py`, `en.py`, helper `t()`), extraction des chaînes visibles mission/feed/impact, `GameState.ui_language` avec fallback stable, et tests de non-régression pour fallback de clés + rendu mission impact/feed. (completed May 24, 2026)

--- a/game/gamestate.py
+++ b/game/gamestate.py
@@ -121,6 +121,7 @@ class GameState:
     unavailable_mission_ids: list[str] = field(default_factory=list)
     ui_high_contrast: bool = False
     ui_audio_feedback_enabled: bool = False
+    ui_language: str = "fr"
     tutorial_progress: dict = field(
         default_factory=lambda: {
             "tutorial_step_index": 0,
@@ -146,6 +147,9 @@ class GameState:
     research_stat_modifiers: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        from .i18n import normalize_language
+
+        self.ui_language = normalize_language(self.ui_language)
         if not self.budget_pool:
             self.budget_pool = self.compute_budget()
         if self.funds.available_funds <= 0 and not self.funds.transaction_history:

--- a/game/i18n/__init__.py
+++ b/game/i18n/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .en import STRINGS as EN_STRINGS
+from .fr import STRINGS as FR_STRINGS
+
+_DICTIONARIES = {"fr": FR_STRINGS, "en": EN_STRINGS}
+DEFAULT_LANGUAGE = "fr"
+
+
+def normalize_language(language: str | None) -> str:
+    if language in _DICTIONARIES:
+        return str(language)
+    return DEFAULT_LANGUAGE
+
+
+def t(key: str, language: str | None = None, **kwargs) -> str:
+    lang = normalize_language(language)
+    table = _DICTIONARIES[lang]
+    fallback_table = _DICTIONARIES[DEFAULT_LANGUAGE]
+    template = table.get(key, fallback_table.get(key, key))
+    return template.format(**kwargs) if kwargs else template

--- a/game/i18n/en.py
+++ b/game/i18n/en.py
@@ -1,0 +1,17 @@
+STRINGS = {
+    "mission.impact.critical": "Risk of lasting emotional scars for the squad.",
+    "mission.impact.high": "Mission likely to carry a heavy emotional burden.",
+    "mission.impact.medium": "Notable human tension, plan post-mission support.",
+    "mission.impact.low": "Human impact stays contained with disciplined execution.",
+    "mission.impact.risk_explanation": "Risk {risk}/5, duration {duration}d, {complications} likely complication(s).",
+    "mission.board.day_suffix": "[Day {day}]",
+    "ui.impact.neutral": "Expected human impact: limited intel, keep vigilance high.",
+    "ui.impact.prefix": "Expected human impact ({level}): {text}",
+    "ui.impact.level.low": "low",
+    "ui.impact.level.medium": "moderate",
+    "ui.impact.level.high": "high",
+    "ui.impact.level.critical": "critical",
+    "feed.just_now": "just now",
+    "feed.one_ago": "1 tick ago",
+    "feed.many_ago": "{count} ticks ago",
+}

--- a/game/i18n/fr.py
+++ b/game/i18n/fr.py
@@ -1,0 +1,17 @@
+STRINGS = {
+    "mission.impact.critical": "Risque de séquelles émotionnelles durables pour l'escouade.",
+    "mission.impact.high": "Mission susceptible de laisser une forte charge émotionnelle.",
+    "mission.impact.medium": "Tension humaine notable, prévoir du soutien post-mission.",
+    "mission.impact.low": "Impact humain contenu si l'exécution reste disciplinée.",
+    "mission.impact.risk_explanation": "Risque {risk}/5, durée {duration}j, {complications} complication(s) probable(s).",
+    "mission.board.day_suffix": "[Jour {day}]",
+    "ui.impact.neutral": "Impact humain attendu: informations limitées, vigilance recommandée.",
+    "ui.impact.prefix": "Impact humain attendu ({level}): {text}",
+    "ui.impact.level.low": "faible",
+    "ui.impact.level.medium": "modéré",
+    "ui.impact.level.high": "élevé",
+    "ui.impact.level.critical": "critique",
+    "feed.just_now": "à l'instant",
+    "feed.one_ago": "il y a 1 instant",
+    "feed.many_ago": "il y a {count} instants",
+}

--- a/game/mission_generation.py
+++ b/game/mission_generation.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .gamestate import GameState
+from .i18n import t
 from .mission_templates import MissionTemplate, create_mission_templates
 from .missions.complications import select_complications
 from .missions.evacuation import create_evacuation_template
@@ -27,7 +28,7 @@ def _mission_seed(game_state: "GameState") -> int:
 
 
 
-def _build_emotional_impact_hint(mission: MissionTemplate) -> dict:
+def _build_emotional_impact_hint(mission: MissionTemplate, language: str | None = None) -> dict:
     """Estimate emotional impact based on objective pressure, risk, duration, and complications."""
     objective_weight = {
         "safe_extraction": 2,
@@ -46,20 +47,23 @@ def _build_emotional_impact_hint(mission: MissionTemplate) -> dict:
     )
     if score >= 8:
         level = "critical"
-        text = "Risque de séquelles émotionnelles durables pour l'escouade."
+        text = t("mission.impact.critical", language)
     elif score >= 6:
         level = "high"
-        text = "Mission susceptible de laisser une forte charge émotionnelle."
+        text = t("mission.impact.high", language)
     elif score >= 4:
         level = "medium"
-        text = "Tension humaine notable, prévoir du soutien post-mission."
+        text = t("mission.impact.medium", language)
     else:
         level = "low"
-        text = "Impact humain contenu si l'exécution reste disciplinée."
+        text = t("mission.impact.low", language)
     short_text = build_short_emotional_impact(level, text)
-    risk_explanation = (
-        f"Risque {mission.risk_level}/5, durée {mission.duration_days}j, "
-        f"{len(mission.possible_complications)} complication(s) probable(s)."
+    risk_explanation = t(
+        "mission.impact.risk_explanation",
+        language,
+        risk=mission.risk_level,
+        duration=mission.duration_days,
+        complications=len(mission.possible_complications),
     )
     return {
         "level": level,
@@ -95,7 +99,7 @@ def generate_mission_board(game_state: "GameState", board_size: int = 3) -> list
         mission.fund_reward = max(20, mission.fund_reward + mission.risk_level * 5)
         mission.starting_enemy_count = max(1, mission.starting_enemy_count + max(0, risk_delta))
         mission.id = f"{mission.id}_d{game_state.calendar.current_day}_s{slot}"
-        mission.title = f"{mission.title} [Day {game_state.calendar.current_day}]"
+        mission.title = f"{mission.title} {t('mission.board.day_suffix', game_state.ui_language, day=game_state.calendar.current_day)}"
         mission_tag_names = [tag.name for tag in mission.tags]
         mission.possible_complications.extend(
             select_complications(
@@ -105,7 +109,7 @@ def generate_mission_board(game_state: "GameState", board_size: int = 3) -> list
             )
         )
         mission.possible_complications = mission.possible_complications[:2]
-        mission.emotional_impact_hint = _build_emotional_impact_hint(mission)
+        mission.emotional_impact_hint = _build_emotional_impact_hint(mission, game_state.ui_language)
         mission.emotional_impact_hint["normalized_tags"] = normalize_mission_tags(mission.tags)
         generated.append(mission)
 

--- a/game/ui/widgets/mission_impact_summary.py
+++ b/game/ui/widgets/mission_impact_summary.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
+from ...i18n import t
 from ..accessibility.states import label_with_non_color_indicator
 
-NEUTRAL_IMPACT_TEXT = "Impact humain attendu: informations limitées, vigilance recommandée."
-IMPACT_LEVEL_LABELS = {
-    "low": "faible",
-    "medium": "modéré",
-    "high": "élevé",
-    "critical": "critique",
-}
+NEUTRAL_IMPACT_TEXT = t("ui.impact.neutral")
+
 
 
 def _tag_names(tagged_items: list[object], empty: str = "none") -> str:
@@ -18,22 +14,22 @@ def _tag_names(tagged_items: list[object], empty: str = "none") -> str:
     return ", ".join(names) if names else empty
 
 
-def impact_hint_text(emotional_impact_hint: dict | None) -> str:
+def impact_hint_text(emotional_impact_hint: dict | None, language: str | None = None) -> str:
     """Return a readable impact hint with fallback for missing/invalid payload."""
     if not emotional_impact_hint:
-        return NEUTRAL_IMPACT_TEXT
+        return t("ui.impact.neutral", language)
 
     level = str(emotional_impact_hint.get("level", "")).lower()
     text = str(emotional_impact_hint.get("text", "")).strip()
-    if level not in IMPACT_LEVEL_LABELS or not text:
-        return NEUTRAL_IMPACT_TEXT
-    return f"Impact humain attendu ({IMPACT_LEVEL_LABELS[level]}): {text}"
+    if level not in {"low", "medium", "high", "critical"} or not text:
+        return t("ui.impact.neutral", language)
+    return t("ui.impact.prefix", language, level=t(f"ui.impact.level.{level}", language), text=text)
 
 
-def build_mission_impact_summary_lines(mission: object) -> list[str]:
+def build_mission_impact_summary_lines(mission: object, language: str | None = None) -> list[str]:
     """Build ordered mission impact lines: operational tags first, then human hint."""
     tags = _tag_names(getattr(mission, "tags", []))
-    hint = impact_hint_text(getattr(mission, "emotional_impact_hint", None))
+    hint = impact_hint_text(getattr(mission, "emotional_impact_hint", None), language)
     return [
         label_with_non_color_indicator(f"Tags opérationnels: {tags}", "normal"),
         label_with_non_color_indicator(hint, "focus"),

--- a/game/ui/widgets/narrative/feed_item.py
+++ b/game/ui/widgets/narrative/feed_item.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ....i18n import t
 from ....narrative.event_feed import NarrativeFeedEntry
 from ...accessibility.states import label_with_non_color_indicator
 
@@ -43,20 +44,20 @@ class NarrativeFeedWidgetLine:
     tone: str = "tense"
 
 
-def readable_relative_timestamp(age_steps: int) -> str:
+def readable_relative_timestamp(age_steps: int, language: str | None = None) -> str:
     if age_steps <= 0:
-        return "à l'instant"
+        return t("feed.just_now", language)
     if age_steps == 1:
-        return "il y a 1 instant"
-    return f"il y a {age_steps} instants"
+        return t("feed.one_ago", language)
+    return t("feed.many_ago", language, count=age_steps)
 
 
-def to_widget_line(entry: NarrativeFeedEntry, age_steps: int, clip: int = 120) -> NarrativeFeedWidgetLine:
+def to_widget_line(entry: NarrativeFeedEntry, age_steps: int, clip: int = 120, language: str | None = None) -> NarrativeFeedWidgetLine:
     category = entry.category if entry.category in _CATEGORY_LABELS else "base"
     icon = _CATEGORY_ICONS[category]
     label = _CATEGORY_LABELS[category]
     tone = _TONE_BY_CATEGORY.get(category, "tense")
-    rel_time = readable_relative_timestamp(age_steps)
+    rel_time = readable_relative_timestamp(age_steps, language)
     body = entry.text.strip()
     if len(body) > clip:
         body = body[: clip - 1].rstrip() + "…"

--- a/tests/test_i18n_mission_feed.py
+++ b/tests/test_i18n_mission_feed.py
@@ -1,0 +1,35 @@
+from game.i18n import t
+from game.mission_generation import _build_emotional_impact_hint
+from game.mission_templates import MissionTemplate
+from game.ui.widgets.mission_impact_summary import impact_hint_text
+from game.ui.widgets.narrative.feed_item import readable_relative_timestamp
+
+
+def test_i18n_fallback_missing_key_returns_key():
+    assert t("missing.key", "en") == "missing.key"
+
+
+def test_mission_impact_rendering_is_consistent_for_language():
+    mission = MissionTemplate(
+        id="m1",
+        title="Test",
+        objective_text="Brief",
+        target_faction="corp",
+        district="Neo",
+        objective_type="extract",
+        risk_level=4,
+        district_pressure={},
+        fund_reward=10,
+        duration_days=2,
+        starting_enemy_count=2,
+        tags=[],
+        possible_complications=["a"],
+    )
+    hint = _build_emotional_impact_hint(mission, "en")
+    rendered = impact_hint_text(hint, "en")
+    assert "Expected human impact" in rendered
+    assert "high" in rendered or "critical" in rendered
+
+
+def test_feed_timestamp_translation():
+    assert readable_relative_timestamp(0, "en") == "just now"


### PR DESCRIPTION
### Motivation
- Provide a minimal, maintainable localization layer for the most visible narrative UI (mission impact cards and the narrative feed) without a large architecture change. 
- Centralize player-facing copy behind a single helper to avoid scattered hardcoded strings and to ensure stable fallback behavior.

### Description
- Add a new `game/i18n/` package with `fr.py`, `en.py` string tables and a single `t(key, language, **kwargs)` helper plus `normalize_language` + `DEFAULT_LANGUAGE` fallback (`fr`).
- Add `ui_language` to `GameState` and normalize it in `__post_init__` so UI modules can read the selected language from game state.
- Replace hardcoded mission strings and day suffix in `game/mission_generation.py` with calls to `t(...)` and thread the `language` into emotional-impact construction.
- Route mission impact rendering and narrative feed timestamps through `t(...)` by updating `game/ui/widgets/mission_impact_summary.py` and `game/ui/widgets/narrative/feed_item.py` to accept an optional `language` param.
- Add a small regression test `tests/test_i18n_mission_feed.py` and update `docs/backlog.md` to mark the UI-26 item done.

### Testing
- Ran collection and unit runs via `PYTHONPATH=. pytest -q tests/test_i18n_mission_feed.py tests/ui/test_narrative_feed_panel.py tests/ui/test_mission_impact_summary.py` to exercise the new code paths.
- Initial test collection failed when `PYTHONPATH` was not set, then the focused test run passed successfully.
- Final automated test result: `PYTHONPATH=. pytest -q ...` completed with all tests passing (10 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13236c9180832b8eedc3dfbad591bb)