### PR TITLE
Add isolated Godot combat spike

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -322,3 +322,7 @@ Automation status:
 
 
 - [x] Squad management: add Downtime menu (activities consume day/resources and affect morale/stress/traits).
+
+## Engine evaluation spikes
+
+- [x] GODOT-SPIKE-01 Evaluate Godot without migrating the game: isolated project under `experiments/godot_combat_spike/`, minimal 2-agent/2-enemy grid mission, JSON state contract, comparison report, and regression checks. Decision: keep disconnected from the Arcade runtime until a documented migration plan exists.

--- a/docs/gameplay/engine_evaluation.md
+++ b/docs/gameplay/engine_evaluation.md
@@ -1,0 +1,33 @@
+# Engine evaluation: Godot combat spike
+
+Status: **spike completed, no migration decision taken**.
+
+## Scope evaluated
+
+The experiment lives in `experiments/godot_combat_spike/` and is intentionally outside the Arcade runtime. It reproduces only one tiny tactical mission:
+
+- an 8x6 grid;
+- 2 agents (`agent_echo`, `agent_vesper`);
+- 2 enemies (`enemy_raider_a`, `enemy_raider_b`);
+- cardinal movement, adjacent attack, and end-turn handoff;
+- JSON export/import fields compatible with the current combat concepts: `mission_id`, `units`, `hp`, `ap`, `turn`, `turn_number`, and `result`.
+
+## Comparison with current Arcade implementation
+
+| Criterion | Godot spike observation | Arcade/current game observation | Early read |
+| --- | --- | --- | --- |
+| Iteration speed | A small scene can be opened and edited visually, but team setup would need Godot installed and conventions for exported state. | Existing Python tests and Arcade code are already wired into the repo workflow. | Arcade remains faster for rules changes today; Godot may become faster for visual scene iteration later. |
+| Readability | Godot scene/script split is readable for the small grid, but rules in GDScript duplicate Python combat concepts. | `game/combat/` already separates pure state transitions from rendering. | Current Python rules are more readable for production combat until a formal bridge exists. |
+| Testability | JSON contract can be checked from Python, but full Godot behavior needs Godot CLI or scene tests. | Pure combat engine tests run with the normal Python suite. | Arcade/Python is stronger for automated tactical-rule tests right now. |
+| Asset integration | Godot would likely improve placement, animation, and scene composition once asset import rules are defined. | Current assets are PNG-oriented and already consumed by Arcade screens. | Godot has potential upside, but migration cost is not justified by this tiny spike alone. |
+| Migration cost | Requires maintaining or translating combat state, input, HUD, camera, and save boundaries. | Production code already contains combat, UI, campaign fallout, and debrief integration. | High. Do not migrate without a staged adapter plan and explicit decision. |
+
+## Decision
+
+Do **not branch** this spike into the main game yet. The experiment is useful as a reference for visual/scene iteration, but it currently duplicates combat rules and lacks the automated coverage depth of the Python combat engine.
+
+## Follow-up options
+
+1. Keep the spike archived as an evaluation artifact.
+2. If Godot remains attractive, run a second spike focused only on asset/camera/HUD feel, not combat rules.
+3. Decide on a one-way JSON replay/export adapter before any production integration.

--- a/experiments/godot_combat_spike/README.md
+++ b/experiments/godot_combat_spike/README.md
@@ -1,0 +1,23 @@
+# Godot combat spike
+
+Experimental Godot 4 project for evaluating tactical combat feel without migrating CyberCity2085.
+
+## Scope
+
+- Isolated from the Arcade runtime: no imports from `game/`, no routing from production screens.
+- Minimal mission only: 8x6 grid, two named agents, two enemies, movement, adjacent attack, turn handoff.
+- JSON import/export shape mirrors current combat concepts: `mission_id`, `units`, `hp`, `ap`, `turn`, `turn_number`, and `result`.
+
+## Manual run
+
+Open this folder as a Godot project and run `scenes/combat_spike.tscn`.
+
+Controls:
+
+- Arrow keys: move selected agent.
+- Space: attack first living enemy if adjacent.
+- Tab: switch agent.
+- T: end turn.
+- J: print exported JSON state.
+
+Decision gate: this project must remain disconnected from the main game until `docs/gameplay/engine_evaluation.md` records a follow-up decision.

