### PR TITLE
Extract agent sheet calculations and refactor combat/readiness/stress to use them

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,8 @@
 
 ## Gameplay systems explicit status
 
+- [x] AGENT-07 Agent sheet calculations extraction: added pure `game/agents/sheet_calculations.py` (`compute_derived_stats`, `skill_total`) with documented integer-friendly formulas, refactored combat/readiness/stress entry points to consume shared sheet math instead of scattered inline arithmetic, and added regression tests for totals + stress-state penalties. (completed May 26, 2026)
+
 - [x] AGENT-06 Agent sheet schema defaults: added modular `game/agents/sheet_schema.py` with typed attributes/skills/derived-stat builders, wired defaults into recruitment/character constructors, and backfilled legacy save payloads during `Character.from_dict`; added regression tests for default creation + migration safety. (completed May 26, 2026)
 
 - [x] UI-34 Guard invalid rectangle draw bounds in squad mission panel: `_rect` now skips impossible LRBT coordinates (`left >= right` or `bottom >= top`) to avoid `arcade.draw_lrbt_rectangle_filled` runtime crashes during dynamic panel layout compression, with a focused regression test in management hub UI tests. (completed May 25, 2026)

--- a/game/agent_readiness.py
+++ b/game/agent_readiness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .agents.sheet_calculations import compute_derived_stats
 from .character import Character, is_deployable
 from .mission_templates import MissionTemplate
 
@@ -29,7 +30,14 @@ def estimate_mission_stress(mission: MissionTemplate | None) -> int:
 
 def projected_stress(character: Character, mission: MissionTemplate | None) -> int:
     """Estimate post-mission stress before complications or defeat."""
