### PR TITLE
Add squad downtime menu and activity system

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -235,3 +235,5 @@ Automation status:
 - [x] Agent naming cleanup: placeholder labels like `Agent 1` now normalize to role codenames on creation/load, and the recruit chooser sits above the lower HUD controls instead of overlapping them.
 - [x] Roster management: added squad-room agent removal from the roster, with selection cleanup and regression coverage.
 
+
+- [x] Squad management: add Downtime menu (activities consume day/resources and affect morale/stress/traits).

--- a/docs/gameplay/playable_loop.md
+++ b/docs/gameplay/playable_loop.md
@@ -18,3 +18,8 @@ CyberCity2085 playable loop must always follow this chain:
 ## Design decision
 
 This loop keeps **agents as the emotional core** while preserving a compact modular structure: each stage changes persistent state and leaves readable traces in logs/UI.
+
+## Downtime (Squad / Management)
+- New downtime menu in Squad view with three activities.
+- Each activity spends 1 day + strategic resource, then updates selected agents' stress, morale (loyalty proxy), and traits.
+- Shortcuts: keys 7/8/9.

--- a/game/management/downtime.py
+++ b/game/management/downtime.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from game.character import Character
+from game.gamestate import GameState
+
+
+@dataclass(frozen=True)
+class DowntimeActivity:
+    key: str
+    label: str
+    days_cost: int
+    resource_key: str
+    resource_cost: int
+    morale_delta: int
+    stress_delta: int
+    add_trait: str | None = None
+
+
+DOWNTIME_ACTIVITIES: tuple[DowntimeActivity, ...] = (
+    DowntimeActivity(
+        key="shore_leave",
+        label="Shore Leave",
+        days_cost=1,
+        resource_key="credits",
+        resource_cost=8,
+        morale_delta=10,
+        stress_delta=-12,
+        add_trait="grounded",
+    ),
+    DowntimeActivity(
+        key="sim_drills",
+        label="Sim Drills",
+        days_cost=1,
+        resource_key="intel",
+        resource_cost=2,
+        morale_delta=4,
+        stress_delta=6,
+        add_trait="disciplined",
+    ),
+    DowntimeActivity(
+        key="group_therapy",
+        label="Group Therapy",
+        days_cost=1,
+        resource_key="influence",
+        resource_cost=1,
+        morale_delta=6,
+        stress_delta=-18,
+        add_trait="vulnerable",
+    ),
+)
+
+
+def can_run_activity(gs: GameState, activity: DowntimeActivity) -> bool:
+    return gs.strategic_resources.get(activity.resource_key, 0) >= activity.resource_cost
+
+
+def apply_activity(gs: GameState, activity: DowntimeActivity, squad: list[Character]) -> str:
+    if not squad:
+        return "Select at least one agent for downtime."
+    if not can_run_activity(gs, activity):
+        return f"Not enough {activity.resource_key} for {activity.label}."
+
+    gs.strategic_resources[activity.resource_key] -= activity.resource_cost
+    for _ in range(activity.days_cost):
+        gs.advance_days(1, reason=f"downtime:{activity.key}")
+
+    for agent in squad:
+        agent.stress = max(0, min(100, agent.stress + activity.stress_delta))
+        agent.loyalty = max(-100, min(100, agent.loyalty + activity.morale_delta))
+        if activity.add_trait and activity.add_trait not in agent.traits:
+            agent.traits.append(activity.add_trait)
+
+    return (
+        f"Downtime: {activity.label} (-{activity.resource_cost} {activity.resource_key}, "
+        f"{activity.days_cost} day)"
+    )

--- a/game/ui/screens/management_screen.py
+++ b/game/ui/screens/management_screen.py
@@ -49,6 +49,7 @@ from game.agent_specializations import (
 )
 from game.recruitment import build_recruitment_candidates, recruit_agent
 from game.management.morale import aggregate_squad_morale
+from game.management.downtime import DOWNTIME_ACTIVITIES, apply_activity
 from game.ui import GameView
 from game.ui import palette
 from game.ui.action_feedback import push_action
@@ -343,6 +344,9 @@ class ManagementView(GameView):
                     self.deployment_cursor,
                 )
                 self.pending_launch_confirm = False
+            elif key in (arcade.key.KEY_7, arcade.key.KEY_8, arcade.key.KEY_9):
+                idx = key - arcade.key.KEY_7
+                self._do_downtime_activity(idx)
             elif key in (arcade.key.KEY_1, arcade.key.KEY_2, arcade.key.KEY_3):
                 idx = key - arcade.key.KEY_1
                 if idx < len(self.game_state.mission_templates):
@@ -1537,6 +1541,29 @@ class ManagementView(GameView):
         )
         self._hits.append(_HitRegion(x0 + 10, lb, x1 - 10, lt, "launch_mission", None))
 