--- a/experiments/godot_combat_spike/data/mission_state.gd
+++ b/experiments/godot_combat_spike/data/mission_state.gd
@@ -1,0 +1,53 @@
+extends Resource
+class_name SpikeMissionState
+
+const GRID_WIDTH := 8
+const GRID_HEIGHT := 6
+const DEFAULT_MISSION_ID := "godot_combat_spike_01"
+
+var mission_id: String = DEFAULT_MISSION_ID
+var turn: String = "player"
+var turn_number: int = 1
+var result: String = "in_progress"
+var units: Array[Dictionary] = []
+var event_log: Array[String] = []
+
+static func default_state() -> SpikeMissionState:
+	var state := SpikeMissionState.new()
+	state.units = [
+		{"id": "agent_echo", "team": "agent", "role": "samurai", "hp": 11, "max_hp": 11, "ap": 2, "position": {"x": 1, "y": 2}},
+		{"id": "agent_vesper", "team": "agent", "role": "sniper", "hp": 11, "max_hp": 11, "ap": 2, "position": {"x": 1, "y": 3}},
+		{"id": "enemy_raider_a", "team": "enemy", "role": "grunt", "hp": 10, "max_hp": 10, "ap": 2, "position": {"x": 5, "y": 2}},
+		{"id": "enemy_raider_b", "team": "enemy", "role": "grunt", "hp": 10, "max_hp": 10, "ap": 2, "position": {"x": 5, "y": 3}},
+	]
+	state.event_log = ["Spike mission loaded outside the Arcade runtime."]
+	return state
+
+static func from_json_text(json_text: String) -> SpikeMissionState:
+	var parsed = JSON.parse_string(json_text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return SpikeMissionState.default_state()
+	var state := SpikeMissionState.new()
+	state.mission_id = str(parsed.get("mission_id", DEFAULT_MISSION_ID))
+	state.turn = str(parsed.get("turn", "player"))
+	state.turn_number = int(parsed.get("turn_number", 1))
+	state.result = str(parsed.get("result", "in_progress"))
+	state.units = parsed.get("units", [])
+	state.event_log = parsed.get("event_log", [])
+	return state
+
+func to_dictionary() -> Dictionary:
+	return {
+		"mission_id": mission_id,
+		"turn": turn,
+		"turn_number": turn_number,
+		"result": result,
+		"units": units,
+		"event_log": event_log,
+	}
+
+func to_json_text() -> String:
+	return JSON.stringify(to_dictionary(), "  ")
+
+func living_units(team: String) -> Array[Dictionary]:
+	return units.filter(func(unit): return unit.get("team", "") == team and int(unit.get("hp", 0)) > 0)

--- a/experiments/godot_combat_spike/logic/combat_rules.gd
+++ b/experiments/godot_combat_spike/logic/combat_rules.gd
@@ -1,0 +1,71 @@
+extends RefCounted
+class_name SpikeCombatRules
+
+const MOVE_COST := 1
+const ATTACK_COST := 1
+const ATTACK_DAMAGE := 4
+const ATTACK_RANGE := 1
+
+static func unit_at(state: SpikeMissionState, x: int, y: int) -> Dictionary:
+	for unit in state.units:
+		var pos: Dictionary = unit.get("position", {})
+		if int(pos.get("x", -1)) == x and int(pos.get("y", -1)) == y and int(unit.get("hp", 0)) > 0:
+			return unit
+	return {}
+
+static func move_unit(state: SpikeMissionState, unit_id: String, dx: int, dy: int) -> bool:
+	var unit := _find_living_unit(state, unit_id)
+	if unit.is_empty() or int(unit.get("ap", 0)) < MOVE_COST:
+		return false
+	var pos: Dictionary = unit.get("position", {})
+	var nx := int(pos.get("x", 0)) + dx
+	var ny := int(pos.get("y", 0)) + dy
+	if nx < 0 or ny < 0 or nx >= SpikeMissionState.GRID_WIDTH or ny >= SpikeMissionState.GRID_HEIGHT:
+		return false
+	if not unit_at(state, nx, ny).is_empty():
+		return false
+	unit["position"] = {"x": nx, "y": ny}
+	unit["ap"] = int(unit.get("ap", 0)) - MOVE_COST
+	state.event_log.append("%s moves to %d,%d." % [unit_id, nx, ny])
+	return true
+
+static func attack_unit(state: SpikeMissionState, attacker_id: String, target_id: String) -> bool:
+	var attacker := _find_living_unit(state, attacker_id)
+	var target := _find_living_unit(state, target_id)
+	if attacker.is_empty() or target.is_empty() or int(attacker.get("ap", 0)) < ATTACK_COST:
+		return false
+	if attacker.get("team") == target.get("team") or _distance(attacker, target) > ATTACK_RANGE:
+		return false
+	target["hp"] = max(0, int(target.get("hp", 0)) - ATTACK_DAMAGE)
+	attacker["ap"] = int(attacker.get("ap", 0)) - ATTACK_COST
+	state.event_log.append("%s attacks %s for %d." % [attacker_id, target_id, ATTACK_DAMAGE])
+	_update_result(state)
+	return true
+
+static func end_turn(state: SpikeMissionState) -> void:
+	if state.result != "in_progress":
+		return
+	state.turn = "enemy" if state.turn == "player" else "player"
+	if state.turn == "player":
+		state.turn_number += 1
+	for unit in state.units:
+		if int(unit.get("hp", 0)) > 0 and unit.get("team") == state.turn:
+			unit["ap"] = 2
+	state.event_log.append("Turn changes to %s." % state.turn)
+
+static func _find_living_unit(state: SpikeMissionState, unit_id: String) -> Dictionary:
+	for unit in state.units:
+		if unit.get("id") == unit_id and int(unit.get("hp", 0)) > 0:
+			return unit
+	return {}
+
+static func _distance(a: Dictionary, b: Dictionary) -> int:
+	var ap: Dictionary = a.get("position", {})
+	var bp: Dictionary = b.get("position", {})
+	return abs(int(ap.get("x", 0)) - int(bp.get("x", 0))) + abs(int(ap.get("y", 0)) - int(bp.get("y", 0)))
+
+static func _update_result(state: SpikeMissionState) -> void:
+	if state.living_units("enemy").is_empty():
+		state.result = "victory"
+	elif state.living_units("agent").is_empty():
+		state.result = "defeat"

--- a/experiments/godot_combat_spike/project.godot
+++ b/experiments/godot_combat_spike/project.godot
@@ -1,0 +1,15 @@
+; Engine evaluation spike only. Do not load from the Arcade runtime.
+config_version=5
+
+[application]
+config/name="CyberCity2085 Godot Combat Spike"
+run/main_scene="res://scenes/combat_spike.tscn"
+config/features=PackedStringArray("4.2")
+
+[display]
+window/size/viewport_width=960
+window/size/viewport_height=640
+
+[input]
+end_turn={"deadzone":0.5,"events":[Object(InputEventKey,"physical_keycode":84)]}
+export_state={"deadzone":0.5,"events":[Object(InputEventKey,"physical_keycode":74)]}

--- a/experiments/godot_combat_spike/samples/mission_state.json
+++ b/experiments/godot_combat_spike/samples/mission_state.json
@@ -1,0 +1,13 @@
+{
+  "mission_id": "godot_combat_spike_01",
+  "turn": "player",
+  "turn_number": 1,
+  "result": "in_progress",
+  "units": [
+    {"id": "agent_echo", "team": "agent", "role": "samurai", "hp": 11, "max_hp": 11, "ap": 2, "position": {"x": 1, "y": 2}},
+    {"id": "agent_vesper", "team": "agent", "role": "sniper", "hp": 11, "max_hp": 11, "ap": 2, "position": {"x": 1, "y": 3}},
+    {"id": "enemy_raider_a", "team": "enemy", "role": "grunt", "hp": 10, "max_hp": 10, "ap": 2, "position": {"x": 5, "y": 2}},
+    {"id": "enemy_raider_b", "team": "enemy", "role": "grunt", "hp": 10, "max_hp": 10, "ap": 2, "position": {"x": 5, "y": 3}}
+  ],
+  "event_log": ["Spike mission loaded outside the Arcade runtime."]
+}

--- a/experiments/godot_combat_spike/scenes/combat_spike.tscn
+++ b/experiments/godot_combat_spike/scenes/combat_spike.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=4 format=3 uid="uid://cybercity2085_godot_spike"]
+
+[ext_resource type="Script" path="res://data/mission_state.gd" id="1_state"]
+[ext_resource type="Script" path="res://logic/combat_rules.gd" id="2_rules"]
+[ext_resource type="Script" path="res://scripts/combat_spike.gd" id="3_view"]
+
+[node name="CombatSpike" type="Node2D"]
+script = ExtResource("3_view")

