### PR TITLE
Add modular agent sheet schema and legacy save backfill

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,8 @@
 
 ## Gameplay systems explicit status
 
+- [x] AGENT-06 Agent sheet schema defaults: added modular `game/agents/sheet_schema.py` with typed attributes/skills/derived-stat builders, wired defaults into recruitment/character constructors, and backfilled legacy save payloads during `Character.from_dict`; added regression tests for default creation + migration safety. (completed May 26, 2026)
+
 - [x] UI-34 Guard invalid rectangle draw bounds in squad mission panel: `_rect` now skips impossible LRBT coordinates (`left >= right` or `bottom >= top`) to avoid `arcade.draw_lrbt_rectangle_filled` runtime crashes during dynamic panel layout compression, with a focused regression test in management hub UI tests. (completed May 25, 2026)
 
 - [x] UI-33 Action aftermath HUD slot: ajout d'une ligne temporaire causale après move/skill/tir (`DMG`, `STATUT`, `SUPPRESSION`) affichée dans une zone fixe du HUD pour éviter le clutter visuel, avec timer court et tests dédiés. (completed May 25, 2026)

--- a/game/agents/__init__.py
+++ b/game/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent schema helpers and defaults."""
+
+from .sheet_schema import AgentSheet, normalize_agent_sheet, default_agent_sheet
+
+__all__ = ["AgentSheet", "normalize_agent_sheet", "default_agent_sheet"]

--- a/game/agents/sheet_schema.py
+++ b/game/agents/sheet_schema.py
@@ -1,0 +1,104 @@
+"""Typed schema helpers for agent sheet payloads.
+
+Keeps recruitment/new-character creation and save migration aligned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from game.stats import PlayerStats
+
+SKILL_MIN_RANK = 0
+SKILL_MAX_RANK = 10
+
+
+@dataclass
+class AgentSheet:
+    attributes: dict[str, int] = field(default_factory=dict)
+    skills: dict[str, int] = field(default_factory=dict)
+    derived_stats: dict[str, int] = field(default_factory=dict)
+
+
+def _clamp_rank(value: Any) -> int:
+    rank = int(value) if isinstance(value, (int, float)) else SKILL_MIN_RANK
+    return max(SKILL_MIN_RANK, min(SKILL_MAX_RANK, rank))
+
+
+def build_default_attributes(stats: PlayerStats | None = None) -> dict[str, int]:
+    base = stats or PlayerStats()
+    return {
+        "level": int(base.level),
+        "str": int(base.str),
+        "agi": int(base.agi),
+        "con": int(base.con),
+        "cha": int(base.cha),
+        "psi": int(base.psi),
+        "defense": int(base.defense),
+    }
+
+
+def build_default_skills() -> dict[str, int]:
+    return {
+        "firearms": 0,
+        "close_combat": 0,
+        "tactics": 0,
+        "tech": 0,
+        "medicine": 0,
+        "influence": 0,
+        "stealth": 0,
+        "composure": 0,
+        "psychokinesis": 0,
+        "pyrokinesis": 0,
+        "cryokinesis": 0,
+        "telepathy": 0,
+    }
+
+
+def build_default_derived_stats(stats: PlayerStats | None = None) -> dict[str, int]:
+    base = stats or PlayerStats()
+    return {
+        "hp": int(base.hp),
+        "aim": int(base.agi + base.level),
+        "defense": int(base.defense),
+        "crit": int(max(0, base.agi // 2)),
+        "initiative": int(base.agi + base.cha),
+        "stress_cap": int(10 + base.con + base.cha),
+        "recovery_rate": int(max(1, 1 + base.con // 2)),
+        "resolve": int(base.psi + base.cha),
+    }
+
+
+def default_agent_sheet(stats: PlayerStats | None = None) -> AgentSheet:
+    return AgentSheet(
+        attributes=build_default_attributes(stats),
+        skills=build_default_skills(),
+        derived_stats=build_default_derived_stats(stats),
+    )
+
+
+def normalize_agent_sheet(
+    *,
+    stats: PlayerStats,
+    attributes: dict[str, Any] | None,
+    skills: dict[str, Any] | None,
+    derived_stats: dict[str, Any] | None,
+) -> AgentSheet:
+    defaults = default_agent_sheet(stats)
+    normalized_attributes = dict(defaults.attributes)
+    normalized_attributes.update({k: int(v) for k, v in (attributes or {}).items() if isinstance(v, (int, float))})
+
+    normalized_skills = dict(defaults.skills)
+    for key, value in (skills or {}).items():
+        if key in normalized_skills:
+            normalized_skills[key] = _clamp_rank(value)
+
+    normalized_derived = dict(defaults.derived_stats)
+    normalized_derived.update({k: int(v) for k, v in (derived_stats or {}).items() if isinstance(v, (int, float))})
+
+    return AgentSheet(
+        attributes=normalized_attributes,
+        skills=normalized_skills,
+        derived_stats=normalized_derived,
+    )

--- a/game/character.py
+++ b/game/character.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field, asdict
 
 
+from .agents.sheet_schema import default_agent_sheet, normalize_agent_sheet
 from .management.equipment import AgentLoadout
 from .stats import PlayerStats
 from .relationships.mentor_history import serialize_links
@@ -34,6 +35,9 @@ class Character:
     loadout: AgentLoadout = field(default_factory=AgentLoadout)
     personality_primary_trait: str = ""
     personality_secondary_trait: str = ""
+    attributes: dict[str, int] = field(default_factory=lambda: default_agent_sheet().attributes)
+    skills: dict[str, int] = field(default_factory=lambda: default_agent_sheet().skills)
+    derived_stats: dict[str, int] = field(default_factory=lambda: default_agent_sheet().derived_stats)
 
     def to_dict(self) -> dict:
         return {
@@ -61,12 +65,21 @@ class Character:
             "loadout": self.loadout.to_dict(),
             "personality_primary_trait": self.personality_primary_trait,
             "personality_secondary_trait": self.personality_secondary_trait,
+            "attributes": dict(self.attributes),
+            "skills": dict(self.skills),
+            "derived_stats": dict(self.derived_stats),
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> "Character":
         stats_data = data.get("stats", {})
         stats = PlayerStats(**stats_data)
+        sheet = normalize_agent_sheet(
+            stats=stats,
+            attributes=data.get("attributes"),
+            skills=data.get("skills"),
+            derived_stats=data.get("derived_stats"),
+        )
         return cls(
             name=data.get("name", "Unnamed"),
             role=data.get("role", "samurai"),
@@ -92,6 +105,9 @@ class Character:
             loadout=AgentLoadout.from_dict(data.get("loadout")),
             personality_primary_trait=str(data.get("personality_primary_trait", "")),
             personality_secondary_trait=str(data.get("personality_secondary_trait", "")),
+            attributes=sheet.attributes,
+            skills=sheet.skills,
+            derived_stats=sheet.derived_stats,
         )
 
     def gain_xp(self, amount: int) -> None:

--- a/game/recruitment.py
+++ b/game/recruitment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from .agents.sheet_schema import default_agent_sheet
 from .character import Character
 from .stats import PlayerStats
 from .relationships.mentor_history import upsert_mentor_link
@@ -55,6 +56,7 @@ def create_character(name: str, role: str) -> Character:
     stats.recalculate_hp()
     cleaned_name = normalize_agent_name(name, [], role)
     primary_trait, secondary_trait = assign_personality_traits(cleaned_name, role, roster_index=0)
+    sheet = default_agent_sheet(stats)
     return Character(
         name=cleaned_name,
         role=role,
@@ -62,6 +64,9 @@ def create_character(name: str, role: str) -> Character:
         talent_points=1,
         personality_primary_trait=primary_trait,
         personality_secondary_trait=secondary_trait or "",
+        attributes=sheet.attributes,
+        skills=sheet.skills,
+        derived_stats=sheet.derived_stats,
     )
 
 

--- a/tests/test_agent_sheet_schema.py
+++ b/tests/test_agent_sheet_schema.py
@@ -1,0 +1,33 @@
+import unittest
+
+from game.character import Character
+from game.recruitment import create_character
+
+
+class TestAgentSheetSchema(unittest.TestCase):
+    def test_new_recruit_gets_schema_defaults(self):
+        recruit = create_character("Agent 1", "sniper")
+
+        self.assertIn("str", recruit.attributes)
+        self.assertIn("firearms", recruit.skills)
+        self.assertIn("resolve", recruit.derived_stats)
+        self.assertEqual(recruit.attributes["agi"], recruit.stats.agi)
+
+    def test_old_save_payload_is_backfilled_and_skill_ranks_are_bounded(self):
+        legacy_payload = {
+            "name": "Legacy",
+            "role": "psi",
+            "stats": {"level": 2, "psi": 9, "str": 2, "agi": 3, "con": 2, "cha": 4, "defense": 1},
+            "skills": {"telepathy": 99, "firearms": -5},
+        }
+
+        restored = Character.from_dict(legacy_payload)
+
+        self.assertIn("attributes", restored.to_dict())
+        self.assertIn("derived_stats", restored.to_dict())
+        self.assertEqual(restored.skills["telepathy"], 10)
+        self.assertEqual(restored.skills["firearms"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a small, explicit schema for agent dossier fields so recruitment, UI, and persistence remain synchronized and maintainable.
- Ensure backward compatibility by automatically backfilling older save payloads that lack the new sheet fields.
- Bound skill ranks to prevent corrupted/out-of-range values from legacy saves or malformed payloads.

### Description
- Added a new module `game/agents/sheet_schema.py` containing `AgentSheet`, builders `build_default_attributes`, `build_default_skills`, `build_default_derived_stats`, `default_agent_sheet`, and `normalize_agent_sheet` with rank clamping logic.
- Exported helpers via `game/agents/__init__.py` and wired `default_agent_sheet` into `game/recruitment.create_character` so new recruits receive synchronized schema defaults.
- Extended the `Character` dataclass to include `attributes`, `skills`, and `derived_stats`, updated `to_dict` to serialize them, and updated `from_dict` to call `normalize_agent_sheet` to backfill missing fields and clamp skill ranks.
- Added `tests/test_agent_sheet_schema.py` and updated `docs/backlog.md` with an AGENT-06 entry.

### Testing
- Ran `pytest` for the targeted tests (`tests/test_agent_sheet_schema.py` and `tests/test_agent_equipment.py`) and the final run with `PYTHONPATH=.` passed all checks.
- Final test output: `7 passed` (targeted regression checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15fbd2cc84832b9aa31dba63d59722)