### PR TITLE
Introduce shared combat movement rule and wire through view/AI

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -32,7 +32,7 @@ Three-phase plan to bring the battle/mission view to professional tactical-RPG s
 
 ### Phase 3 — Gameplay Depth
 
-- [ ] BATTLE-G01 Terrain pathfinding: wire `can_move_to()` in `combat_system.py` to existing `terrain_profile` walkability mask + occupancy check; enemy AI respects same rules.
+- [x] BATTLE-G01 Terrain pathfinding: reduced to one shared tactical movement rule in `game/combat/movement.py`; BattleView deployment/keyboard movement and enemy AI now use the same terrain + occupancy checks. (completed June 7, 2026)
 - [ ] BATTLE-G02 Enhanced enemy AI: cover-seeking before attacking; flanking preference using `cover_system.py::flanking_detection`; commander subtype buffs adjacent grunt/heavy AGI.
 - [ ] BATTLE-G03 Dynamic mid-battle events: extend `complications.py` with `in_battle_effect` field; trigger reinforcements/blackout/timer via `_check_complications(turn_number)` in `start_player_turn()`; show complication flash banner.
 - [ ] BATTLE-G04 Status effects: add `status_effects: list[str]` to `Unit`; support `suppressed` (−2 move AP), `bleeding` (−1 HP/turn), `stunned` (skip next action); icon badges on unit labels in HUD.

--- a/game/combat/__init__.py
+++ b/game/combat/__init__.py
@@ -1,6 +1,7 @@
 """Pure tactical combat state and transition helpers."""
 
 from .engine import CombatEngine, CombatActionResult, BattleCheckResult
+from .movement import can_enter_cell, path_to_cell, reachable_cells
 from .state import CombatState
 
 __all__ = [
@@ -8,4 +9,7 @@ __all__ = [
     "CombatActionResult",
     "CombatEngine",
     "CombatState",
+    "can_enter_cell",
+    "path_to_cell",
+    "reachable_cells",
 ]

--- a/game/combat/engine.py
+++ b/game/combat/engine.py
@@ -97,6 +97,7 @@ class CombatEngine:
             on_overwatch_shot=on_overwatch_shot,
             can_enter=self.can_enter,
             cover_nodes=self.cover_nodes,
+            movement_mode=self.state.movement_mode,
         )
         return self.end_battle_check()
 