--- a/experiments/godot_combat_spike/scripts/combat_spike.gd
+++ b/experiments/godot_combat_spike/scripts/combat_spike.gd
@@ -1,0 +1,78 @@
+extends Node2D
+
+const CELL_SIZE := 72
+const ORIGIN := Vector2(96, 96)
+const TEAM_COLORS := {"agent": Color.CYAN, "enemy": Color.INDIAN_RED}
+
+var mission_state: SpikeMissionState = SpikeMissionState.default_state()
+var selected_unit_id := "agent_echo"
+
+func _ready() -> void:
+	print(mission_state.to_json_text())
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("end_turn"):
+		SpikeCombatRules.end_turn(mission_state)
+		queue_redraw()
+	elif event.is_action_pressed("export_state"):
+		print(mission_state.to_json_text())
+	elif event is InputEventKey and event.pressed:
+		_handle_key(event.keycode)
+
+func _handle_key(keycode: int) -> void:
+	var moved := false
+	if keycode == KEY_UP:
+		moved = SpikeCombatRules.move_unit(mission_state, selected_unit_id, 0, -1)
+	elif keycode == KEY_DOWN:
+		moved = SpikeCombatRules.move_unit(mission_state, selected_unit_id, 0, 1)
+	elif keycode == KEY_LEFT:
+		moved = SpikeCombatRules.move_unit(mission_state, selected_unit_id, -1, 0)
+	elif keycode == KEY_RIGHT:
+		moved = SpikeCombatRules.move_unit(mission_state, selected_unit_id, 1, 0)
+	elif keycode == KEY_SPACE:
+		SpikeCombatRules.attack_unit(mission_state, selected_unit_id, _nearest_enemy_id())
+	elif keycode == KEY_TAB:
+		_cycle_agent()
+	if moved or keycode in [KEY_SPACE, KEY_TAB]:
+		queue_redraw()
+
+func _draw() -> void:
+	_draw_grid()
+	_draw_units()
+	draw_string(ThemeDB.fallback_font, Vector2(32, 36), "Godot combat spike — isolated from Arcade runtime", HORIZONTAL_ALIGNMENT_LEFT, -1, 18, Color.WHITE)
+	draw_string(ThemeDB.fallback_font, Vector2(32, 60), "Arrows move | Space attack | Tab switch agent | T end turn | J export JSON", HORIZONTAL_ALIGNMENT_LEFT, -1, 16, Color.LIGHT_GRAY)
+	draw_string(ThemeDB.fallback_font, Vector2(32, 600), "Mission %s | Turn %d %s | Result %s" % [mission_state.mission_id, mission_state.turn_number, mission_state.turn, mission_state.result], HORIZONTAL_ALIGNMENT_LEFT, -1, 16, Color.WHITE)
+
+func _draw_grid() -> void:
+	for x in range(SpikeMissionState.GRID_WIDTH):
+		for y in range(SpikeMissionState.GRID_HEIGHT):
+			var rect := Rect2(ORIGIN + Vector2(x, y) * CELL_SIZE, Vector2(CELL_SIZE, CELL_SIZE))
+			draw_rect(rect, Color(0.05, 0.08, 0.11), true)
+			draw_rect(rect, Color(0.18, 0.55, 0.68), false, 1.0)
+
+func _draw_units() -> void:
+	for unit in mission_state.units:
+		if int(unit.get("hp", 0)) <= 0:
+			continue
+		var pos: Dictionary = unit.get("position", {})
+		var center := ORIGIN + Vector2(int(pos.get("x", 0)), int(pos.get("y", 0))) * CELL_SIZE + Vector2(CELL_SIZE / 2, CELL_SIZE / 2)
+		var color: Color = TEAM_COLORS.get(unit.get("team", ""), Color.GRAY)
+		draw_circle(center, 24, color)
+		if unit.get("id") == selected_unit_id:
+			draw_circle(center, 30, Color.GOLD, false, 3.0)
+		draw_string(ThemeDB.fallback_font, center + Vector2(-28, 44), "%s HP:%d AP:%d" % [unit.get("id", "unit"), int(unit.get("hp", 0)), int(unit.get("ap", 0))], HORIZONTAL_ALIGNMENT_LEFT, -1, 12, Color.WHITE)
+
+func _nearest_enemy_id() -> String:
+	for unit in mission_state.living_units("enemy"):
+		return str(unit.get("id", ""))
+	return ""
+
+func _cycle_agent() -> void:
+	var agents := mission_state.living_units("agent")
+	if agents.is_empty():
+		return
+	var index := 0
+	for i in range(agents.size()):
+		if agents[i].get("id") == selected_unit_id:
+			index = i + 1
+	selected_unit_id = str(agents[index % agents.size()].get("id"))

