### PR TITLE
Expose agent sheet snapshot in command deck barracks

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,7 @@
 
 ## Gameplay systems explicit status
 
+- [x] AGENT-08 Agent sheet visibilité in-game: le panneau Agent Barracks affiche désormais une ligne "Sheet" compacte (STR/AGI/PSI, Firearms/Tactics, Aim/Resolve) par agent, pour rendre les données de fiche enfin actionnables pendant la sélection d'escouade; test UI mis à jour pour verrouiller ce rendu. (completed May 26, 2026)
 - [x] AGENT-07 Agent sheet calculations extraction: added pure `game/agents/sheet_calculations.py` (`compute_derived_stats`, `skill_total`) with documented integer-friendly formulas, refactored combat/readiness/stress entry points to consume shared sheet math instead of scattered inline arithmetic, and added regression tests for totals + stress-state penalties. (completed May 26, 2026)
 
 - [x] AGENT-06 Agent sheet schema defaults: added modular `game/agents/sheet_schema.py` with typed attributes/skills/derived-stat builders, wired defaults into recruitment/character constructors, and backfilled legacy save payloads during `Character.from_dict`; added regression tests for default creation + migration safety. (completed May 26, 2026)

--- a/game/ui/screens/command_deck/layout.py
+++ b/game/ui/screens/command_deck/layout.py
@@ -78,6 +78,20 @@ def deck_panel_by_key(panels: list[DeckPanel], key: str) -> DeckPanel:
     raise KeyError(key)
 
 
+def _agent_sheet_snapshot_line(character: Character) -> str:
+    """Return one compact in-game line surfacing core agent-sheet values."""
+    attrs = character.attributes or {}
+    skills = character.skills or {}
+    derived = character.derived_stats or {}
+    return (
+        "  Sheet "
+        f"STR {int(attrs.get('str', 0))} AGI {int(attrs.get('agi', 0))} "
+        f"PSI {int(attrs.get('psi', 0))} "
+        f"Firearms {int(skills.get('firearms', 0))} Tactics {int(skills.get('tactics', 0))} "
+        f"Aim {int(derived.get('aim', 0))} Resolve {int(derived.get('resolve', 0))}"
+    )
+
+
 def build_agent_card_lines(
     characters: list[Character], selected_names: set[str], cursor_index: int
 ) -> list[str]:
@@ -100,6 +114,7 @@ def build_agent_card_lines(
         )
         lines.append(f"{cursor} {selected} {summary} // {state}{recovery}")
         lines.append(dossier.strip())
+        lines.append(_agent_sheet_snapshot_line(character))
         if character.pending_points > 0:
             lines.append(
                 f"STAT UPGRADE {character.pending_points}: "

--- a/tests/test_command_deck_ui.py
+++ b/tests/test_command_deck_ui.py
@@ -43,8 +43,9 @@ class CommandDeckUITest(unittest.TestCase):
 
         self.assertTrue(lines[0].startswith("> [X] Vega"))
         self.assertIn("Trait:", lines[1])
-        self.assertTrue(lines[2].startswith("  [ ] Knox"))
-        self.assertIn("// MEDBAY 2T", lines[2])
+        self.assertIn("Sheet STR", lines[2])
+        self.assertTrue(lines[3].startswith("  [ ] Knox"))
+        self.assertIn("// MEDBAY 2T", lines[3])
 
     def test_ops_table_header_blends_district_objective_and_risk(self):
         mission = create_mission_templates("Chrome Warrens")[1]


### PR DESCRIPTION
### Motivation
- The agent sheet data (attributes/skills/derived_stats) existed but was not visible during squad selection, reducing actionability of agent decisions. 
- Surface a minimal, readable snapshot of core sheet values in the Agent Barracks to strengthen agent-centered decision-making without large UI changes. 
- Keep the change small and modular to follow the project priorities of emergent storytelling and maintainability.

### Description
- Added a small helper `_agent_sheet_snapshot_line` to `game/ui/screens/command_deck/layout.py` that formats a compact sheet line showing `STR/AGI/PSI`, `Firearms/Tactics`, and `Aim/Resolve` for a character. 
- Integrated the snapshot into `build_agent_card_lines` so each roster card now appends the `Sheet` line after the dossier line. 
- Updated `tests/test_command_deck_ui.py` to assert the new rendering order and presence of the `Sheet` line. 
- Updated `docs/backlog.md` to record the completed `AGENT-08` backlog entry describing the in-game visibility addition.

### Testing
- Running `pytest -q tests/test_command_deck_ui.py` initially failed during collection due to the test runner environment missing the repository import path. 
- Re-running tests with the repository on the import path via `PYTHONPATH=. pytest -q tests/test_command_deck_ui.py` produced `3 passed` and the updated UI test succeeded. 
- No other test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16049c55b8832b9981cb89388daf81)