### PR TITLE
Add RPG level-up choice model with projected derived-stat impacts

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,8 @@
 
 ## Gameplay systems explicit status
 
+- [x] AGENT-08 Level-up choice model in RPG armory flow: added Option A (+1 attribute, capped) and Option B (+2 skill ranks split across allowed skills, capped), surfaced projected derived-stat deltas directly in room action labels before click confirm, and covered with RPG view regression tests. (completed May 26, 2026)
+
 - [x] AGENT-07 Agent sheet calculations extraction: added pure `game/agents/sheet_calculations.py` (`compute_derived_stats`, `skill_total`) with documented integer-friendly formulas, refactored combat/readiness/stress entry points to consume shared sheet math instead of scattered inline arithmetic, and added regression tests for totals + stress-state penalties. (completed May 26, 2026)
 
 - [x] AGENT-06 Agent sheet schema defaults: added modular `game/agents/sheet_schema.py` with typed attributes/skills/derived-stat builders, wired defaults into recruitment/character constructors, and backfilled legacy save payloads during `Character.from_dict`; added regression tests for default creation + migration safety. (completed May 26, 2026)

--- a/game/progression.py
+++ b/game/progression.py
@@ -1,0 +1,92 @@
+"""Compact progression helpers for level-up choices and UI projections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .agents.sheet_calculations import compute_derived_stats
+from .agents.sheet_schema import SKILL_MAX_RANK
+from .character import Character
+
+ATTRIBUTE_MAX = 10
+ATTRIBUTE_KEYS = ("psi", "str", "agi", "con", "cha")
+ALLOWED_SKILL_KEYS = (
+    "firearms",
+    "close_combat",
+    "tactics",
+    "tech",
+    "medicine",
+    "influence",
+    "stealth",
+    "composure",
+    "psychokinesis",
+    "pyrokinesis",
+    "cryokinesis",
+    "telepathy",
+)
+
+
+@dataclass(frozen=True)
+class ProgressionProjection:
+    stats_delta: dict[str, int]
+    skills_delta: dict[str, int]
+    derived_delta: dict[str, int]
+
+
+def _derived_for(character: Character, stats_override: dict[str, int] | None = None, skills_override: dict[str, int] | None = None) -> dict[str, int]:
+    attrs = dict(character.attributes)
+    attrs.update(
+        {
+            "level": int(character.stats.level),
+            "str": int((stats_override or {}).get("str", character.stats.str)),
+            "agi": int((stats_override or {}).get("agi", character.stats.agi)),
+            "con": int((stats_override or {}).get("con", character.stats.con)),
+            "cha": int((stats_override or {}).get("cha", character.stats.cha)),
+            "psi": int((stats_override or {}).get("psi", character.stats.psi)),
+            "defense": int(character.stats.defense),
+        }
+    )
+    skills = dict(character.skills)
+    if skills_override:
+        skills.update(skills_override)
+    return compute_derived_stats(attrs, skills, {}, "steady")
+
+
+def option_a_projection(character: Character, stat_key: str) -> ProgressionProjection:
+    current = int(getattr(character.stats, stat_key))
+    next_value = min(ATTRIBUTE_MAX, current + 1)
+    stat_delta = next_value - current
+    before = _derived_for(character)
+    after = _derived_for(character, {stat_key: next_value})
+    return ProgressionProjection(
+        stats_delta={stat_key: stat_delta},
+        skills_delta={},
+        derived_delta={k: after.get(k, 0) - before.get(k, 0) for k in after},
+    )
+
+
+def option_b_plan(character: Character) -> dict[str, int]:
+    remaining = 2
+    updates: dict[str, int] = {}
+    for skill_key in ALLOWED_SKILL_KEYS:
+        if remaining <= 0:
+            break
+        current = int(character.skills.get(skill_key, 0))
+        can_add = max(0, SKILL_MAX_RANK - current)
+        if can_add <= 0:
+            continue
+        add = min(remaining, can_add)
+        updates[skill_key] = current + add
+        remaining -= add
+    return updates
+
+
+def option_b_projection(character: Character) -> ProgressionProjection:
+    before = _derived_for(character)
+    updates = option_b_plan(character)
+    after = _derived_for(character, skills_override=updates)
+    return ProgressionProjection(
+        stats_delta={},
+        skills_delta={k: updates[k] - int(character.skills.get(k, 0)) for k in updates},
+        derived_delta={k: after.get(k, 0) - before.get(k, 0) for k in after},
+    )

--- a/game/stats.py
+++ b/game/stats.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 import random
 
+ATTRIBUTE_MAX = 10
+SKILL_RANK_MAX = 10
+
 
 @dataclass
 class PlayerStats:

--- a/game/views.py
+++ b/game/views.py
@@ -124,6 +124,7 @@ from .ui.combat_action_bar import (
     layout_combat_action_buttons,
 )
 from .ui.panels import draw_graphical_command_surface
+from .progression import ATTRIBUTE_KEYS, option_a_projection, option_b_plan, option_b_projection
 from .ui.room_interaction import (
     ROOM_ACTIONS,
     RoomAction,
@@ -1369,6 +1370,10 @@ class RPGView(GameView):
             self._level_active_agent(action_key.removeprefix("level_"))
             self._refresh_squad_room_actions()
             return
+        if action_key.startswith("skillup_"):
+            self._level_active_agent_skill(action_key.removeprefix("skillup_"))
+            self._refresh_squad_room_actions()
+            return
         if action_key == "launch":
             self.launch_selected_mission()
 
@@ -1442,16 +1447,31 @@ class RPGView(GameView):
             )
             active_agent = self._active_agent()
             if active_agent and active_agent.pending_points > 0:
-                points = active_agent.pending_points
+                option_b = option_b_projection(active_agent)
+                option_b_hint = ", ".join(
+                    f"{key[:3].upper()}+{delta}" for key, delta in option_b.skills_delta.items() if delta > 0
+                ) or "No eligible skills"
                 actions.extend(
                     [
-                        RoomAction("level_psi", "research", f"+PSI {points}"),
-                        RoomAction("level_str", "armory", f"+STR {points}"),
-                        RoomAction("level_agi", "radar", f"+AGI {points}"),
-                        RoomAction("level_con", "shield", f"+CON {points}"),
-                        RoomAction("level_cha", "influence", f"+CHA {points}"),
+                        RoomAction(
+                            "skillup_auto",
+                            "research",
+                            f"B: +2 skills ({option_b_hint}) | Resolve {option_b.derived_delta.get('resolve', 0):+d} Aim {option_b.derived_delta.get('aim', 0):+d}",
+                        ),
                     ]
                 )
+                for stat_key in ATTRIBUTE_KEYS:
+                    proj = option_a_projection(active_agent, stat_key)
+                    delta = proj.stats_delta.get(stat_key, 0)
+                    if delta <= 0:
+                        continue
+                    actions.append(
+                        RoomAction(
+                            f"level_{stat_key}",
+                            "research" if stat_key == "psi" else "armory" if stat_key == "str" else "radar" if stat_key == "agi" else "shield" if stat_key == "con" else "influence",
+                            f"A: +1 {stat_key.upper()} | HP {proj.derived_delta.get('hp', 0):+d} Def {proj.derived_delta.get('defense', 0):+d} Res {proj.derived_delta.get('resolve', 0):+d}",
+                        )
+                    )
         elif room_key == "barracks":
             # Expose recruit actions directly at index 0 (no nav wrapper).
             actions = list(ROOM_ACTIONS.get("squad", {}).get("barracks", []))
@@ -1529,14 +1549,35 @@ class RPGView(GameView):
 
     def _level_active_agent(self, stat_key: str) -> None:
         active_agent = self._active_agent()
-        if not active_agent or active_agent.pending_points <= 0:
+        if not active_agent or active_agent.pending_points <= 0 or stat_key not in ATTRIBUTE_KEYS:
             return
-        if stat_key not in {"psi", "str", "agi", "con", "cha"}:
+        projection = option_a_projection(active_agent, stat_key)
+        delta = projection.stats_delta.get(stat_key, 0)
+        if delta <= 0:
+            self.message = f"{active_agent.name} {stat_key.upper()} is already capped."
             return
-        setattr(active_agent.stats, stat_key, getattr(active_agent.stats, stat_key) + 1)
+        setattr(active_agent.stats, stat_key, getattr(active_agent.stats, stat_key) + delta)
         active_agent.pending_points -= 1
         active_agent.stats.recalculate_hp()
-        self.message = f"{active_agent.name} trained {stat_key.upper()} (+1)."
+        self.message = f"{active_agent.name} option A: {stat_key.upper()} +{delta}."
+        self.game_state.add_event(self.message)
+
+    def _level_active_agent_skill(self, action_key: str) -> None:
+        active_agent = self._active_agent()
+        if not active_agent or active_agent.pending_points <= 0 or action_key != "auto":
+            return
+        planned = option_b_plan(active_agent)
+        if not planned:
+            self.message = f"{active_agent.name} has no eligible skills to raise."
+            return
+        applied: list[str] = []
+        for key, target in planned.items():
+            current = int(active_agent.skills.get(key, 0))
+            if target > current:
+                active_agent.skills[key] = target
+                applied.append(f"{key}+{target-current}")
+        active_agent.pending_points -= 1
+        self.message = f"{active_agent.name} option B: {', '.join(applied)}."
         self.game_state.add_event(self.message)
 
     def _room_info_lines(self) -> dict[str, list[str]]:

--- a/tests/test_rpg_view.py
+++ b/tests/test_rpg_view.py
@@ -361,6 +361,29 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
         self.assertEqual(agent.stats.str, str_before + 1)
         self.assertEqual(agent.pending_points, 0)
 
+
+    def test_armory_room_option_b_spends_one_point_and_adds_two_skill_ranks(self):
+        from game.ui.facility import build_facility_rooms, facility_room_by_key
+
+        agent = Character("Leveler", pending_points=1)
+        game_state = GameState(characters=[agent])
+        view = views.RPGView(game_state)
+        view.window = _FakeWindow()
+        view.setup()
+        room = facility_room_by_key(
+            build_facility_rooms(view.window.width, view.window.height, "squad"),
+            "armory",
+        )
+        view.on_mouse_press(room.left + room.width // 2, room.bottom + room.height // 2, None, None)
+        before = dict(agent.skills)
+        b_button = next(button for button in view.room_ui.action_buttons if button.action.key == "skillup_auto").rect
+
+        view.on_mouse_press(b_button.center_x, b_button.center_y, None, None)
+
+        self.assertEqual(agent.pending_points, 0)
+        gained = sum(max(0, agent.skills.get(k, 0) - before.get(k, 0)) for k in before)
+        self.assertEqual(gained, 2)
+
     def test_insertion_room_launches_selected_mission(self):
         from game.ui.facility import build_facility_rooms, facility_room_by_key
 
@@ -533,7 +556,8 @@ class RPGViewMissionLaunchTest(unittest.TestCase):
             views.arcade.draw_text = original_draw_text
 
         self.assertTrue(any("Upgrade points 3" in text for text in drawn_text))
-        self.assertIn("+STR 3", drawn_text)
+        self.assertTrue(any(text.startswith("A: +1 STR") for text in drawn_text))
+        self.assertTrue(any(text.startswith("B: +2 SKILLS") for text in drawn_text))
         self.assertIn("PTS 3", drawn_text)
 
     def test_pending_upgrade_roster_card_uses_valid_rectangles(self):


### PR DESCRIPTION
### Motivation

- Introduce a compact, modular level-up choice model so players can pick between a single-attribute bump or splitting skill ranks, with caps enforced and immediate projected impact visible in the RPG armory UI. 
- Keep the progression math isolated for readability and testability while wiring the choice into existing room actions and level-up handlers. 

### Description

- Added a new helper module `game/progression.py` implementing Option A/A projection (`+1` attribute, capped), Option B planning/projection (`+2` skill ranks split across allowed skills, capped), and derived-stat delta calculation for UI preview. 
- Exposed projected impacts in the armory room by updating `game/views.py` to add a `skillup_auto` action and to render Option A/B labels that include projected derived deltas (HP/DEF/Resolve/Aim) before confirmation. 
- Implemented application logic for Option A and Option B in `game/views.py` (`_level_active_agent` now uses the projection to respect attribute caps and `_level_active_agent_skill` applies the Option B plan), and added small progression cap constants in `game/stats.py`. 
- Updated `tests/test_rpg_view.py` to expect the new labels and added a regression test that Option B spends one pending point and grants exactly +2 total skill ranks, and updated `docs/backlog.md` to mark `AGENT-08` complete. 

### Testing

- Ran the focused test selection `PYTHONPATH=. pytest -q tests/test_rpg_view.py -k "armory_room_can_spend_level_up_points or armory_room_option_b_spends_one_point_and_adds_two_skill_ranks or leveling_room_displays_remaining_points"`, and the run completed with `3 passed, 25 deselected`. 
- The new `Option B` regression specifically verifies that spending one pending point applies exactly two skill-rank increases and that the UI displays both `A:` and `B:` action labels with projected derived-stat deltas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16034e7650832b8e9ddbe08df24849)