+        # Downtime menu
+        dt_top = lb - 10
+        dt_bottom = max(y0 + 84, dt_top - 108)
+        _rect(x0 + 10, dt_bottom, x1 - 10, dt_top, (10, 20, 28, 220))
+        arcade.draw_line(x0 + 10, dt_top, x1 - 10, dt_top, palette.ACCENT, 2)
+        arcade.draw_text("DOWNTIME [7-9]", x0 + 18, dt_top - 16, palette.ACCENT, font_size=10, bold=True)
+        by = dt_top - 42
+        for idx, activity in enumerate(DOWNTIME_ACTIVITIES):
+            row_h = 26
+            row_top = by - idx * (row_h + 6)
+            row_bottom = row_top - row_h
+            if row_bottom <= dt_bottom + 4:
+                break
+            _rect(x0 + 14, row_bottom, x1 - 14, row_top, (8, 16, 22, 210))
+            arcade.draw_text(
+                f"{idx + 7}. {activity.label}", x0 + 20, row_top - 16, palette.TEXT, font_size=10, bold=True
+            )
+            arcade.draw_text(
+                f"-{activity.days_cost}d  -{activity.resource_cost} {activity.resource_key}  morale {activity.morale_delta:+}  stress {activity.stress_delta:+}",
+                x0 + 180, row_top - 16, palette.MUTED_TEXT, font_size=9,
+            )
+            self._hits.append(_HitRegion(x0 + 14, row_bottom, x1 - 14, row_top, "downtime_activity", idx))
+
         # Message display
         if self.message:
             arcade.draw_text(
@@ -1765,6 +1792,10 @@ class ManagementView(GameView):
             self._do_launch_mission()
             return
 
+        if action == "downtime_activity":
+            self._do_downtime_activity(int(data))
+            return
+
         if action == "recruit_prompt":
             self._do_recruit_prompt()
             return
@@ -1905,6 +1936,16 @@ class ManagementView(GameView):
         event = events[event_index]
         if 0 <= choice_index < len(event.choices):
             self.game_state.respond_to_event(event.id, event.choices[choice_index].key)
+
+    def _do_downtime_activity(self, activity_index: int) -> None:
+        gs = self.game_state
+        if activity_index < 0 or activity_index >= len(DOWNTIME_ACTIVITIES):
+            return
+        activity = DOWNTIME_ACTIVITIES[activity_index]
+        squad = selected_deployable_agents(gs.characters, gs.selected_agent_names)
+        result = apply_activity(gs, activity, squad)
+        self.message = result
+        gs.add_event(result)
 
     def _do_recruit_prompt(self) -> None:
         """Open the recruit chooser with a small list of named agents."""

--- a/tests/test_downtime_management.py
+++ b/tests/test_downtime_management.py
@@ -1,0 +1,29 @@
+from game.character import Character
+from game.gamestate import GameState
+from game.management.downtime import DOWNTIME_ACTIVITIES, apply_activity
+
+
+def test_downtime_consumes_day_resource_and_updates_agent_state():
+    gs = GameState(characters=[Character(name="Nova")])
+    gs.selected_agent_names = ["Nova"]
+    gs.strategic_resources["credits"] = 20
+    activity = DOWNTIME_ACTIVITIES[0]
+
+    before_day = gs.calendar.current_day
+    result = apply_activity(gs, activity, gs.characters)
+
+    assert "Downtime" in result
+    assert gs.calendar.current_day == before_day + 1
+    assert gs.strategic_resources["credits"] == 12
+    assert gs.characters[0].stress == 0
+    assert gs.characters[0].loyalty == 10
+    assert "grounded" in gs.characters[0].traits
+
+
+def test_downtime_blocks_when_resource_missing():
+    gs = GameState(characters=[Character(name="Iris")])
+    gs.strategic_resources["influence"] = 0
+
+    msg = apply_activity(gs, DOWNTIME_ACTIVITIES[2], gs.characters)
+
+    assert "Not enough influence" in msg


### PR DESCRIPTION
### Motivation
- Provide a small, emotionally meaningful squad-management interaction that spends strategic time/resources and affects agents' morale/stress/traits. 
- Keep the feature modular and lightweight so it fits the existing management loop and is easy to extend.

### Description
- Add a dedicated downtime model and logic in `game/management/downtime.py` defining `DowntimeActivity`, `DOWNTIME_ACTIVITIES`, `apply_activity`, and `can_run_activity` for centralized behavior. 
- Wire the downtime system into the squad UI in `game/ui/screens/management_screen.py` by importing the module, rendering a `DOWNTIME [7-9]` menu, adding clickable hit regions, and adding keyboard shortcuts `7/8/9` that call a new `_do_downtime_activity` handler which applies the activity to `selected_deployable_agents`. 
- Add unit tests in `tests/test_downtime_management.py` to cover successful application (day/resource consumed and agent state updated) and blocked behavior when resources are insufficient. 
- Update documentation/backlog entries in `docs/backlog.md` and `docs/gameplay/playable_loop.md` to record the new downtime loop and controls.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_downtime_management.py` and the suite passed: `2 passed`.
- Basic UI integration exercised by rendering/menu wiring (keyboard + clickable hit regions) covered by the new handler and hit-region registrations compiled during local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144c51f86c832bbfcc959ebf35d5b1)