--- a/tests/test_godot_combat_spike.py
+++ b/tests/test_godot_combat_spike.py
@@ -1,0 +1,59 @@
+"""Regression checks for the isolated Godot combat spike."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SPIKE_ROOT = Path("experiments/godot_combat_spike")
+STATE_SAMPLE = SPIKE_ROOT / "samples" / "mission_state.json"
+
+
+def test_godot_spike_project_remains_outside_main_runtime() -> None:
+    assert (SPIKE_ROOT / "project.godot").exists()
+    spike_files = [
+        path
+        for path in SPIKE_ROOT.rglob("*")
+        if path.is_file() and path.suffix in {".gd", ".tscn", ".godot"}
+    ]
+    assert spike_files, "spike should contain a tiny Godot project"
+
+    joined = "\n".join(path.read_text(encoding="utf-8") for path in spike_files)
+    assert "res://" in joined
+    assert "game/" not in joined
+    assert "import arcade" not in joined.lower()
+    assert "from arcade import" not in joined.lower()
+
+
+def test_sample_state_matches_current_combat_state_contract() -> None:
+    payload = json.loads(STATE_SAMPLE.read_text(encoding="utf-8"))
+
+    assert payload["mission_id"] == "godot_combat_spike_01"
+    assert payload["turn"] in {"player", "enemy"}
+    assert payload["turn_number"] >= 1
+    assert payload["result"] in {"in_progress", "victory", "defeat"}
+    assert len(payload["units"]) == 4
+    assert [unit["team"] for unit in payload["units"]].count("agent") == 2
+    assert [unit["team"] for unit in payload["units"]].count("enemy") == 2
+
+    required_unit_keys = {"id", "team", "role", "hp", "max_hp", "ap", "position"}
+    for unit in payload["units"]:
+        assert required_unit_keys <= unit.keys()
+        assert isinstance(unit["id"], str) and unit["id"]
+        assert unit["team"] in {"agent", "enemy"}
+        assert 0 <= unit["hp"] <= unit["max_hp"]
+        assert unit["ap"] >= 0
+        assert set(unit["position"].keys()) == {"x", "y"}
+        assert 0 <= unit["position"]["x"] < 8
+        assert 0 <= unit["position"]["y"] < 6
+
+
+def test_spike_documents_json_export_and_decision_gate() -> None:
+    readme = (SPIKE_ROOT / "README.md").read_text(encoding="utf-8")
+    report = Path("docs/gameplay/engine_evaluation.md").read_text(encoding="utf-8")
+
+    for expected in ["mission_id", "units", "hp", "ap", "result"]:
+        assert expected in readme
+        assert expected in report
+    assert "must remain disconnected" in readme
+    assert "not branch" in report.lower()


### PR DESCRIPTION
### Motivation

- Evaluate Godot as a lightweight visual/tactical authoring option without migrating the existing Arcade runtime or duplicating production systems.
- Produce a minimal, readable spike that reproduces a single mission (grid, 2 agents, 2 enemies, move/attack/end-turn) and a JSON state contract compatible with current combat concepts.
- Keep the experiment strictly disconnected from the main game until a documented migration decision is taken.

### Description

- Added an isolated Godot 4 project under `experiments/godot_combat_spike/` including `project.godot`, `scenes/combat_spike.tscn`, `scripts/combat_spike.gd`, `logic/combat_rules.gd`, and `data/mission_state.gd` to separate state, rules, and view into readable subdirectories.
- Included a sample JSON export `experiments/godot_combat_spike/samples/mission_state.json` and a human README `experiments/godot_combat_spike/README.md` documenting controls and the decision gate.
- Added a short evaluation report at `docs/gameplay/engine_evaluation.md` comparing Godot vs Arcade on iteration speed, readability, testability, asset integration, and migration cost, and updated `docs/backlog.md` with the spike status.
- Added regression tests `tests/test_godot_combat_spike.py` that assert the spike is isolated, validate the JSON contract, and verify the decision/documentation presence.

### Testing

- Ran `python -m pytest tests/test_godot_combat_spike.py` and the test passed (spike isolation, JSON contract, docs checks).
- Ran `python -m pytest tests/test_godot_combat_spike.py tests/test_combat_engine.py` to ensure new tests do not regress core combat engine tests and both suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252cec006c832b844ca9eba9362f64)