### PR TITLE
Double-click agent card opens full character sheet modal in Squad room

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,7 @@
 
 ## Gameplay systems explicit status
 
+- [x] UI-38 Double-click agent card opens full character sheet in Squad room: added a dedicated full-sheet modal (attributes, core skills, derived stats, and loadout snapshot) while preserving single-click deploy selection; ESC closes the modal. (completed May 27, 2026)
 - [x] AGENT-09 Agent sheet visibilité in-game: le panneau Agent Barracks affiche désormais une ligne "Sheet" compacte (STR/AGI/PSI, Firearms/Tactics, Aim/Resolve) par agent, pour rendre les données de fiche enfin actionnables pendant la sélection d'escouade; test UI mis à jour pour verrouiller ce rendu. (completed May 26, 2026)
 - [x] AGENT-08 Level-up choice model in RPG armory flow: added Option A (+1 attribute, capped) and Option B (+2 skill ranks split across allowed skills, capped), surfaced projected derived-stat deltas directly in room action labels before click confirm, and covered with RPG view regression tests. (completed May 26, 2026)
 - [x] AGENT-07 Agent sheet calculations extraction: added pure `game/agents/sheet_calculations.py` (`compute_derived_stats`, `skill_total`) with documented integer-friendly formulas, refactored combat/readiness/stress entry points to consume shared sheet math instead of scattered inline arithmetic, and added regression tests for totals + stress-state penalties. (completed May 26, 2026)

--- a/game/ui/screens/management_screen.py
+++ b/game/ui/screens/management_screen.py
@@ -21,6 +21,7 @@ presentation layer changes.
 from __future__ import annotations
 
 import math
+import time
 from dataclasses import dataclass
 
 import arcade
@@ -228,6 +229,9 @@ class ManagementView(GameView):
         self.pending_launch_mission_id: str | None = None
         self.message: str = ""
         self.equipment_catalog = default_equipment_catalog()
+        self._last_agent_click_time: float = 0.0
+        self._last_agent_click_index: int | None = None
+        self.expanded_agent_sheet_index: int | None = None
 
         ensure_mission_templates(self.game_state)
         self.game_state.selected_agent_names = sanitize_selected_agent_names(
@@ -298,6 +302,45 @@ class ManagementView(GameView):
 
         # Notifications toast — newest-first, bottom-right corner
         _draw_notification_toast(self.notifications, w, h)
+        self._draw_expanded_agent_sheet_modal(w, h)
+
+
+    def _draw_expanded_agent_sheet_modal(self, w: int, h: int) -> None:
+        if self.expanded_agent_sheet_index is None:
+            return
+        gs = self.game_state
+        if self.expanded_agent_sheet_index >= len(gs.characters):
+            self.expanded_agent_sheet_index = None
+            return
+
+        char = gs.characters[self.expanded_agent_sheet_index]
+        _rect(0, 0, w, h, (0, 0, 0, 170))
+        mw = min(760, w - 120)
+        mh = min(470, h - 110)
+        mx0 = (w - mw) // 2
+        my0 = (h - mh) // 2
+        mx1 = mx0 + mw
+        my1 = my0 + mh
+        _panel(mx0, my0, mx1, my1, f"FULL AGENT SHEET — {char.name.upper()}", palette.HEADER)
+
+        stats = char.stats
+        skills = char.skills
+        summary_lines = [
+            f"Role {char.role.upper()}   HP {stats.hp}/{stats.max_hp}   Stress {char.stress}   Loyalty {char.loyalty}",
+            f"Recovery {char.recovery_turns}d   Pending points {char.pending_points}   Talent points {char.talent_points}",
+            f"Attributes  STR {stats.str}  AGI {stats.agi}  PSI {stats.psi}  DEF {stats.defense}  CON {stats.con}",
+            f"Core skills  Firearms {skills.get('firearms', 0)}  Tactics {skills.get('tactics', 0)}  Engineering {skills.get('engineering', 0)}  Medicine {skills.get('medicine', 0)}",
+            f"Derived  Aim {getattr(stats, 'aim', 0)}  Resolve {getattr(stats, 'resolve', 0)}",
+        ]
+        for idx, line in enumerate(summary_lines):
+            arcade.draw_text(line, mx0 + 16, my1 - 50 - idx * 24, palette.TEXT, font_size=12)
+
+        loadout_lines = char.loadout.summary_lines()[:6]
+        arcade.draw_text("Loadout", mx0 + 16, my1 - 190, palette.ACCENT, font_size=11, bold=True)
+        for idx, line in enumerate(loadout_lines or ["No equipment assigned."]):
+            arcade.draw_text(line, mx0 + 16, my1 - 214 - idx * 20, palette.MUTED_TEXT, font_size=10)
+
+        arcade.draw_text("Press ESC to close.", mx1 - 16, my0 + 14, palette.MUTED_TEXT, font_size=10, anchor_x="right")
 
     def on_key_press(self, key: int, modifiers: int) -> None:
         # Tab shortcuts
@@ -308,6 +351,10 @@ class ManagementView(GameView):
             arcade.key.F4: "research",
             arcade.key.F5: "intel",
         }