--- a/game/combat/movement.py
+++ b/game/combat/movement.py
@@ -1,0 +1,183 @@
+"""Shared tactical movement rules for combat deployment, player input, and AI."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable
+from typing import Literal, Protocol
+
+from game.unit import Unit
+
+CELL_SIZE = 32
+MovementMode = Literal["fluid", "tactical_grid"]
+
+
+class WalkabilityProfile(Protocol):
+    """Minimal terrain contract used by combat movement."""
+
+    def is_walkable(self, x: int, y: int) -> bool:
+        """Return whether the cell at pixel/grid position ``(x, y)`` can be entered."""
+
+
+def _living_units(units: Iterable[Unit] | None) -> Iterable[Unit]:
+    if units is None:
+        return ()
+    return (unit for unit in units if getattr(unit, "health", 0) > 0)
+
+
+def _is_occupied(
+    x: int,
+    y: int,
+    allied_units: Iterable[Unit] | None,
+    enemy_units: Iterable[Unit] | None,
+    *,
+    exclude: Unit | None = None,
+) -> bool:
+    """Return whether any living unit except ``exclude`` occupies a destination."""
+    for unit in [*_living_units(allied_units), *_living_units(enemy_units)]:
+        if unit is exclude:
+            continue
+        if getattr(unit, "position", None) == (x, y):
+            return True
+    return False
+
+
+def can_enter_cell(
+    x: int,
+    y: int,
+    *,
+    terrain_profile: WalkabilityProfile | None = None,
+    allied_units: Iterable[Unit] | None = None,
+    enemy_units: Iterable[Unit] | None = None,
+    exclude: Unit | None = None,
+    movement_mode: MovementMode = "tactical_grid",
+) -> bool:
+    """Return whether the shared combat movement rule allows entering a cell.
+
+    ``fluid`` keeps the looser legacy feel by allowing units to pass through
+    occupied cells while still honoring terrain masks. ``tactical_grid`` blocks
+    both terrain and living unit occupancy.
+    """
+    if (
+        terrain_profile is not None
+        and hasattr(terrain_profile, "is_walkable")
+        and not terrain_profile.is_walkable(x, y)
+    ):
+        return False
+    if movement_mode == "tactical_grid" and _is_occupied(
+        x, y, allied_units, enemy_units, exclude=exclude
+    ):
+        return False
+    return True
+
+
+def reachable_cells(
+    start: tuple[int, int],
+    movement_budget: int,
+    *,
+    width: int,
+    height: int,
+    cell_size: int = CELL_SIZE,
+    terrain_profile: WalkabilityProfile | None = None,
+    allied_units: Iterable[Unit] | None = None,
+    enemy_units: Iterable[Unit] | None = None,
+    exclude: Unit | None = None,
+    movement_mode: MovementMode = "tactical_grid",
+) -> set[tuple[int, int]]:
+    """Return cells reachable from ``start`` within a cardinal-step budget."""
+    if movement_budget < 0:
+        return set()
+
+    reachable: set[tuple[int, int]] = {start}
+    seen: set[tuple[int, int]] = {start}
+    queue = deque([(start[0], start[1], 0)])
+
+    while queue:
+        x, y, steps = queue.popleft()
+        if steps >= movement_budget:
+            continue
+        for next_x, next_y in (
+            (x + cell_size, y),
+            (x - cell_size, y),
+            (x, y + cell_size),
+            (x, y - cell_size),
+        ):
+            if not (0 <= next_x < width and 0 <= next_y < height):
+                continue
+            if (next_x, next_y) in seen:
+                continue
+            if not can_enter_cell(
+                next_x,
+                next_y,
+                terrain_profile=terrain_profile,
+                allied_units=allied_units,
+                enemy_units=enemy_units,
+                exclude=exclude,
+                movement_mode=movement_mode,
+            ):
+                continue
+            seen.add((next_x, next_y))
+            reachable.add((next_x, next_y))
+            queue.append((next_x, next_y, steps + 1))
+    return reachable
+
+
+def path_to_cell(
+    start: tuple[int, int],
+    goal: tuple[int, int],
+    movement_budget: int,
+    *,
+    width: int,
+    height: int,
+    cell_size: int = CELL_SIZE,
+    terrain_profile: WalkabilityProfile | None = None,
+    allied_units: Iterable[Unit] | None = None,
+    enemy_units: Iterable[Unit] | None = None,
+    exclude: Unit | None = None,
+    movement_mode: MovementMode = "tactical_grid",
+) -> list[tuple[int, int]] | None:
+    """Return the shortest cardinal path from ``start`` to ``goal``, if reachable."""
+    if start == goal:
+        return [start]
+    if movement_budget < 0:
+        return None
+
+    seen: set[tuple[int, int]] = {start}
+    previous: dict[tuple[int, int], tuple[int, int]] = {}
+    queue = deque([(start[0], start[1], 0)])
+
+    while queue:
+        x, y, steps = queue.popleft()
+        if steps >= movement_budget:
+            continue
+        for next_x, next_y in (
+            (x + cell_size, y),
+            (x - cell_size, y),
+            (x, y + cell_size),
+            (x, y - cell_size),
+        ):
+            cell = (next_x, next_y)
+            if not (0 <= next_x < width and 0 <= next_y < height):
+                continue
+            if cell in seen:
+                continue
+            if not can_enter_cell(
+                next_x,
+                next_y,
+                terrain_profile=terrain_profile,
+                allied_units=allied_units,
+                enemy_units=enemy_units,
+                exclude=exclude,
+                movement_mode=movement_mode,
+            ):
+                continue
+            previous[cell] = (x, y)
+            if cell == goal:
+                path = [goal]
+                while path[-1] != start:
+                    path.append(previous[path[-1]])
+                path.reverse()
+                return path
+            seen.add(cell)
+            queue.append((next_x, next_y, steps + 1))
+    return None

--- a/game/combat/state.py
+++ b/game/combat/state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from game.combat.movement import MovementMode
 from game.mission_templates import MissionTemplate
 from game.unit import Unit
 
@@ -29,6 +30,7 @@ class CombatState:
     active_index: int = 0
     logs: list[str] = field(default_factory=list)
     tactical_flags: dict[str, Any] = field(default_factory=dict)
+    movement_mode: MovementMode = "tactical_grid"
 
     @property
     def active_unit(self) -> Unit | None:

--- a/game/combat_system.py
+++ b/game/combat_system.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace
 
 from .agents.sheet_calculations import compute_derived_stats
 from .character import Character
+from .combat.movement import MovementMode, can_enter_cell
 from .agent_specializations import apply_talent_bonuses
 from .deployment import (
     deployable_agents,
@@ -394,6 +395,31 @@ def _apply_commander_buffs(enemy_units: list[Unit]) -> dict[int, int]:
     return bonuses
 
 
+
+def _can_enter_ai_cell(
+    x: int,
+    y: int,
+    player_units: list[Unit],
+    enemy_units: list[Unit],
+    *,
+    exclude: Unit | None = None,
+    terrain_profile=None,
+    movement_mode: MovementMode = "tactical_grid",
+    legacy_can_enter: Callable[[int, int], bool] | None = None,
+) -> bool:
+    """Apply the shared movement rule plus legacy view gates for enemy AI."""
+    if legacy_can_enter is not None and not legacy_can_enter(x, y):
+        return False
+    return can_enter_cell(
+        x,
+        y,
+        terrain_profile=terrain_profile,
+        allied_units=player_units,
+        enemy_units=enemy_units,
+        exclude=exclude,
+        movement_mode=movement_mode,
+    )
+
 def run_enemy_ai(
     player_units: list[Unit],
     enemy_units: list[Unit],
@@ -404,6 +430,8 @@ def run_enemy_ai(
     on_overwatch_shot: Callable[[Unit, Unit, int], None] | None = None,
     can_enter: Callable[[int, int], bool] | None = None,
     cover_nodes: list | None = None,
+    terrain_profile=None,
+    movement_mode: MovementMode = "tactical_grid",
 ) -> list[EnemyActionResult]:
     """Run enemy actions and return inspectable outcomes for the view/test layer."""
     results: list[EnemyActionResult] = []
@@ -475,10 +503,17 @@ def run_enemy_ai(
                     step_dx, step_dy = cover_step
                     new_x = enemy.position[0] + step_dx
                     new_y = enemy.position[1] + step_dy
-                    blocked = is_occupied(new_x, new_y, player_units, enemy_units, exclude=enemy)
-                    if can_enter is not None and not can_enter(new_x, new_y):
-                        blocked = True
-                    if not blocked:
+                    can_enter_destination = _can_enter_ai_cell(
+                        new_x,
+                        new_y,
+                        player_units,
+                        enemy_units,
+                        exclude=enemy,
+                        terrain_profile=terrain_profile,
+                        movement_mode=movement_mode,
+                        legacy_can_enter=can_enter,
+                    )
+                    if can_enter_destination:
                         enemy.move(step_dx, step_dy)
                         results.append(EnemyActionResult(enemy, target, moved=True))
                         continue
@@ -493,12 +528,16 @@ def run_enemy_ai(
                     for step_dx, step_dy in step_candidates:
                         new_x = enemy.position[0] + step_dx
                         new_y = enemy.position[1] + step_dy
-                        blocked = is_occupied(
-                            new_x, new_y, player_units, enemy_units, exclude=enemy
-                        )
-                        if can_enter is not None and not can_enter(new_x, new_y):
-                            blocked = True
-                        if blocked:
+                        if not _can_enter_ai_cell(
+                            new_x,
+                            new_y,
+                            player_units,
+                            enemy_units,
+                            exclude=enemy,
+                            terrain_profile=terrain_profile,
+                            movement_mode=movement_mode,
+                            legacy_can_enter=can_enter,
+                        ):
                             continue
                         enemy.move(step_dx, step_dy)
                         moved = True

--- a/game/views.py
+++ b/game/views.py
@@ -105,7 +105,7 @@ from .battle_maps import (
 )
 from .battle_outcomes import resolve_defeated_agent_outcome
 from .combat_preview import estimate_attack_preview, line_of_fire_warning
-from .combat import CombatEngine, CombatState
+from .combat import CombatEngine, CombatState, can_enter_cell
 from .narrative.debrief import build_mission_debrief_report
 from .character import Character, is_deployable
 from .management.equipment import EQUIPMENT_SLOTS, default_equipment_catalog
@@ -1754,6 +1754,7 @@ class BattleView(GameView):
             allied_units=self.player_units,
             enemy_units=self.enemy_units,
             objective=self.battle_objective,
+            movement_mode="tactical_grid",
         )
         self.combat_engine = CombatEngine(
             self.combat_state,
@@ -1880,16 +1881,18 @@ class BattleView(GameView):
         )
 
     def can_move_to(self, x: int, y: int, *, exclude: Unit | None = None) -> bool:
-        """Return True when (x, y) is on walkable terrain.
-
-        Occupancy is intentionally not checked here (UI-51: player movement
-        stays unrestricted so melee positioning remains fluid). Terrain
-        obstacles from the walkability mask are still respected.
-        """
-        profile = getattr(self, "terrain_profile", None)
-        if profile is not None and hasattr(profile, "is_walkable") and not profile.is_walkable(x, y):
-            return False
-        return True
+        """Return True when the shared combat movement rule allows a cell."""
+        state = getattr(self, "combat_state", None)
+        movement_mode = getattr(state, "movement_mode", "tactical_grid")
+        return can_enter_cell(
+            x,
+            y,
+            terrain_profile=getattr(self, "terrain_profile", None),
+            allied_units=getattr(self, "player_units", []),
+            enemy_units=getattr(self, "enemy_units", []),
+            exclude=exclude,
+            movement_mode=movement_mode,
+        )
 
     def is_occupied(self, x: int, y: int, *, exclude: Unit | None = None) -> bool:
         """Check if a map position is occupied by any living unit."""
@@ -2300,6 +2303,8 @@ class BattleView(GameView):
             on_overwatch_shot=callbacks["on_overwatch_shot"],
             can_enter=lambda x, y: self.can_move_to(x, y, exclude=None),
             cover_nodes=getattr(self, "cover_nodes", None),
+            terrain_profile=getattr(self, "terrain_profile", None),
+            movement_mode=getattr(self.combat_state, "movement_mode", "tactical_grid"),
         )
 
     def on_draw(self):
@@ -2581,6 +2586,22 @@ class BattleView(GameView):
             self.pending_attack = pending
         else:
             self.message = "No visible enemy in range"
+
+    def _try_move_active_player(self, player: Unit, dx: int, dy: int) -> bool:
+        """Move the active unit through the shared combat movement rule."""
+        result = self.combat_engine.perform_action(
+            "move",
+            actor=player,
+            move_delta=(dx, dy),
+        )
+        if not result.success:
+            self.message = result.message
+            return False
+        self._sync_view_from_combat_state()
+        self._set_action_aftermath(action_label="MOVE")
+        self._log_move(player)
+        self.game_state.mark_tutorial_event("used_battle_controls")
+        return True
 
     def _perform_combat_action(self, action_key: str) -> bool:
         """Perform a clicked or keyed combat action for the active player unit."""
@@ -2882,25 +2903,13 @@ class BattleView(GameView):
                     self.end_battle(True)
                     return
         elif key == arcade.key.UP:
-            player.move(0, 32)
-            self._set_action_aftermath(action_label="MOVE")
-            self._log_move(player)
-            self.game_state.mark_tutorial_event("used_battle_controls")
+            self._try_move_active_player(player, 0, 32)
         elif key == arcade.key.DOWN:
-            player.move(0, -32)
-            self._set_action_aftermath(action_label="MOVE")
-            self._log_move(player)
-            self.game_state.mark_tutorial_event("used_battle_controls")
+            self._try_move_active_player(player, 0, -32)
         elif key == arcade.key.LEFT:
-            player.move(-32, 0)
-            self._set_action_aftermath(action_label="MOVE")
-            self._log_move(player)
-            self.game_state.mark_tutorial_event("used_battle_controls")
+            self._try_move_active_player(player, -32, 0)
         elif key == arcade.key.RIGHT:
-            player.move(32, 0)
-            self._set_action_aftermath(action_label="MOVE")
-            self._log_move(player)
-            self.game_state.mark_tutorial_event("used_battle_controls")
+            self._try_move_active_player(player, 32, 0)
         elif key == arcade.key.SPACE:
             self._perform_combat_action("melee")
         elif key == arcade.key.F:
@@ -3171,6 +3180,9 @@ class BattleView(GameView):
             ww = getattr(self.window, "width", 1280)
             nx = max(16, min(ww - 16, unit.position[0] + dx))
             ny = max(16, min(_DEPLOY_ZONE_H - 16, unit.position[1] + dy))
+            if not self.can_move_to(nx, ny, exclude=unit):
+                self.message = "Deployment cell blocked."
+                return
             unit.position = (nx, ny)
             if unit.sprite:
                 unit.sprite.center_x = nx

--- a/tests/test_agent_aftermath.py
+++ b/tests/test_agent_aftermath.py
@@ -202,14 +202,18 @@ class AgentAftermathTest(unittest.TestCase):
         )
         self.assertIn("Event Log Test", game_state.characters[0].history[0])
 
-    def test_battle_view_movement_is_unrestricted(self):
+    def test_battle_view_movement_uses_tactical_grid_occupancy(self):
         game_state = GameState(characters=[Character("Runner")])
         battle_view = views.BattleView(game_state)
         battle_view.player_units = [Unit(position=(0, 0), character=game_state.characters[0])]
         battle_view.enemy_units = [Unit(position=(32, 0), unit_type="grunt")]
         battle_view.terrain_profile = object()
 
-        self.assertTrue(battle_view.can_move_to(32, 0, exclude=battle_view.player_units[0]))
+        battle_view.combat_state = views.CombatState(
+            None, battle_view.player_units, battle_view.enemy_units
+        )
+
+        self.assertFalse(battle_view.can_move_to(32, 0, exclude=battle_view.player_units[0]))
         self.assertTrue(battle_view.can_move_to(999, 999, exclude=None))
 
     def test_dashboard_report_shows_latest_compact_aftermath_first(self):

--- a/tests/test_combat_movement.py
+++ b/tests/test_combat_movement.py
@@ -1,0 +1,112 @@
+"""Shared combat movement rule tests."""
+
+import unittest
+
+from game.combat.movement import can_enter_cell, path_to_cell, reachable_cells
+from game.combat_system import run_enemy_ai
+from game.unit import Unit
+
+
+class FakeTerrainProfile:
+    def __init__(self, walkable: set[tuple[int, int]]):
+        self.walkable = walkable
+
+    def is_walkable(self, x: int, y: int) -> bool:
+        return (x, y) in self.walkable
+
+
+def _unit(x: int, y: int, *, hp: int = 10, ap: int = 1) -> Unit:
+    unit = Unit(position=(x, y), health=hp)
+    unit.action_points = ap
+    return unit
+
+
+class CombatMovementRuleTest(unittest.TestCase):
+    def test_blocked_terrain_refuses_entry(self):
+        terrain = FakeTerrainProfile({(0, 0)})
+
+        self.assertFalse(
+            can_enter_cell(32, 0, terrain_profile=terrain, movement_mode="tactical_grid")
+        )
+
+    def test_occupied_cell_refuses_entry_in_tactical_grid(self):
+        mover = _unit(0, 0)
+        blocker = _unit(32, 0)
+        terrain = FakeTerrainProfile({(0, 0), (32, 0)})
+
+        self.assertFalse(
+            can_enter_cell(
+                32,
+                0,
+                terrain_profile=terrain,
+                allied_units=[mover, blocker],
+                enemy_units=[],
+                exclude=mover,
+                movement_mode="tactical_grid",
+            )
+        )
+
+    def test_walkable_empty_cell_allows_entry_and_path(self):
+        mover = _unit(0, 0)
+        terrain = FakeTerrainProfile({(0, 0), (32, 0), (64, 0), (32, 32)})
+
+        self.assertTrue(
+            can_enter_cell(
+                32,
+                0,
+                terrain_profile=terrain,
+                allied_units=[mover],
+                enemy_units=[],
+                exclude=mover,
+                movement_mode="tactical_grid",
+            )
+        )
+        self.assertEqual(
+            path_to_cell(
+                (0, 0),
+                (64, 0),
+                2,
+                width=96,
+                height=64,
+                terrain_profile=terrain,
+                allied_units=[mover],
+                exclude=mover,
+            ),
+            [(0, 0), (32, 0), (64, 0)],
+        )
+
+    def test_reachable_cells_excludes_refused_destination(self):
+        mover = _unit(0, 0)
+        blocker = _unit(32, 0)
+        terrain = FakeTerrainProfile({(0, 0), (32, 0), (0, 32)})
+
+        cells = reachable_cells(
+            (0, 0),
+            1,
+            width=96,
+            height=64,
+            terrain_profile=terrain,
+            allied_units=[mover, blocker],
+            enemy_units=[],
+            exclude=mover,
+            movement_mode="tactical_grid",
+        )
+
+        self.assertIn((0, 32), cells)
+        self.assertNotIn((32, 0), cells)
+
+    def test_enemy_ai_refuses_blocked_movement_step(self):
+        player = _unit(0, 0, hp=100)
+        enemy = _unit(64, 0, hp=50, ap=1)
+        enemy.unit_type = "enemy"
+        terrain = FakeTerrainProfile({(0, 0), (64, 0)})
+
+        results = run_enemy_ai([player], [enemy], terrain_profile=terrain)
+
+        self.assertEqual(enemy.position, (64, 0))
+        self.assertTrue(results)
+        self.assertFalse(any(result.moved for result in results))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Consolidate scattered movement logic into a single, testable rule so the view, deployment controls, and enemy AI all respect the same terrain and occupancy semantics and to complete the `BATTLE-G01` work item.

### Description
- Add `game/combat/movement.py` providing `can_enter_cell`, `reachable_cells`, `path_to_cell`, `MovementMode`, and a minimal `WalkabilityProfile` contract so terrain masks (`TerrainProfile.is_walkable`) and occupancy are applied in one place.
- Add `movement_mode: MovementMode = "tactical_grid"` to `CombatState` and export the new movement helpers from `game/combat/__init__.py`.
- Wire the shared rule into the runtime: `BattleView.can_move_to` now calls `can_enter_cell`, deployment cursor movement checks the same rule, keyboard movement is routed through `CombatEngine.perform_action("move")` via a new `_try_move_active_player`, and `run_enemy_ai` uses a `_can_enter_ai_cell` helper that delegates to `can_enter_cell` (passed `terrain_profile` and `movement_mode`).
- Add movement-focused tests in `tests/test_combat_movement.py`, adjust one battle-view movement regression in `tests/test_agent_aftermath.py`, and update `docs/backlog.md` to mark `BATTLE-G01` as reduced/completed by the shared rule.

### Testing
- Ran the movement and related engine tests with `python -m pytest tests/test_combat_movement.py tests/test_combat_core.py tests/test_combat_engine.py tests/test_agent_aftermath.py -q`, which passed (25 tests across those files passed).
- Byte-compiled modified modules with `python -m py_compile game/combat/movement.py game/combat/state.py game/combat_system.py game/combat/engine.py game/views.py` with no errors.
- Ran the full test suite with `python -m pytest -q`; the full suite produced 7 failures unrelated to movement (missing generated map assets / localization and UI expectations), so those regressions are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25254efe94832b83539c862f9e44db)