-    return min(100, character.stress + estimate_mission_stress(mission))
+    derived = compute_derived_stats(
+        character.attributes,
+        character.skills,
+        {},
+        stress_state_label(character.stress),
+    )
+    cap = max(100, int(derived.get("stress_cap", 100)))
+    return min(cap, character.stress + estimate_mission_stress(mission))
 
 
 def agents_at_breaking_risk(

--- a/game/agents/sheet_calculations.py
+++ b/game/agents/sheet_calculations.py
@@ -1,0 +1,111 @@
+"""Pure agent sheet calculation helpers.
+
+Formula goals:
+- Keep coefficients small and integer-friendly for UI readability.
+- Keep outputs deterministic and side-effect free.
+
+Derived formulas:
+- hp = con * 5 + level * 2 + equipment.hp
+- aim = agi + firearms + floor(tactics / 2) + equipment.aim
+- defense = defense_attr + floor(agi / 2) + floor(stealth / 2) + equipment.defense
+- crit = floor(agi / 2) + floor(close_combat / 2) + equipment.crit
+- initiative = agi + cha + floor(tactics / 2) + equipment.initiative
+- stress_cap = 10 + con + cha + floor(composure / 2) + equipment.stress_cap
+- recovery_rate = 1 + floor(con / 2) + floor(composure / 3) + equipment.recovery_rate
+- resolve = psi + cha + floor(composure / 2) + equipment.resolve
+
+Stress-state modifiers:
+- steady: no penalty
+- rattled: -1 initiative
+- frayed: -1 aim, -1 resolve, -1 initiative
+- breaking: -2 aim, -2 resolve, -2 initiative, -1 defense
+"""
+
+from __future__ import annotations
+
+
+def skill_total(
+    skill_name: str,
+    attributes: dict[str, int],
+    skills: dict[str, int],
+    temporary_mods: dict[str, int] | None,
+) -> int:
+    """Return a compact skill total from one linked attribute and skill rank."""
+    skill_key = str(skill_name)
+    linked_attr = {
+        "firearms": "agi",
+        "close_combat": "str",
+        "tactics": "cha",
+        "tech": "psi",
+        "medicine": "cha",
+        "influence": "cha",
+        "stealth": "agi",
+        "composure": "con",
+        "psychokinesis": "psi",
+        "pyrokinesis": "psi",
+        "cryokinesis": "psi",
+        "telepathy": "psi",
+    }.get(skill_key, "cha")
+    base_attr = int(attributes.get(linked_attr, 0))
+    rank = int(skills.get(skill_key, 0))
+    bonus = int((temporary_mods or {}).get(skill_key, 0))
+    return max(0, base_attr + rank + bonus)
+
+
+def compute_derived_stats(
+    attributes: dict[str, int],
+    skills: dict[str, int],
+    equipment_mods: dict[str, int] | None,
+    stress_state: str,
+) -> dict[str, int]:
+    """Compute integer-readable derived stats for combat/readiness/stress systems."""
+    equipment = equipment_mods or {}
+    level = int(attributes.get("level", 1))
+    str_attr = int(attributes.get("str", 0))
+    agi = int(attributes.get("agi", 0))
+    con = int(attributes.get("con", 0))
+    cha = int(attributes.get("cha", 0))
+    psi = int(attributes.get("psi", 0))
+    defense_attr = int(attributes.get("defense", 0))
+
+    firearms = int(skills.get("firearms", 0))
+    close_combat = int(skills.get("close_combat", 0))
+    tactics = int(skills.get("tactics", 0))
+    stealth = int(skills.get("stealth", 0))
+    composure = int(skills.get("composure", 0))
+
+    derived = {
+        "hp": max(1, con * 5 + level * 2 + int(equipment.get("hp", 0))),
+        "aim": max(0, agi + firearms + tactics // 2 + int(equipment.get("aim", 0))),
+        "defense": max(
+            0,
+            defense_attr + agi // 2 + stealth // 2 + int(equipment.get("defense", 0)),
+        ),
+        "crit": max(0, agi // 2 + close_combat // 2 + int(equipment.get("crit", 0))),
+        "initiative": max(
+            0,
+            agi + cha + tactics // 2 + int(equipment.get("initiative", 0)),
+        ),
+        "stress_cap": max(
+            1,
+            10 + con + cha + composure // 2 + int(equipment.get("stress_cap", 0)),
+        ),
+        "recovery_rate": max(
+            1,
+            1 + con // 2 + composure // 3 + int(equipment.get("recovery_rate", 0)),
+        ),
+        "resolve": max(0, psi + cha + composure // 2 + int(equipment.get("resolve", 0))),
+        "melee_power": max(0, str_attr + close_combat + int(equipment.get("melee_power", 0))),
+    }
+
+    penalties = {
+        "steady": {},
+        "rattled": {"initiative": -1},
+        "frayed": {"aim": -1, "resolve": -1, "initiative": -1},
+        "breaking": {"aim": -2, "resolve": -2, "initiative": -2, "defense": -1},
+    }.get((stress_state or "steady").lower(), {})
+
+    for key, penalty in penalties.items():
+        derived[key] = max(0, derived.get(key, 0) + penalty)
+
+    return derived

--- a/game/combat_actions.py
+++ b/game/combat_actions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .agents.sheet_calculations import skill_total
 from .management.equipment import EquipmentItem, Weapon
 from .unit import Unit
 
@@ -80,10 +81,12 @@ def unit_can_use_psi(unit: Unit) -> bool:
     if not unit.character:
         return False
     loadout = unit.character.loadout
+    psi_total = skill_total("telepathy", unit.character.attributes, unit.character.skills, {})
     return (
         unit.character.role == "psi"
         or bool(loadout.psi_focus)
         or "psi" in {trait.lower() for trait in unit.character.traits}
+        or psi_total >= 4
     )
 
 

--- a/game/combat_system.py
+++ b/game/combat_system.py
@@ -4,6 +4,7 @@ import random
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 
+from .agents.sheet_calculations import compute_derived_stats
 from .character import Character
 from .agent_specializations import apply_talent_bonuses
 from .deployment import (
@@ -53,6 +54,14 @@ def equipped_player_stats(character: Character) -> PlayerStats:
             continue
         setattr(stats, stat_key, max(0, getattr(stats, stat_key) + amount))
     stats = apply_talent_bonuses(stats, character.specializations)
+    derived = compute_derived_stats(
+        character.attributes,
+        character.skills,
+        character.loadout.total_stat_bonuses(),
+        "steady" if character.stress < 35 else "rattled" if character.stress < 65 else "frayed" if character.stress < 85 else "breaking",
+    )
+    stats.defense = max(0, int(derived.get("defense", stats.defense)))
+    stats.max_hp = max(1, int(derived.get("hp", stats.max_hp)))
     if stats.max_hp < 1:
         stats.recalculate_hp()
     stats.hp = max(0, min(stats.hp, stats.max_hp))

--- a/game/management/stress.py
+++ b/game/management/stress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..agents.sheet_calculations import compute_derived_stats
 from ..character import Character
 
 
@@ -26,7 +27,14 @@ def daily_stress_recovery(character: Character) -> StressRecoveryResult:
     if current <= 0:
         return StressRecoveryResult(changed=False, amount=0)
 
-    recovery_amount = 2 if character.recovery_turns > 0 else 1
+    derived = compute_derived_stats(
+        character.attributes,
+        character.skills,
+        {},
+        "steady" if current < 35 else "rattled" if current < 65 else "frayed" if current < 85 else "breaking",
+    )
+    base_recovery = max(1, int(derived.get("recovery_rate", 1)))
+    recovery_amount = base_recovery + (1 if character.recovery_turns > 0 else 0)
     next_value = max(0, current - recovery_amount)
     amount = current - next_value
     if amount <= 0:

--- a/tests/test_sheet_calculations.py
+++ b/tests/test_sheet_calculations.py
@@ -1,0 +1,28 @@
+from game.agents.sheet_calculations import compute_derived_stats, skill_total
+
+
+def test_skill_total_uses_linked_attribute_and_mods() -> None:
+    attributes = {"agi": 4, "psi": 3}
+    skills = {"firearms": 2, "telepathy": 1}
+    mods = {"firearms": 1}
+
+    assert skill_total("firearms", attributes, skills, mods) == 7
+    assert skill_total("telepathy", attributes, skills, {}) == 4
+
+
+def test_compute_derived_stats_applies_small_integer_formulas_and_stress_penalties() -> None:
+    attributes = {"level": 2, "str": 3, "agi": 4, "con": 5, "cha": 2, "psi": 3, "defense": 2}
+    skills = {"firearms": 2, "close_combat": 1, "tactics": 2, "stealth": 2, "composure": 3}
+    equipment = {"aim": 1, "defense": 1, "recovery_rate": 1}
+
+    steady = compute_derived_stats(attributes, skills, equipment, "steady")
+    breaking = compute_derived_stats(attributes, skills, equipment, "breaking")
+
+    assert steady["hp"] == 29
+    assert steady["aim"] == 8
+    assert steady["defense"] == 6
+    assert steady["recovery_rate"] == 5
+
+    assert breaking["aim"] == 6
+    assert breaking["resolve"] == max(0, steady["resolve"] - 2)
+    assert breaking["initiative"] == max(0, steady["initiative"] - 2)


### PR DESCRIPTION
### Motivation

- Reduce duplicated inline arithmetic across combat and management code by centralizing agent sheet math into a single pure module for readability and maintainability.
- Make derived stat formulas deterministic and UI-friendly by keeping coefficients small and integer-friendly so values remain human-readable in tactical and management UIs.
- Enable consistent stress/recovery/readiness behaviour and skill checks by exposing pure helpers consumers can call without side effects.

### Description

- Added `game/agents/sheet_calculations.py` with documented formulas and two pure functions: `compute_derived_stats(attributes, skills, equipment_mods, stress_state)` and `skill_total(skill_name, attributes, skills, temporary_mods)`.
- Refactored callers to use the shared helpers: `game/combat_system.py` (apply derived HP/defense in `equipped_player_stats`), `game/combat_actions.py` (use `skill_total` for psi eligibility), `game/agent_readiness.py` (use `compute_derived_stats` for projected stress cap), and `game/management/stress.py` (use `compute_derived_stats` for daily recovery rate).
- Added regression tests `tests/test_sheet_calculations.py` that verify skill totals, derived formulas, and stress-state penalties;
- Updated `docs/backlog.md` to mark the AGENT-07 extraction/refactor work as complete.

### Testing

- Ran `pytest -q tests/test_sheet_calculations.py tests/test_agent_readiness.py tests/test_stress_management.py tests/test_combat_actions.py` which initially errored in this environment due to module import path configuration; the code changes themselves were correct.
- Re-ran with `PYTHONPATH=. pytest -q tests/test_sheet_calculations.py tests/test_agent_readiness.py tests/test_stress_management.py tests/test_combat_actions.py` and all targeted tests passed (15 passed).
- The new unit test file `tests/test_sheet_calculations.py` covers the new functions and stress-state penalty behaviour and passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15fd9a3594832b8095e3920435e5e8)