+        if key == arcade.key.ESCAPE and self.expanded_agent_sheet_index is not None:
+            self.expanded_agent_sheet_index = None
+            return
+
         if key in tab_keys:
             self.active_tab = tab_keys[key]
             return
@@ -1793,9 +1840,20 @@ class ManagementView(GameView):
         if action == "agent_card":
             self.deployment_cursor = data
             self.message = ""
-            # Double-click / toggle selection
+            now = time.monotonic()
+            is_double_click = (
+                self._last_agent_click_index == data
+                and (now - self._last_agent_click_time) <= 0.35
+            )
+            self._last_agent_click_time = now
+            self._last_agent_click_index = data
             char = gs.characters[data] if data < len(gs.characters) else None
             if char:
+                if is_double_click:
+                    self.expanded_agent_sheet_index = data
+                    self.pending_launch_confirm = False
+                    self.message = f"Opened full sheet for {char.name}."
+                    return
                 gs.selected_agent_names, self.message = toggle_agent_selection(
                     gs.characters, gs.selected_agent_names, data
                 )
@@ -2241,6 +2299,9 @@ class ManagementView(GameView):
         self._hits = []
         self.active_tab = "command"
         self.equipment_catalog = default_equipment_catalog()
+        self._last_agent_click_time: float = 0.0
+        self._last_agent_click_index: int | None = None
+        self.expanded_agent_sheet_index: int | None = None
 
         ensure_mission_templates(self.game_state)
         self.game_state.selected_agent_names = sanitize_selected_agent_names(
@@ -2286,8 +2347,47 @@ class ManagementView(GameView):
         if self.message:
             arcade.draw_text(self.message, 22, 34, palette.WARNING, 10)
         _draw_notification_toast(self.notifications, w, h)
+        self._draw_expanded_agent_sheet_modal(w, h)
         self._draw_legacy_room_content()
         draw_expanded_room_controls(w, h, self.room_ui)
+
+
+    def _draw_expanded_agent_sheet_modal(self, w: int, h: int) -> None:
+        if self.expanded_agent_sheet_index is None:
+            return
+        gs = self.game_state
+        if self.expanded_agent_sheet_index >= len(gs.characters):
+            self.expanded_agent_sheet_index = None
+            return
+
+        char = gs.characters[self.expanded_agent_sheet_index]
+        _rect(0, 0, w, h, (0, 0, 0, 170))
+        mw = min(760, w - 120)
+        mh = min(470, h - 110)
+        mx0 = (w - mw) // 2
+        my0 = (h - mh) // 2
+        mx1 = mx0 + mw
+        my1 = my0 + mh
+        _panel(mx0, my0, mx1, my1, f"FULL AGENT SHEET — {char.name.upper()}", palette.HEADER)
+
+        stats = char.stats
+        skills = char.skills
+        summary_lines = [
+            f"Role {char.role.upper()}   HP {stats.hp}/{stats.max_hp}   Stress {char.stress}   Loyalty {char.loyalty}",
+            f"Recovery {char.recovery_turns}d   Pending points {char.pending_points}   Talent points {char.talent_points}",
+            f"Attributes  STR {stats.str}  AGI {stats.agi}  PSI {stats.psi}  DEF {stats.defense}  CON {stats.con}",
+            f"Core skills  Firearms {skills.get('firearms', 0)}  Tactics {skills.get('tactics', 0)}  Engineering {skills.get('engineering', 0)}  Medicine {skills.get('medicine', 0)}",
+            f"Derived  Aim {getattr(stats, 'aim', 0)}  Resolve {getattr(stats, 'resolve', 0)}",
+        ]
+        for idx, line in enumerate(summary_lines):
+            arcade.draw_text(line, mx0 + 16, my1 - 50 - idx * 24, palette.TEXT, font_size=12)
+
+        loadout_lines = char.loadout.summary_lines()[:6]
+        arcade.draw_text("Loadout", mx0 + 16, my1 - 190, palette.ACCENT, font_size=11, bold=True)
+        for idx, line in enumerate(loadout_lines or ["No equipment assigned."]):
+            arcade.draw_text(line, mx0 + 16, my1 - 214 - idx * 20, palette.MUTED_TEXT, font_size=10)
+
+        arcade.draw_text("Press ESC to close.", mx1 - 16, my0 + 14, palette.MUTED_TEXT, font_size=10, anchor_x="right")
 
     def on_key_press(self, key: int, modifiers: int) -> None:
         esc_key = getattr(arcade.key, "ESCAPE", None)
@@ -2320,7 +2420,9 @@ class ManagementView(GameView):
             if code is not None
         }
         if esc_key is not None and key == esc_key:
-            if self.room_ui.is_open:
+            if self.expanded_agent_sheet_index is not None:
+                self.expanded_agent_sheet_index = None
+            elif self.room_ui.is_open:
                 close_room(self.room_ui)
             else:
                 from game.ui.screens.title_screen import TitleView

--- a/tests/test_management_hub_ui.py
+++ b/tests/test_management_hub_ui.py
@@ -117,6 +117,28 @@ class ManagementHubUITest(unittest.TestCase):
         view.game_state.selected_agent_names = [view.game_state.characters[0].name]
         view.game_state.spec_ops_assets = default_spec_ops_assets()
 
+
+    def test_double_click_agent_card_opens_full_sheet(self):
+        view = ManagementView(GameState())
+        view.window = _FakeWindow()
+        view.setup()
+        self._seed_interactive_state(view)
+
+        view._dispatch("agent_card", 0)
+        view._dispatch("agent_card", 0)
+
+        self.assertEqual(view.expanded_agent_sheet_index, 0)
+
+    def test_escape_closes_expanded_agent_sheet(self):
+        view = ManagementView(GameState())
+        view.window = _FakeWindow()
+        view.setup()
+        self._seed_interactive_state(view)
+        view.expanded_agent_sheet_index = 0
+
+        view.on_key_press(management_screen.arcade.key.ESCAPE, 0)
+
+        self.assertIsNone(view.expanded_agent_sheet_index)
     def test_management_view_uses_the_hub_room_model(self):
         view = ManagementView(GameState())
         view.window = _FakeWindow()


### PR DESCRIPTION
### Motivation
- Let players open a full, readable character sheet from the Squad roster via a quick double-click while keeping single-click behavior as the deploy-selection toggle. 
- Surface richer agent identity and emotional data (attributes, skills, derived stats, loadout) without adding extra screens or breaking existing flows.
- Make the interaction predictable by allowing `ESC` to close the sheet before room/title navigation.

### Description
- Added per-view click state and modal state: `_last_agent_click_time`, `_last_agent_click_index`, and `expanded_agent_sheet_index`, and used `time.monotonic()` to detect a double-click within a 0.35s threshold.
- Implemented `_draw_expanded_agent_sheet_modal` to render a centered overlay showing role, HP/stress/loyalty, recovery/pending/talent points, attributes, core skills, derived stats, and a loadout snapshot; wired it into the main draw path so it overlays content.
- Updated action dispatch for `agent_card` so a double-click opens the modal while a single click preserves `toggle_agent_selection` behavior.
- Adjusted `ESC` handling to close the expanded sheet first (if open) before falling back to room-close/title navigation.
- Added two UI regression tests in `tests/test_management_hub_ui.py`: `test_double_click_agent_card_opens_full_sheet` and `test_escape_closes_expanded_agent_sheet`.
- Updated `docs/backlog.md` with a completed backlog item for this interaction.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_management_hub_ui.py -k 'double_click_agent_card_opens_full_sheet or escape_closes_expanded_agent_sheet'` and both new tests passed.
- Ran `PYTHONPATH=. pytest -q tests/test_management_hub_ui.py` to exercise the file; the two new tests pass, and a pre-existing unrelated assertion (`test_launch_mission_footer_is_lower_and_separated_from_room_text`) remains failing in this environment (no change to that logic in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17158d70d8832bb66310194845007f)